### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/packages/auth-utils/utils/refreshEveSsoToken.ts
+++ b/packages/auth-utils/utils/refreshEveSsoToken.ts
@@ -36,7 +36,16 @@ export const refreshEveSsoToken = async (params: {
   });
 
   if (!refreshedTokensResponse.ok) {
-    console.log({ params });
+    console.log({
+      message: "Error refreshing EVE SSO token",
+      status: refreshedTokensResponse.status,
+      statusText: refreshedTokensResponse.statusText,
+      params: {
+        eveClientId,
+        eveClientSecret: "[REDACTED]",
+        refreshToken: "[REDACTED]",
+      },
+    });
     console.log(refreshedTokensResponse.body);
     throw new Error("error refreshing access token");
   }


### PR DESCRIPTION
Potential fix for [https://github.com/joaomlneto/jitaspace/security/code-scanning/3](https://github.com/joaomlneto/jitaspace/security/code-scanning/3)

To fix the problem, we must avoid logging sensitive fields (`eveClientSecret`, `refreshToken`) while still allowing useful debugging information. The general approach is to either remove the problematic log entirely or log only non-sensitive metadata (e.g., HTTP status, error text) and, if absolutely necessary, a redacted version of the parameters.

The best minimal fix without changing existing functionality is: in `packages/auth-utils/utils/refreshEveSsoToken.ts`, replace the `console.log({ params });` line with logging that does not include secrets. For example, we can log the HTTP status and a redacted view of the params in which the secret fields are replaced with constant placeholders. This preserves some debuggability while preventing secret exposure. No new imports are needed; we can construct a small redacted object inline. We leave the subsequent `console.log(refreshedTokensResponse.body);` as-is, assuming it does not contain our own secrets (it might contain tokens from the identity provider; if you want to be stricter you can also remove or gate that log, but CodeQL’s flagged sink is the `params` log).

Concretely:
- Edit `packages/auth-utils/utils/refreshEveSsoToken.ts`, in the `if (!refreshedTokensResponse.ok)` block.
- Replace `console.log({ params });` with a log that only exposes non-sensitive parameter names and redacts their values, plus the response status information.
- Keep the rest of the function unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
