### PR TITLE
Restore entity avatars in Select components for Mantine v7+

### DIFF
--- a/.changeset/select-avatars-mantine-v7.md
+++ b/.changeset/select-avatars-mantine-v7.md
@@ -1,0 +1,11 @@
+---
+"@jitaspace/ui": patch
+---
+
+Restore entity avatars in Select components for Mantine v7+
+
+The `itemComponent` prop used in Mantine v6 was removed in v7. `EveEntitySelect`
+and `EsiSearchSelect` now use the `renderOption` prop to display entity avatars
+on the left side of each dropdown option. `EsiSearchSelect` also renders the
+category badge alongside the avatar and name, matching the existing behaviour of
+`EsiSearchMultiSelect`.

--- a/packages/ui/Select/EsiSearchSelect/EsiSearchSelect.tsx
+++ b/packages/ui/Select/EsiSearchSelect/EsiSearchSelect.tsx
@@ -2,11 +2,14 @@
 
 import type { SelectProps } from "@mantine/core";
 import React, { memo } from "react";
-import { Loader, Select } from "@mantine/core";
+import { Badge, Group, Loader, rem, Select } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 
 import { type GetCharactersCharacterIdSearchQueryParamsCategoriesEnum } from "@jitaspace/esi-client";
 import { useEsiNamesCache, useEsiSearch } from "@jitaspace/hooks";
+
+import { EveEntityAvatar } from "../../Avatar";
+import { EveEntityName } from "../../Text";
 
 export type EsiSearchSelectProps = Omit<
   SelectProps,
@@ -60,7 +63,34 @@ export const EsiSearchSelect = memo(
         searchable
         searchValue={searchValue}
         onSearchChange={onSearchChange}
-        //itemComponent={EsiSearchSelectItem}
+        renderOption={({ option }) => {
+          const category = (
+            option as typeof option & {
+              category?: GetCharactersCharacterIdSearchQueryParamsCategoriesEnum;
+            }
+          ).category;
+          return (
+            <Group wrap="nowrap" justify="space-between">
+              <Group wrap="nowrap" gap="xs">
+                <EveEntityAvatar
+                  entityId={option.value}
+                  category={category}
+                  size={24}
+                />
+                <EveEntityName
+                  entityId={option.value}
+                  category={category}
+                  style={{ lineHeight: 1, fontSize: rem(12) }}
+                />
+              </Group>
+              {category && (
+                <Badge size="xs" variant="subtle">
+                  {category}
+                </Badge>
+              )}
+            </Group>
+          );
+        }}
         rightSection={isLoadingData && <Loader size="sm" />}
         nothingFoundMessage={
           (searchValue ?? "").length < 3

--- a/packages/ui/Select/EveEntitySelect/EveEntitySelect.tsx
+++ b/packages/ui/Select/EveEntitySelect/EveEntitySelect.tsx
@@ -1,13 +1,12 @@
 "use client";
 
+import type { SelectProps } from "@mantine/core";
 import React, { memo } from "react";
-import { Select, type SelectProps } from "@mantine/core";
+import { Group, Select, Text } from "@mantine/core";
 
 import { useEsiNamesCache } from "@jitaspace/hooks";
 
-
-
-
+import { EveEntityAvatar } from "../../Avatar";
 
 export type EveEntitySelectProps = Omit<SelectProps, "data"> & {
   entityIds: {
@@ -28,11 +27,18 @@ export const EveEntitySelect = memo(
             value: `${id}`,
             label:
               name ??
-              getNameFromCache(typeof id === "string" ? parseInt(id, 10) : id) ??
+              getNameFromCache(
+                typeof id === "string" ? parseInt(id, 10) : id,
+              ) ??
               "",
           }))
           .sort((a, b) => (a.label ?? "").localeCompare(b.label ?? ""))}
-        //itemComponent={EveEntitySelectItem}
+        renderOption={({ option }) => (
+          <Group wrap="nowrap" gap="xs">
+            <EveEntityAvatar entityId={option.value} size={24} />
+            <Text size="sm">{option.label}</Text>
+          </Group>
+        )}
         {...otherProps}
       />
     );


### PR DESCRIPTION
## Restore entity avatars in Select dropdowns (Mantine v7+)

### Problem

Since the migration from Mantine v6 to v7 (over two years ago), entity avatars had disappeared from the dropdown options in `EveEntitySelect` and `EsiSearchSelect` (e.g. the character/corporation/alliance pickers used in the mail editor). The old v6 `itemComponent` prop was removed in v7 with no direct replacement, and the custom item renderers were commented out rather than ported.

### Solution

Ported the custom dropdown rendering to Mantine v7+'s `renderOption` prop:

- **`EveEntitySelect`** — each option now shows a circular entity avatar to the left of the entity name.
- **`EsiSearchSelect`** — each option now shows a circular entity avatar + resolved entity name on the left, and a subtle category badge (character / corporation / alliance / …) on the right. This matches the existing rendering in `EsiSearchMultiSelect`, which already used the Combobox primitive and was unaffected.

No behaviour changes — only the visual rendering of dropdown options is affected.

Closes #356