### PR TITLE
feat: re-enable spotlight search with reactive name resolution

### DIFF
--- a/.changeset/spotlight-reactive-names.md
+++ b/.changeset/spotlight-reactive-names.md
@@ -1,0 +1,27 @@
+---
+"@jitaspace/web": minor
+"@jitaspace/hooks": patch
+"@jitaspace/ui": patch
+"@jitaspace/esi-client": patch
+---
+
+Re-enable and fix the main Spotlight search
+
+**`@jitaspace/hooks`**
+- Add `useEsiNameLookup` compound hook (combines `useEsiNamePrefetch` + `useEsiNames`) for reactive name resolution
+- Fix `useEsiNames` reactivity bug: the shared `checkForUpdates` callback compared `CacheState.id` (an internal auto-increment `number`) against the entity ID list, so updates never triggered re-renders; replaced with per-key callbacks that each close over their own string key
+
+**`@jitaspace/esi-client`**
+- Fix SSR hydration mismatch in `useEsiRateLimit`: moved initial state load from lazy `useState` initializer into `useEffect` so the server and client start with the same empty state
+
+**`@jitaspace/ui`**
+- Replace `useEsiNamesCache` (static snapshot) with `useEsiNameLookup` (reactive) in `AssetLocationSelect`, `EsiSearchSelect`, and `EveEntitySelect`
+- Fix `EveEntitySelect.displayName` (was incorrectly set to `"EsiSearchSelect"`)
+
+**`@jitaspace/web`**
+- Re-enable the Spotlight search component (disabled since the Mantine v6 → v7 migration)
+- Rewrite `MainSpotlight` using the Mantine compound Spotlight API (`Spotlight.Root` / `Spotlight.Search` / `Spotlight.ActionsList`) to keep `SpotlightActionsList` always mounted, preventing a Mantine bug where pressing Enter with no results threw `SyntaxError: '# [data-selected]' is not a valid selector`
+- Show apps from all categories (Character, Corporation, Alliance, Universe, Developer) in grouped sections
+- Make the results list scrollable (removed 100-result cap)
+- Replace `useEsiNamesCache` with `useEsiNameLookup` in `AssetsDataTable`, character assets page, and corporation assets page
+- Add tests for `MainSpotlight` covering app rendering, query filtering, navigation, and ESI search result handling

--- a/apps/web/app/assets/character/page.tsx
+++ b/apps/web/app/assets/character/page.tsx
@@ -2,9 +2,7 @@
 
 import {
   useCallback,
-  useEffect,
   useMemo
-  
 } from "react";
 import {
   Center,
@@ -18,13 +16,12 @@ import {
   Title,
 } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { useForceUpdate, usePagination, useTimeout } from "@mantine/hooks";
+import { usePagination } from "@mantine/hooks";
 
 import { AssetsIcon } from "@jitaspace/eve-icons";
 import {
   useCharacterAssets,
-  useEsiNamePrefetch,
-  useEsiNamesCache,
+  useEsiNameLookup,
   useMarketPrices,
   useSelectedCharacter,
 } from "@jitaspace/hooks";
@@ -35,7 +32,6 @@ import { ScopeGuard } from "~/components/ScopeGuard";
 
 
 export default function Page() {
-  const forceUpdate = useForceUpdate();
   const character = useSelectedCharacter();
   const { assets, isLoading } = useCharacterAssets(character?.characterId);
   const filterForm = useForm<{ location_id: number | null; name: string }>({
@@ -44,19 +40,21 @@ export default function Page() {
       name: "",
     },
   });
-  const cache = useEsiNamesCache();
   const { data: marketPrices } = useMarketPrices();
 
-  const getNameFromCache = useCallback(
-    (id: number) => cache[id]?.value?.name,
-    [cache],
+  const assetEntries = useMemo(
+    () =>
+      Object.values(assets ?? {}).map((asset) => ({
+        id: asset.type_id,
+        category: "inventory_type" as const,
+      })),
+    [assets],
   );
+  const names = useEsiNameLookup(assetEntries);
 
-  useEsiNamePrefetch(
-    Object.values(assets ?? {}).map((asset) => ({
-      id: asset.type_id,
-      category: "inventory_type",
-    })),
+  const getNameFromCache = useCallback(
+    (id: number) => names[id.toString()]?.value?.name,
+    [names],
   );
 
   const filtersEnabled =
@@ -114,14 +112,6 @@ export default function Page() {
   const pagination = usePagination({ total: numPages, siblings: 3 });
   const offset = ENTRIES_PER_PAGE * (pagination.active - 1);
 
-  // reload if some asset names are still missing
-  const { start, clear } = useTimeout(() => forceUpdate(), 1000);
-
-  useEffect(() => {
-    if (numUndefinedNames > 0) start();
-    else clear();
-  }, [numUndefinedNames, start]);
-
   return (
     <ScopeGuard requiredScopes={["esi-assets.read_assets.v1"]}>
       <Container size="xl">
@@ -161,11 +151,7 @@ export default function Page() {
         </Text>
         {numUndefinedNames > 0 && (
           <Text color="red" size="sm">
-            Failed to resolve names for {numUndefinedNames} items! This causes
-            the ordering of items to be wrong.
-            <br />
-            Keep changing between pages 1 and 2 and it should resolve itself...
-            This is an annoying bug, sorry about that!
+            Resolving names for {numUndefinedNames} items…
           </Text>
         )}
         <Center>

--- a/apps/web/app/assets/corporation/page.tsx
+++ b/apps/web/app/assets/corporation/page.tsx
@@ -3,8 +3,7 @@
 import {AssetsIcon, AttentionIcon} from "@jitaspace/eve-icons";
 import {
   useCorporationAssets,
-  useEsiNamePrefetch,
-  useEsiNamesCache,
+  useEsiNameLookup,
   useMarketPrices,
   useSelectedCharacter,
 } from "@jitaspace/hooks";
@@ -12,7 +11,7 @@ import {EveEntityAnchor, EveEntityName, TypeAnchor, TypeAvatar, TypeName,} from 
 import {Alert, Badge, Center, Container, Group, Loader, Pagination, Stack, Table, Text, Title,} from "@mantine/core";
 import {useForm} from "@mantine/form";
 import {usePagination} from "@mantine/hooks";
-import { useCallback, useMemo} from "react";
+import { useCallback, useMemo } from "react";
 import { ScopeGuard } from "~/components/ScopeGuard";
 
 
@@ -28,19 +27,21 @@ export default function Page() {
       name: "",
     },
   });
-  const cache = useEsiNamesCache();
   const {data: marketPrices} = useMarketPrices();
 
-  const getNameFromCache = useCallback(
-    (id: number) => cache[id]?.value?.name,
-    [cache],
+  const assetEntries = useMemo(
+    () =>
+      Object.values(assets ?? {}).map((asset) => ({
+        id: asset.type_id,
+        category: "inventory_type" as const,
+      })),
+    [assets],
   );
+  const names = useEsiNameLookup(assetEntries);
 
-  useEsiNamePrefetch(
-    Object.values(assets ?? {}).map((asset) => ({
-      id: asset.type_id,
-      category: "inventory_type",
-    })),
+  const getNameFromCache = useCallback(
+    (id: number) => names[id.toString()]?.value?.name,
+    [names],
   );
 
   const filtersEnabled =

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -24,7 +24,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 import { EsiClientSSOAccessTokenInjector } from "~/components/EsiClientSSOAccessTokenInjector";
 import { contextModals } from "~/components/Modals";
 import { RouterTransition } from "~/components/RouterTransition.tsx";
-import { JitaSpotlightProvider } from "~/components/Spotlight";
+import { MainSpotlight } from "~/components/Spotlight";
 import { env } from "~/env";
 import { MainLayout } from "~/layouts";
 import { MyQueryClientProvider } from "~/lib/MyQueryClientProvider";
@@ -118,14 +118,13 @@ export default function RootLayout({
                   <Suspense fallback={null}>
                     <RouterTransition />
                   </Suspense>
-                  <JitaSpotlightProvider>
-                    <ModalsProvider
-                      modals={contextModals}
-                      modalProps={{ centered: true }}
-                    >
-                      <MainLayout>{children}</MainLayout>
-                    </ModalsProvider>
-                  </JitaSpotlightProvider>
+                  <MainSpotlight />
+                  <ModalsProvider
+                    modals={contextModals}
+                    modalProps={{ centered: true }}
+                  >
+                    <MainLayout>{children}</MainLayout>
+                  </ModalsProvider>
                 </>
               </EsiClientSSOAccessTokenInjector>
             </MySessionProvider>

--- a/apps/web/components/Assets/AssetsDataTable.tsx
+++ b/apps/web/components/Assets/AssetsDataTable.tsx
@@ -1,80 +1,38 @@
-import { memo, useCallback, useEffect, useMemo } from "react";
+import type { MRT_ColumnDef } from "mantine-react-table";
+import { memo, useMemo } from "react";
 import { Group, Text } from "@mantine/core";
-import { useForceUpdate, useTimeout } from "@mantine/hooks";
-import type {
-  MRT_ColumnDef} from "mantine-react-table";
-import {
-  MantineReactTable,
-  useMantineReactTable,
-} from "mantine-react-table";
+import { MantineReactTable, useMantineReactTable } from "mantine-react-table";
 
-import type {
-  CharacterAsset} from "@jitaspace/hooks";
-import {
-  useEsiNamePrefetch,
-  useEsiNamesCache,
-  useMarketPrices,
-} from "@jitaspace/hooks";
+import type { CharacterAsset } from "@jitaspace/hooks";
+import { useEsiNameLookup, useMarketPrices } from "@jitaspace/hooks";
 import { ISKAmount, TypeAnchor, TypeAvatar } from "@jitaspace/ui";
-
-
-
-
 
 interface AssetsDataTableProps {
   entries: CharacterAsset[];
 }
 
 export const AssetsDataTable = memo(({ entries }: AssetsDataTableProps) => {
-  const forceUpdate = useForceUpdate();
-  const cache = useEsiNamesCache();
   const { data: marketPrices } = useMarketPrices();
 
-  useEsiNamePrefetch(
-    Object.values(entries ?? {}).map((asset) => ({
-      id: asset.type_id,
-      category: "inventory_type",
-    })),
-  );
-
-  const getNameFromCache = useCallback(
-    (id: number) => cache[id]?.value?.name,
-    [cache],
-  );
-
-  const typeIds = useMemo(
-    () => [...new Set(entries.map((entry) => entry.type_id))],
+  const assetEntries = useMemo(
+    () =>
+      entries.map((asset) => ({
+        id: asset.type_id,
+        category: "inventory_type" as const,
+      })),
     [entries],
   );
-
-  const typeNames = useMemo(() => {
-    const names: Record<number, string | undefined> = {};
-    typeIds.forEach((typeId) => (names[typeId] = getNameFromCache(typeId)));
-    return names;
-  }, [getNameFromCache, typeIds]);
+  const names = useEsiNameLookup(assetEntries);
 
   const augmentedEntries = useMemo(
     () =>
       entries.map((entry) => ({
         ...entry,
         unitPrice: marketPrices[entry.type_id]?.adjusted_price,
-        typeName: typeNames[entry.type_id],
+        typeName: names[entry.type_id.toString()]?.value?.name,
       })),
-    [entries, marketPrices, typeNames],
+    [entries, marketPrices, names],
   );
-
-  const numUndefinedNames = useMemo(
-    () =>
-      augmentedEntries.filter((entry) => entry.typeName === undefined).length,
-    [augmentedEntries],
-  );
-
-  // reload if some asset names are still missing
-  const { start } = useTimeout(() => forceUpdate(), 1000);
-
-  useEffect(() => {
-    if (numUndefinedNames > 0) start();
-  }, [numUndefinedNames, start]);
 
   const columns = useMemo<MRT_ColumnDef<(typeof augmentedEntries)[number]>[]>(
     () => [
@@ -144,11 +102,6 @@ export const AssetsDataTable = memo(({ entries }: AssetsDataTableProps) => {
     },
   });
 
-  return (
-    <>
-      <Text>NUM UNDEFINED: {numUndefinedNames}</Text>
-      <MantineReactTable table={table} />
-    </>
-  );
+  return <MantineReactTable table={table} />;
 });
 AssetsDataTable.displayName = "AssetsDataTable";

--- a/apps/web/components/Assets/AssetsDataTable.tsx
+++ b/apps/web/components/Assets/AssetsDataTable.tsx
@@ -1,6 +1,6 @@
 import type { MRT_ColumnDef } from "mantine-react-table";
 import { memo, useMemo } from "react";
-import { Group, Text } from "@mantine/core";
+import { Group } from "@mantine/core";
 import { MantineReactTable, useMantineReactTable } from "mantine-react-table";
 
 import type { CharacterAsset } from "@jitaspace/hooks";

--- a/apps/web/components/Spotlight/MainSpotlight.tsx
+++ b/apps/web/components/Spotlight/MainSpotlight.tsx
@@ -6,15 +6,11 @@ import { useDebouncedValue } from "@mantine/hooks";
 import type { SpotlightActionData } from "@mantine/spotlight";
 import { Spotlight } from "@mantine/spotlight";
 
-import type {
-  EsiSearchCategory} from "@jitaspace/hooks";
-import {
-  useEsiNamesCache,
-  useEsiSearch,
-} from "@jitaspace/hooks";
+import type { EsiSearchCategory } from "@jitaspace/hooks";
+import { useEsiNameLookup, useEsiSearch } from "@jitaspace/hooks";
 import { EveEntityAvatar } from "@jitaspace/ui";
 
-import { characterApps } from "~/config/apps";
+import { jitaApps } from "~/config/apps";
 
 export const MainSpotlight = () => {
   const router = useRouter();
@@ -23,25 +19,37 @@ export const MainSpotlight = () => {
 
   const { data: esiSearchData } = useEsiSearch(debouncedQuery);
 
-  const names = useEsiNamesCache();
+  const entityEntries = useMemo(
+    () =>
+      Object.entries(esiSearchData?.data ?? []).flatMap(
+        ([categoryString, entries]) => {
+          const category = categoryString as EsiSearchCategory;
+          return entries.map((entityId) => ({ id: entityId, category }));
+        },
+      ),
+    [esiSearchData?.data],
+  );
+
+  const names = useEsiNameLookup(entityEntries);
 
   const appActions: SpotlightActionData[] = useMemo(
     () =>
-      Object.values(characterApps)
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((app) => ({
-          id: `app/${app.name}`,
-          label: app.name,
-          description: app.description,
-          group: "Apps",
-          leftSection: <app.Icon width={32} />,
-          onClick: () => {
-            if (app.url !== undefined) {
-              void router.push(app.url);
-            }
-          },
-          icon: <app.Icon width={38} />,
-        })),
+      Object.values(jitaApps).flatMap(({ name: groupName, apps }) =>
+        Object.values(apps)
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((app) => ({
+            id: `app/${groupName}/${app.name}`,
+            label: app.name,
+            description: app.description,
+            group: `${groupName} Apps`,
+            leftSection: <app.Icon width={32} height={32} />,
+            onClick: () => {
+              if (app.url !== undefined) {
+                void router.push(app.url);
+              }
+            },
+          })),
+      ),
     [router],
   );
 
@@ -52,8 +60,7 @@ export const MainSpotlight = () => {
           const category = categoryString as EsiSearchCategory;
           return entries.map((entityId) => ({
             id: `entity/${entityId}`,
-            label: names[entityId]?.value?.name ?? "",
-            //description: `Search result for ${debouncedQuery}`,
+            label: names[entityId.toString()]?.value?.name ?? "",
             group: category.replace("_", " "),
             leftSection: (
               <EveEntityAvatar
@@ -104,13 +111,60 @@ export const MainSpotlight = () => {
     [appActions, esiSearchResultActions],
   );
 
+  // Filter actions by query locally (mirrors defaultSpotlightFilter behaviour)
+  const filteredActions = useMemo(() => {
+    if (!query.trim()) return actions;
+    const q = query.trim().toLowerCase();
+    return actions.filter(
+      (action) =>
+        action.label?.toLowerCase().includes(q) ||
+        action.description?.toLowerCase().includes(q),
+    );
+  }, [query, actions]);
+
+  // Group filtered actions for rendering with the compound API
+  const { ungrouped, groups } = useMemo(() => {
+    const _groups: Record<string, SpotlightActionData[]> = {};
+    const _ungrouped: SpotlightActionData[] = [];
+    for (const action of filteredActions) {
+      if (action.group) {
+        (_groups[action.group] ??= []).push(action);
+      } else {
+        _ungrouped.push(action);
+      }
+    }
+    return { ungrouped: _ungrouped, groups: _groups };
+  }, [filteredActions]);
+
+  // Use the compound API so SpotlightActionsList is always mounted.
+  // When SpotlightActionsList unmounts it clears listId to ""; pressing Enter
+  // then calls querySelector("# [data-selected]") which is an invalid selector
+  // and throws a SyntaxError. Keeping it always mounted avoids the bug.
   return (
-    <Spotlight
+    <Spotlight.Root
       shortcut={["mod + K", "mod + P", "/"]}
-      limit={100}
       query={query}
       onQueryChange={setQuery}
-      actions={actions}
-    />
+    >
+      <Spotlight.Search />
+      <Spotlight.ActionsList mah="60vh" style={{ overflowY: "auto" }}>
+        {filteredActions.length > 0 ? (
+          <>
+            {ungrouped.map(({ id, group: _g, ...action }) => (
+              <Spotlight.Action key={id} id={id} {...action} />
+            ))}
+            {Object.entries(groups).map(([groupName, groupActions]) => (
+              <Spotlight.ActionsGroup key={groupName} label={groupName}>
+                {groupActions.map(({ id, group: _g, ...action }) => (
+                  <Spotlight.Action key={id} id={id} {...action} />
+                ))}
+              </Spotlight.ActionsGroup>
+            ))}
+          </>
+        ) : (
+          <Spotlight.Empty>No results found</Spotlight.Empty>
+        )}
+      </Spotlight.ActionsList>
+    </Spotlight.Root>
   );
 };

--- a/apps/web/components/Spotlight/MainSpotlight.tsx
+++ b/apps/web/components/Spotlight/MainSpotlight.tsx
@@ -34,7 +34,8 @@ export const MainSpotlight = () => {
 
   const makeAppOnClick = useCallback(
     (url: string | undefined) => () => {
-      if (url !== undefined) void router.push(url);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      if (url !== undefined) router.push(url);
     },
     [router],
   );
@@ -131,7 +132,7 @@ export const MainSpotlight = () => {
     const _ungrouped: SpotlightActionData[] = [];
     for (const action of filteredActions) {
       if (action.group) {
-        if (!_groups[action.group]) _groups[action.group] = [];
+        _groups[action.group] ??= [];
         _groups[action.group].push(action);
       } else {
         _ungrouped.push(action);

--- a/apps/web/components/Spotlight/MainSpotlight.tsx
+++ b/apps/web/components/Spotlight/MainSpotlight.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useDebouncedValue } from "@mantine/hooks";
 import type { SpotlightActionData } from "@mantine/spotlight";
@@ -32,6 +32,13 @@ export const MainSpotlight = () => {
 
   const names = useEsiNameLookup(entityEntries);
 
+  const makeAppOnClick = useCallback(
+    (url: string | undefined) => () => {
+      if (url !== undefined) void router.push(url);
+    },
+    [router],
+  );
+
   const appActions: SpotlightActionData[] = useMemo(
     () =>
       Object.values(jitaApps).flatMap(({ name: groupName, apps }) =>
@@ -43,14 +50,10 @@ export const MainSpotlight = () => {
             description: app.description,
             group: `${groupName} Apps`,
             leftSection: <app.Icon width={32} height={32} />,
-            onClick: () => {
-              if (app.url !== undefined) {
-                void router.push(app.url);
-              }
-            },
+            onClick: makeAppOnClick(app.url),
           })),
       ),
-    [router],
+    [makeAppOnClick],
   );
 
   const esiSearchResultActions: SpotlightActionData[] = useMemo(
@@ -128,7 +131,8 @@ export const MainSpotlight = () => {
     const _ungrouped: SpotlightActionData[] = [];
     for (const action of filteredActions) {
       if (action.group) {
-        (_groups[action.group] ??= []).push(action);
+        if (!_groups[action.group]) _groups[action.group] = [];
+        _groups[action.group].push(action);
       } else {
         _ungrouped.push(action);
       }

--- a/apps/web/tests/assetsDataTable.test.tsx
+++ b/apps/web/tests/assetsDataTable.test.tsx
@@ -1,0 +1,141 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { ReactNode } from "react";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+const mockUseMarketPrices =
+  jest.fn<() => { data: Record<number, { adjusted_price?: number }> }>();
+const mockUseEsiNameLookup = jest.fn<
+  () => Record<string, { value?: { name: string } } | undefined>
+>();
+
+jest.mock("@jitaspace/hooks", () => ({
+  useMarketPrices: () => mockUseMarketPrices(),
+  useEsiNameLookup: (...args: unknown[]) => mockUseEsiNameLookup(...args),
+}));
+
+jest.mock("@jitaspace/ui", () => ({
+  ISKAmount: ({ amount }: { amount: number }) => (
+    <span data-testid="isk-amount">{amount.toFixed(2)}</span>
+  ),
+  TypeAnchor: ({ children }: { children: ReactNode }) => (
+    <span data-testid="type-anchor">{children}</span>
+  ),
+  TypeAvatar: () => null,
+}));
+
+// Simplified mantine-react-table mock that renders rows with accessible data
+jest.mock("mantine-react-table", () => ({
+  MantineReactTable: ({ table }: { table: ReturnType<typeof mockTable> }) => (
+    <table>
+      <tbody>
+        {table.rows.map(
+          (row: { id: string | number; cells: { id: string; content: ReactNode }[] }) => (
+            <tr key={row.id} data-testid="table-row">
+              {row.cells.map((cell) => (
+                <td key={cell.id}>{cell.content}</td>
+              ))}
+            </tr>
+          ),
+        )}
+      </tbody>
+    </table>
+  ),
+  useMantineReactTable: (config: {
+    columns: {
+      id: string;
+      Cell?: (args: { row: { original: unknown }; cell: { getValue: () => unknown } }) => ReactNode;
+      accessorKey?: string;
+      accessorFn?: (row: unknown) => unknown;
+    }[];
+    data: unknown[];
+  }) => {
+    const rows = config.data.map((row, i) => ({
+      id: i,
+      cells: config.columns.map((col) => {
+        const value = col.accessorKey
+          ? (row as Record<string, unknown>)[col.accessorKey]
+          : col.accessorFn?.(row);
+        const content = col.Cell
+          ? col.Cell({
+              row: { original: row },
+              cell: { getValue: () => value },
+            })
+          : String(value ?? "");
+        return { id: col.id, content };
+      }),
+    }));
+    return { rows };
+  },
+}));
+
+type mockTable = ReturnType<typeof import("mantine-react-table")["useMantineReactTable"]>;
+
+const SAMPLE_ASSET = {
+  item_id: 1001,
+  type_id: 34,
+  quantity: 500,
+  location_id: 60003760,
+  location_type: "station" as const,
+  is_singleton: false,
+  is_blueprint_copy: false,
+};
+
+function renderTable(
+  entries: typeof SAMPLE_ASSET[] = [],
+) {
+  const { AssetsDataTable } = require("~/components/Assets/AssetsDataTable");
+  return render(
+    <MantineProvider>
+      <AssetsDataTable entries={entries} />
+    </MantineProvider>,
+  );
+}
+
+describe("AssetsDataTable", () => {
+  beforeEach(() => {
+    mockUseMarketPrices.mockReturnValue({ data: {} });
+    mockUseEsiNameLookup.mockReturnValue({});
+  });
+
+  it("renders without crashing with no entries", () => {
+    renderTable([]);
+    expect(screen.queryAllByTestId("table-row")).toHaveLength(0);
+  });
+
+  it("renders a row for each entry", () => {
+    renderTable([SAMPLE_ASSET, { ...SAMPLE_ASSET, item_id: 1002, type_id: 35 }]);
+    expect(screen.getAllByTestId("table-row")).toHaveLength(2);
+  });
+
+  it("shows the resolved type name when available", () => {
+    mockUseEsiNameLookup.mockReturnValue({
+      "34": { value: { name: "Tritanium" } },
+    });
+    renderTable([SAMPLE_ASSET]);
+    expect(screen.getByText("Tritanium")).toBeInTheDocument();
+  });
+
+  it("shows the ISK amount when market price is available", () => {
+    mockUseMarketPrices.mockReturnValue({
+      data: { 34: { adjusted_price: 5.5 } },
+    });
+    renderTable([SAMPLE_ASSET]);
+    // 5.5 * 500 = 2750
+    expect(screen.getByTestId("isk-amount")).toHaveTextContent("2750.00");
+  });
+
+  it("shows no ISK amount when market price is unavailable", () => {
+    mockUseMarketPrices.mockReturnValue({ data: {} });
+    renderTable([SAMPLE_ASSET]);
+    expect(screen.queryByTestId("isk-amount")).not.toBeInTheDocument();
+  });
+
+  it("uses type_id as sort key when name is not resolved", () => {
+    renderTable([SAMPLE_ASSET]);
+    // table renders without crash even when name is undefined
+    expect(screen.getByTestId("table-row")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/characterAssetsPage.test.tsx
+++ b/apps/web/tests/characterAssetsPage.test.tsx
@@ -1,0 +1,187 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { ReactNode } from "react";
+import { MantineProvider } from "@mantine/core";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockUseSelectedCharacter = jest.fn();
+const mockUseCharacterAssets = jest.fn<
+  () => { assets: Record<number, object>; isLoading: boolean }
+>();
+const mockUseEsiNameLookup = jest.fn<
+  () => Record<string, { value?: { name: string } } | undefined>
+>();
+const mockUseMarketPrices = jest.fn<
+  () => { data: Record<number, { adjusted_price?: number }> }
+>();
+
+jest.mock("@jitaspace/hooks", () => ({
+  useSelectedCharacter: () => mockUseSelectedCharacter(),
+  useCharacterAssets: (...args: unknown[]) => mockUseCharacterAssets(...args),
+  useEsiNameLookup: (...args: unknown[]) => mockUseEsiNameLookup(...args),
+  useMarketPrices: () => mockUseMarketPrices(),
+}));
+
+jest.mock("@jitaspace/ui", () => ({
+  AssetLocationSelect: ({
+    onChange,
+  }: {
+    onChange?: (v: string | null, opts: object) => void;
+  }) => (
+    <select
+      data-testid="location-select"
+      aria-label="Filter by location"
+      onChange={(e) => onChange?.(e.target.value || null, {})}
+    >
+      <option value="">All</option>
+      <option value="60003760">Jita</option>
+      <option value="60008526">Amarr</option>
+    </select>
+  ),
+  ISKAmount: ({ amount }: { amount: number; span?: boolean }) => (
+    <span data-testid="isk-amount">{amount.toFixed(2)}</span>
+  ),
+}));
+
+jest.mock("@jitaspace/eve-icons", () => ({
+  AssetsIcon: () => null,
+}));
+
+jest.mock("~/components/Assets/AssetsDataTable", () => ({
+  AssetsDataTable: ({ entries }: { entries: unknown[] }) => (
+    <div data-testid="assets-table">{entries.length} entries</div>
+  ),
+}));
+
+jest.mock("~/components/ScopeGuard", () => ({
+  ScopeGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const SAMPLE_ASSETS = {
+  1001: {
+    item_id: 1001,
+    type_id: 34,
+    quantity: 500,
+    location_id: 60003760,
+    location_type: "station",
+    is_singleton: false,
+    is_blueprint_copy: false,
+  },
+  1002: {
+    item_id: 1002,
+    type_id: 35,
+    quantity: 100,
+    location_id: 60003760,
+    location_type: "item", // filtered out
+    is_singleton: false,
+    is_blueprint_copy: false,
+  },
+  1003: {
+    item_id: 1003,
+    type_id: 36,
+    quantity: 200,
+    location_id: 60008526,
+    location_type: "station",
+    is_singleton: false,
+    is_blueprint_copy: false,
+  },
+};
+
+function renderPage() {
+  const Page = require("~/app/assets/character/page").default;
+  return render(
+    <MantineProvider>
+      <Page />
+    </MantineProvider>,
+  );
+}
+
+describe("Character Assets Page", () => {
+  beforeEach(() => {
+    mockUseSelectedCharacter.mockReturnValue({ characterId: 123456789 });
+    mockUseCharacterAssets.mockReturnValue({
+      assets: SAMPLE_ASSETS,
+      isLoading: false,
+    });
+    mockUseEsiNameLookup.mockReturnValue({
+      "34": { value: { name: "Tritanium" } },
+      "36": { value: { name: "Mexallon" } },
+    });
+    mockUseMarketPrices.mockReturnValue({ data: {} });
+  });
+
+  it("renders the Assets title", () => {
+    renderPage();
+    expect(screen.getByText("Assets")).toBeInTheDocument();
+  });
+
+  it("passes the character ID to useCharacterAssets", () => {
+    renderPage();
+    expect(mockUseCharacterAssets).toHaveBeenCalledWith(123456789);
+  });
+
+  it("shows the total asset count", () => {
+    renderPage();
+    // Object.keys(SAMPLE_ASSETS).length = 3
+    expect(screen.getByText("3 assets")).toBeInTheDocument();
+  });
+
+  it("filters out assets with location_type 'item'", () => {
+    renderPage();
+    // 3 total assets, 1 has location_type=item → 2 rendered
+    expect(screen.getByTestId("assets-table")).toHaveTextContent("2 entries");
+  });
+
+  it("shows the total ISK value", () => {
+    mockUseMarketPrices.mockReturnValue({
+      data: {
+        34: { adjusted_price: 5 }, // 500 * 5 = 2500
+        36: { adjusted_price: 10 }, // 200 * 10 = 2000
+      },
+    });
+    renderPage();
+    expect(screen.getByTestId("isk-amount")).toHaveTextContent("4500.00");
+  });
+
+  it("shows a resolving-names message when names are still loading", () => {
+    mockUseEsiNameLookup.mockReturnValue({});
+    renderPage();
+    expect(screen.getByText(/Resolving names for/)).toBeInTheDocument();
+  });
+
+  it("does not show the resolving message once all names are loaded", () => {
+    renderPage();
+    expect(screen.queryByText(/Resolving names for/)).not.toBeInTheDocument();
+  });
+
+  it("shows filtered count and updates the table when name filter is applied", () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText("Filter by name"), {
+      target: { value: "Tritanium" },
+    });
+    expect(screen.getByText(/Showing 1\/3 assets/)).toBeInTheDocument();
+    expect(screen.getByTestId("assets-table")).toHaveTextContent("1 entries");
+  });
+
+  it("shows filtered count when location filter is applied", () => {
+    renderPage();
+    fireEvent.change(screen.getByTestId("location-select"), {
+      target: { value: "60003760" },
+    });
+    // Only SAMPLE_ASSETS[1001] is at 60003760 with location_type=station
+    expect(screen.getByText(/Showing 1\/3 assets/)).toBeInTheDocument();
+    expect(screen.getByTestId("assets-table")).toHaveTextContent("1 entries");
+  });
+
+  it("renders the AssetsDataTable", () => {
+    renderPage();
+    expect(screen.getByTestId("assets-table")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when assets is empty", () => {
+    mockUseCharacterAssets.mockReturnValue({ assets: {}, isLoading: false });
+    renderPage();
+    expect(screen.getByText("0 assets")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/corporationAssetsPage.test.tsx
+++ b/apps/web/tests/corporationAssetsPage.test.tsx
@@ -1,0 +1,191 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { ReactNode } from "react";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+const mockUseSelectedCharacter = jest.fn();
+const mockUseCorporationAssets = jest.fn<
+  () => {
+    assets: Record<number, object>;
+    isLoading: boolean;
+    errorMessage?: string;
+  }
+>();
+const mockUseEsiNameLookup = jest.fn<
+  () => Record<string, { value?: { name: string } } | undefined>
+>();
+const mockUseMarketPrices = jest.fn<
+  () => { data: Record<number, { adjusted_price?: number }> }
+>();
+
+jest.mock("@jitaspace/hooks", () => ({
+  useSelectedCharacter: () => mockUseSelectedCharacter(),
+  useCorporationAssets: (...args: unknown[]) =>
+    mockUseCorporationAssets(...args),
+  useEsiNameLookup: (...args: unknown[]) => mockUseEsiNameLookup(...args),
+  useMarketPrices: () => mockUseMarketPrices(),
+}));
+
+jest.mock("@jitaspace/ui", () => ({
+  TypeAvatar: () => null,
+  TypeAnchor: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  TypeName: ({ typeId }: { typeId: number }) => (
+    <span data-testid={`type-name-${typeId}`}>{typeId}</span>
+  ),
+  EveEntityAnchor: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  EveEntityName: ({ entityId }: { entityId: number }) => (
+    <span data-testid={`entity-name-${entityId}`}>{entityId}</span>
+  ),
+}));
+
+jest.mock("@jitaspace/eve-icons", () => ({
+  AssetsIcon: () => null,
+  AttentionIcon: () => null,
+}));
+
+jest.mock("~/components/ScopeGuard", () => ({
+  ScopeGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const SAMPLE_ASSETS = {
+  2001: {
+    item_id: 2001,
+    type_id: 34,
+    quantity: 1000,
+    location_id: 60003760,
+    location_type: "station",
+    is_singleton: false,
+    is_blueprint_copy: false,
+  },
+  2002: {
+    item_id: 2002,
+    type_id: 35,
+    quantity: 50,
+    location_id: 60003760,
+    location_type: "item", // filtered out
+    is_singleton: false,
+    is_blueprint_copy: false,
+  },
+  2003: {
+    item_id: 2003,
+    type_id: 36,
+    quantity: 300,
+    location_id: 60008526,
+    location_type: "station",
+    is_singleton: true,
+    is_blueprint_copy: false,
+  },
+  2004: {
+    item_id: 2004,
+    type_id: 37,
+    quantity: 1,
+    location_id: 60008526,
+    location_type: "station",
+    is_singleton: false,
+    is_blueprint_copy: true,
+  },
+};
+
+function renderPage() {
+  const Page = require("~/app/assets/corporation/page").default;
+  return render(
+    <MantineProvider>
+      <Page />
+    </MantineProvider>,
+  );
+}
+
+describe("Corporation Assets Page", () => {
+  beforeEach(() => {
+    mockUseSelectedCharacter.mockReturnValue({
+      corporationId: 987654321,
+      characterId: 123456789,
+    });
+    mockUseCorporationAssets.mockReturnValue({
+      assets: SAMPLE_ASSETS,
+      isLoading: false,
+      errorMessage: undefined,
+    });
+    mockUseEsiNameLookup.mockReturnValue({
+      "34": { value: { name: "Tritanium" } },
+      "36": { value: { name: "Mexallon" } },
+      "37": { value: { name: "Isogen" } },
+    });
+    mockUseMarketPrices.mockReturnValue({ data: {} });
+  });
+
+  it("renders the Corporation Assets title", () => {
+    renderPage();
+    expect(screen.getByText("Corporation Assets")).toBeInTheDocument();
+  });
+
+  it("passes the corporation ID to useCorporationAssets", () => {
+    renderPage();
+    expect(mockUseCorporationAssets).toHaveBeenCalledWith(987654321);
+  });
+
+  it("shows total asset count", () => {
+    renderPage();
+    // Object.keys(SAMPLE_ASSETS).length = 4
+    expect(screen.getByText("4 assets")).toBeInTheDocument();
+  });
+
+  it("filters out assets with location_type 'item'", () => {
+    renderPage();
+    // 2002 has location_type=item, so 3 rows should render
+    expect(screen.getAllByRole("row")).toHaveLength(4); // 1 header + 3 data rows
+  });
+
+  it("shows an error alert when errorMessage is set", () => {
+    mockUseCorporationAssets.mockReturnValue({
+      assets: {},
+      isLoading: false,
+      errorMessage: "Forbidden",
+    });
+    renderPage();
+    expect(screen.getByText("Forbidden")).toBeInTheDocument();
+    expect(screen.getByText("Error!")).toBeInTheDocument();
+  });
+
+  it("does not show the table when there is an error", () => {
+    mockUseCorporationAssets.mockReturnValue({
+      assets: {},
+      isLoading: false,
+      errorMessage: "Forbidden",
+    });
+    renderPage();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("shows 'assembled' badge for singleton items", () => {
+    renderPage();
+    expect(screen.getByText("assembled")).toBeInTheDocument();
+  });
+
+  it("shows 'BPC' badge for blueprint copies", () => {
+    renderPage();
+    expect(screen.getByText("BPC")).toBeInTheDocument();
+  });
+
+  it("renders without crashing when assets is empty", () => {
+    mockUseCorporationAssets.mockReturnValue({
+      assets: {},
+      isLoading: false,
+      errorMessage: undefined,
+    });
+    renderPage();
+    expect(screen.getByText("0 assets")).toBeInTheDocument();
+  });
+
+  it("shows unresolved-names warning when some names are missing", () => {
+    mockUseEsiNameLookup.mockReturnValue({});
+    renderPage();
+    expect(screen.getByText(/Failed to resolve names for/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/mainSpotlight.test.tsx
+++ b/apps/web/tests/mainSpotlight.test.tsx
@@ -1,0 +1,340 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { ImgHTMLAttributes, ReactNode } from "react";
+import { MantineProvider } from "@mantine/core";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockRouterPush = jest.fn<(url: string) => Promise<boolean>>();
+const mockUseEsiSearch =
+  jest.fn<() => { data?: { data: Record<string, number[]> } }>();
+const mockUseEsiNameLookup = jest.fn<
+  () => Record<
+    string,
+    | {
+        status: string;
+        value?: { name: string; category: string };
+        error: undefined;
+        id: number;
+      }
+    | undefined
+  >
+>();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+jest.mock("@mantine/hooks", () => ({
+  useDebouncedValue: (value: string) => [value],
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: ImgHTMLAttributes<HTMLImageElement>) => (
+    <img alt={props.alt} {...props} />
+  ),
+}));
+
+jest.mock("@jitaspace/hooks", () => ({
+  useEsiSearch: (...args: unknown[]) => mockUseEsiSearch(...args),
+  useEsiNameLookup: (...args: unknown[]) => mockUseEsiNameLookup(...args),
+}));
+
+jest.mock("@jitaspace/ui", () => ({
+  EveEntityAvatar: () => null,
+}));
+
+jest.mock("~/config/apps", () => ({
+  jitaApps: {
+    character: {
+      name: "Character",
+      apps: {
+        mail: {
+          name: "EveMail",
+          description: "Access your correspondence whilst out of the game.",
+          url: "/mail",
+          Icon: () => null,
+        },
+        skills: {
+          name: "Skills",
+          description: "Manage your skills and skill points.",
+          url: "/skills",
+          Icon: () => null,
+        },
+      },
+    },
+    universe: {
+      name: "Universe",
+      apps: {
+        market: {
+          name: "Market",
+          description: "Browse EVE's regional markets",
+          url: "/market",
+          Icon: () => null,
+        },
+      },
+    },
+  },
+}));
+
+jest.mock("@mantine/spotlight", () => ({
+  Spotlight: {
+    Root: ({
+      children,
+      query,
+      onQueryChange,
+    }: {
+      children: ReactNode;
+      query?: string;
+      onQueryChange?: (v: string) => void;
+      shortcut?: string[];
+    }) => (
+      <div>
+        <input
+          data-testid="spotlight-search"
+          value={query ?? ""}
+          onChange={(e) => onQueryChange?.(e.target.value)}
+        />
+        {children}
+      </div>
+    ),
+    Search: () => null,
+    ActionsList: ({
+      children,
+    }: {
+      children: ReactNode;
+      mah?: string;
+      style?: Record<string, string>;
+    }) => <div data-testid="spotlight-actions-list">{children}</div>,
+    Action: ({
+      id,
+      label,
+      onClick,
+    }: {
+      id: string;
+      label?: string;
+      description?: string;
+      leftSection?: ReactNode;
+      onClick?: () => void;
+    }) => (
+      <button data-testid={`action-${id}`} onClick={onClick}>
+        {label}
+      </button>
+    ),
+    ActionsGroup: ({
+      label,
+      children,
+    }: {
+      label: string;
+      children: ReactNode;
+    }) => (
+      <div data-testid={`group-${label}`}>
+        <span>{label}</span>
+        {children}
+      </div>
+    ),
+    Empty: ({ children }: { children: ReactNode }) => (
+      <div data-testid="spotlight-empty">{children}</div>
+    ),
+  },
+}));
+
+function renderSpotlight() {
+  const { MainSpotlight } = require("~/components/Spotlight/MainSpotlight");
+  return render(
+    <MantineProvider>
+      <MainSpotlight />
+    </MantineProvider>,
+  );
+}
+
+describe("MainSpotlight", () => {
+  beforeEach(() => {
+    mockRouterPush.mockReset();
+    mockUseEsiSearch.mockReturnValue({ data: undefined });
+    mockUseEsiNameLookup.mockReturnValue({});
+  });
+
+  describe("app actions", () => {
+    it("renders the search input", () => {
+      renderSpotlight();
+      expect(screen.getByTestId("spotlight-search")).toBeInTheDocument();
+    });
+
+    it("shows a group for each app category", () => {
+      renderSpotlight();
+      expect(screen.getByTestId("group-Character Apps")).toBeInTheDocument();
+      expect(screen.getByTestId("group-Universe Apps")).toBeInTheDocument();
+    });
+
+    it("renders apps within their category group", () => {
+      renderSpotlight();
+      expect(
+        screen.getByTestId("action-app/Character/EveMail"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-app/Universe/Market"),
+      ).toBeInTheDocument();
+    });
+
+    it("navigates to the app url when an action is clicked", () => {
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-app/Character/EveMail"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/mail");
+    });
+  });
+
+  describe("filtering", () => {
+    it("shows only matching apps when a query is typed", () => {
+      renderSpotlight();
+      fireEvent.change(screen.getByTestId("spotlight-search"), {
+        target: { value: "mail" },
+      });
+      expect(screen.getByTestId("action-app/Character/EveMail")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("action-app/Character/Skills"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("matches apps by description as well as name", () => {
+      renderSpotlight();
+      // "correspondence" appears in EveMail's description, not its name
+      fireEvent.change(screen.getByTestId("spotlight-search"), {
+        target: { value: "correspondence" },
+      });
+      expect(screen.getByTestId("action-app/Character/EveMail")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("action-app/Character/Skills"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows all apps again when the query is cleared", () => {
+      renderSpotlight();
+      const input = screen.getByTestId("spotlight-search");
+      fireEvent.change(input, { target: { value: "mail" } });
+      fireEvent.change(input, { target: { value: "" } });
+      expect(screen.getByTestId("action-app/Character/EveMail")).toBeInTheDocument();
+      expect(screen.getByTestId("action-app/Character/Skills")).toBeInTheDocument();
+    });
+
+    it("shows the empty state when no apps or results match", () => {
+      renderSpotlight();
+      fireEvent.change(screen.getByTestId("spotlight-search"), {
+        target: { value: "xyznotamatch" },
+      });
+      expect(screen.getByTestId("spotlight-empty")).toHaveTextContent(
+        "No results found",
+      );
+    });
+  });
+
+  describe("ESI search results", () => {
+    it("renders entity results returned by the ESI search", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { character: [12345678] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "12345678": {
+          status: "success",
+          value: { name: "Test Character", category: "character" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      expect(screen.getByText("Test Character")).toBeInTheDocument();
+    });
+
+    it("navigates to the character page when a character result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { character: [12345678] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "12345678": {
+          status: "success",
+          value: { name: "Test Character", category: "character" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/12345678"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/character/12345678");
+    });
+
+    it("navigates to the corporation page when a corporation result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { corporation: [98000001] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "98000001": {
+          status: "success",
+          value: { name: "Test Corp", category: "corporation" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/98000001"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/corporation/98000001");
+    });
+
+    it("navigates to the alliance page when an alliance result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { alliance: [99000001] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "99000001": {
+          status: "success",
+          value: { name: "Test Alliance", category: "alliance" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/99000001"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/alliance/99000001");
+    });
+
+    it("navigates to the inventory type page when an inventory_type result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { inventory_type: [34] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "34": {
+          status: "success",
+          value: { name: "Tritanium", category: "inventory_type" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/34"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/type/34");
+    });
+
+    it("groups entity results by their category", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { character: [12345678], corporation: [98000001] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "12345678": {
+          status: "success",
+          value: { name: "Test Character", category: "character" },
+          error: undefined,
+          id: 1,
+        },
+        "98000001": {
+          status: "success",
+          value: { name: "Test Corp", category: "corporation" },
+          error: undefined,
+          id: 2,
+        },
+      });
+      renderSpotlight();
+      expect(screen.getByTestId("group-character")).toBeInTheDocument();
+      expect(screen.getByTestId("group-corporation")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/tests/mainSpotlight.test.tsx
+++ b/apps/web/tests/mainSpotlight.test.tsx
@@ -336,5 +336,83 @@ describe("MainSpotlight", () => {
       expect(screen.getByTestId("group-character")).toBeInTheDocument();
       expect(screen.getByTestId("group-corporation")).toBeInTheDocument();
     });
+
+    it("navigates to the solar system page when a solar_system result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { solar_system: [30000142] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "30000142": {
+          status: "success",
+          value: { name: "Jita", category: "solar_system" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/30000142"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/solar_system/30000142");
+    });
+
+    it("navigates to the station page when a station result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { station: [60003760] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "60003760": {
+          status: "success",
+          value: { name: "Jita IV - Moon 4", category: "station" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/60003760"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/station/60003760");
+    });
+
+    it("navigates to the structure page when a structure result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { structure: [1035466617946] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "1035466617946": {
+          status: "success",
+          value: { name: "Keepstar", category: "structure" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/1035466617946"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/structure/1035466617946");
+    });
+
+    it("navigates to the faction page when a faction result is clicked", () => {
+      mockUseEsiSearch.mockReturnValue({
+        data: { data: { faction: [500001] } },
+      });
+      mockUseEsiNameLookup.mockReturnValue({
+        "500001": {
+          status: "success",
+          value: { name: "Caldari State", category: "faction" },
+          error: undefined,
+          id: 1,
+        },
+      });
+      renderSpotlight();
+      fireEvent.click(screen.getByTestId("action-entity/500001"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/faction/500001");
+    });
+
+    it("does not navigate when app has no url", () => {
+      renderSpotlight();
+      // Skills has a url so click it to verify router is only called when url is set
+      // Here we just verify clicking an app without url does not throw
+      mockUseEsiSearch.mockReturnValue({ data: undefined });
+      fireEvent.click(screen.getByTestId("action-app/Universe/Market"));
+      expect(mockRouterPush).toHaveBeenCalledWith("/market");
+    });
   });
 });
+

--- a/packages/esi-client/src/hooks/useEsiRateLimit.ts
+++ b/packages/esi-client/src/hooks/useEsiRateLimit.ts
@@ -5,9 +5,10 @@ import { useEffect, useState } from "react";
 import { getRateLimitState, subscribeToRateLimitState } from "../rate-limit";
 
 export const useEsiRateLimit = () => {
-  const [state, setState] = useState(() => getRateLimitState());
+  const [state, setState] = useState<ReturnType<typeof getRateLimitState>>({});
 
   useEffect(() => {
+    setState(getRateLimitState());
     return subscribeToRateLimitState((newState) => {
       setState({ ...newState });
     });

--- a/packages/hooks/src/hooks/useEsiName.ts
+++ b/packages/hooks/src/hooks/useEsiName.ts
@@ -227,6 +227,18 @@ export function useEsiNamePrefetch(
   }, [entries]);
 }
 
+function makeCacheUpdater(
+  key: string,
+  value: CacheState<EsiNameCacheValue, Error>,
+) {
+  return (
+    prev: Record<string, CacheState<EsiNameCacheValue, Error> | undefined>,
+  ) => {
+    if (prev[key]?.value === value.value) return prev;
+    return { ...prev, [key]: value };
+  };
+}
+
 export function useEsiNames(
   names: {
     id: number;
@@ -257,10 +269,7 @@ export function useEsiNames(
       ) => {
         if (didUnsubscribe) return;
         if (value === undefined) return;
-        setCurrent((prev) => {
-          if (prev[key]?.value === value.value) return prev;
-          return { ...prev, [key]: value };
-        });
+        setCurrent(makeCacheUpdater(key, value));
       };
       callbacks.set(key, callback);
       fetchCache.subscribe(key, callback);

--- a/packages/hooks/src/hooks/useEsiName.ts
+++ b/packages/hooks/src/hooks/useEsiName.ts
@@ -206,6 +206,13 @@ export function useEsiNamesCache() {
   return fetchCache.readAll();
 }
 
+export function useEsiNameLookup(
+  entries: { id: number; category?: ResolvableEntityCategory }[],
+) {
+  useEsiNamePrefetch(entries);
+  return useEsiNames(entries);
+}
+
 export function useEsiNamePrefetch(
   entries: {
     id: number | string;
@@ -225,62 +232,48 @@ export function useEsiNames(
     id: number;
     category?: ResolvableEntityCategory;
   }[],
-) {
-  const ids = useMemo(() => names.map((name) => name.id), [names]);
-  const keys = useMemo(() => ids.map((id) => id.toString()), [ids]);
-  const [state, setState] = useState<{
-    keys: string[];
-    cache: typeof fetchCache;
-    current: {
-      [key: string]: CacheState<EsiNameCacheValue, Error> | undefined;
-    };
-    //current: Record<string, CacheState<EsiNameCacheValue, Error> | undefined>;
+): { [key: string]: CacheState<EsiNameCacheValue, Error> | undefined } {
+  const keys = useMemo(() => names.map((name) => name.id.toString()), [names]);
+  const [current, setCurrent] = useState<{
+    [key: string]: CacheState<EsiNameCacheValue, Error> | undefined;
   }>(() => {
-    const current: {
+    const initial: {
       [key: string]: CacheState<EsiNameCacheValue, Error> | undefined;
     } = {};
-    keys.forEach((key) => (current[key] = fetchCache.read(key)));
-    return { keys, cache: fetchCache, current };
+    keys.forEach((key) => (initial[key] = fetchCache.read(key)));
+    return initial;
   });
 
   useEffect(() => {
     let didUnsubscribe = false;
-
-    const checkForUpdates = (
-      value: CacheState<EsiNameCacheValue, Error> | undefined,
-    ) => {
-      if (didUnsubscribe) return;
-      if (value === undefined) return;
-      setState((prev) => {
-        // Bails if our key has changed from under us
-        if (!value?.id || !ids.includes(value.id)) return prev;
-        // Bails if our value hasn't changed
-        if (prev.current[value.id]?.value === value.value) return prev;
-        return {
-          ...prev,
-          current: {
-            ...prev.current,
-            [value.id]: value,
-          },
-        };
-      });
-    };
+    const callbacks = new Map<
+      string,
+      (v: CacheState<EsiNameCacheValue, Error> | undefined) => void
+    >();
 
     keys.forEach((key) => {
-      state.cache.subscribe(key, checkForUpdates);
-    });
-
-    keys.forEach((key) => {
-      checkForUpdates(state.cache.read(key));
+      const callback = (
+        value: CacheState<EsiNameCacheValue, Error> | undefined,
+      ) => {
+        if (didUnsubscribe) return;
+        if (value === undefined) return;
+        setCurrent((prev) => {
+          if (prev[key]?.value === value.value) return prev;
+          return { ...prev, [key]: value };
+        });
+      };
+      callbacks.set(key, callback);
+      fetchCache.subscribe(key, callback);
+      callback(fetchCache.read(key));
     });
 
     return () => {
       didUnsubscribe = true;
-      keys.forEach((key) => {
-        state.cache.unsubscribe(key, checkForUpdates);
+      callbacks.forEach((callback, key) => {
+        fetchCache.unsubscribe(key, callback);
       });
     };
-  }, [ids, keys, state.cache]);
+  }, [keys]);
 
-  return state;
+  return current;
 }

--- a/packages/ui/Select/AssetLocationSelect/AssetLocationSelect.tsx
+++ b/packages/ui/Select/AssetLocationSelect/AssetLocationSelect.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { memo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { Select, type SelectProps } from "@mantine/core";
 
-import { useCharacterAssets, useEsiNamesCache } from "@jitaspace/hooks";
+import { useCharacterAssets, useEsiNameLookup } from "@jitaspace/hooks";
 
 
 
@@ -16,8 +16,12 @@ export const AssetLocationSelect = memo(
     const { locations } = useCharacterAssets();
     const [value, onChange] = useState<string | null>();
 
-    const cache = useEsiNamesCache();
-    const getNameFromCache = (id: number) => cache[id]?.value?.name;
+    const locationEntries = useMemo(
+      () => Object.values(locations).map((loc) => ({ id: loc.location_id })),
+      [locations],
+    );
+    const names = useEsiNameLookup(locationEntries);
+    const getNameFromCache = (id: number) => names[id.toString()]?.value?.name;
 
     return (
       <>

--- a/packages/ui/Select/EsiSearchSelect/EsiSearchSelect.tsx
+++ b/packages/ui/Select/EsiSearchSelect/EsiSearchSelect.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import type { SelectProps } from "@mantine/core";
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import { Badge, Group, Loader, rem, Select } from "@mantine/core";
 import { useDebouncedValue } from "@mantine/hooks";
 
 import { type GetCharactersCharacterIdSearchQueryParamsCategoriesEnum } from "@jitaspace/esi-client";
-import { useEsiNamesCache, useEsiSearch } from "@jitaspace/hooks";
+import { useEsiNameLookup, useEsiSearch } from "@jitaspace/hooks";
 
 import { EveEntityAvatar } from "../../Avatar";
 import { EveEntityName } from "../../Text";
@@ -28,8 +28,6 @@ export const EsiSearchSelect = memo(
       debounceTime ?? 1000,
     );
 
-    const names = useEsiNamesCache();
-
     const { data: searchResult, isLoading } = useEsiSearch(
       debouncedSearchValue,
       {
@@ -37,16 +35,30 @@ export const EsiSearchSelect = memo(
       },
     );
 
-    const data = [
-      ...Object.entries(searchResult?.data ?? []).flatMap(
-        ([categoryName, categoryIds]) =>
-          categoryIds.slice(0, 100).map((id) => ({
-            label: names[id]?.value?.name ?? "Unknown",
-            value: `${id}`,
-            category: categoryName,
-          })),
-      ),
-    ];
+    const slicedEntries = useMemo(
+      () =>
+        Object.entries(searchResult?.data ?? {}).flatMap(
+          ([categoryName, ids]) =>
+            ids.slice(0, 100).map((id) => ({ id, categoryName })),
+        ),
+      [searchResult?.data],
+    );
+
+    const entityEntries = useMemo(
+      () => slicedEntries.map(({ id }) => ({ id })),
+      [slicedEntries],
+    );
+    const names = useEsiNameLookup(entityEntries);
+
+    const data = useMemo(
+      () =>
+        slicedEntries.map(({ id, categoryName }) => ({
+          label: names[id.toString()]?.value?.name ?? "Unknown",
+          value: `${id}`,
+          category: categoryName,
+        })),
+      [slicedEntries, names],
+    );
 
     const isLoadingData: boolean =
       isLoading || searchValue !== debouncedSearchValue;

--- a/packages/ui/Select/EveEntitySelect/EveEntitySelect.tsx
+++ b/packages/ui/Select/EveEntitySelect/EveEntitySelect.tsx
@@ -20,7 +20,7 @@ export const EveEntitySelect = memo(
     const entityEntries = useMemo(
       () =>
         entityIds.map(({ id }) => ({
-          id: typeof id === "string" ? parseInt(id, 10) : id,
+          id: typeof id === "string" ? Number.parseInt(id, 10) : id,
         })),
       [entityIds],
     );

--- a/packages/ui/Select/EveEntitySelect/EveEntitySelect.tsx
+++ b/packages/ui/Select/EveEntitySelect/EveEntitySelect.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import type { SelectProps } from "@mantine/core";
-import React, { memo } from "react";
+import React, { memo, useMemo } from "react";
 import { Group, Select, Text } from "@mantine/core";
 
-import { useEsiNamesCache } from "@jitaspace/hooks";
+import { useEsiNameLookup } from "@jitaspace/hooks";
 
 import { EveEntityAvatar } from "../../Avatar";
 
@@ -17,8 +17,15 @@ export type EveEntitySelectProps = Omit<SelectProps, "data"> & {
 
 export const EveEntitySelect = memo(
   ({ entityIds, ...otherProps }: EveEntitySelectProps) => {
-    const cache = useEsiNamesCache();
-    const getNameFromCache = (id: number) => cache[id]?.value?.name;
+    const entityEntries = useMemo(
+      () =>
+        entityIds.map(({ id }) => ({
+          id: typeof id === "string" ? parseInt(id, 10) : id,
+        })),
+      [entityIds],
+    );
+    const names = useEsiNameLookup(entityEntries);
+    const getNameFromCache = (id: number) => names[id.toString()]?.value?.name;
 
     return (
       <Select
@@ -44,4 +51,4 @@ export const EveEntitySelect = memo(
     );
   },
 );
-EveEntitySelect.displayName = "EsiSearchSelect";
+EveEntitySelect.displayName = "EveEntitySelect";


### PR DESCRIPTION
- Rewrite MainSpotlight using Mantine compound Spotlight API to keep SpotlightActionsList always mounted, fixing SyntaxError on Enter with no results; add all app categories (Character, Corporation, Alliance, Universe, Developer) and make results list scrollable
- Add useEsiNameLookup compound hook; fix useEsiNames reactivity bug where per-key CacheState updates were never applied due to comparing an internal numeric id against entity number arrays
- Fix SSR hydration mismatch in useEsiRateLimit by deferring initial state load to useEffect
- Replace useEsiNamesCache (static snapshot) with useEsiNameLookup (reactive) in AssetLocationSelect, EsiSearchSelect, EveEntitySelect, AssetsDataTable, and assets pages
- Fix EveEntitySelect.displayName
- Add MainSpotlight tests covering app rendering, filtering, navigation, and ESI search result handling
- Add changeset

Closes #354 