### PR TITLE
fix(web): return to originating page after EVE SSO login

### DIFF
--- a/.changeset/login-return-to-originating-page.md
+++ b/.changeset/login-return-to-originating-page.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Return the user to the page they were on after EVE Online SSO login, instead of always redirecting to the homepage. `loginWithEveOnline()` now defaults `returnTo` to the current location when a caller doesn't supply one; the existing same-site `sanitizeReturnTo` guard still applies.

--- a/apps/web/lib/eveOnlineLogin.ts
+++ b/apps/web/lib/eveOnlineLogin.ts
@@ -3,10 +3,17 @@
  * endpoint, which generates `state` + PKCE and redirects to the provider.
  *
  * Replaces next-auth's `signIn("eveonline", ..., { scope })`.
+ *
+ * When `returnTo` is omitted, the user is returned to the page they were on
+ * when login was initiated. The server (`sanitizeReturnTo`) validates this is a
+ * same-site relative path before honouring it.
  */
 export function loginWithEveOnline(scopes: string[], returnTo?: string): void {
   const params = new URLSearchParams();
   params.set("scope", [...new Set(scopes)].join(" "));
-  if (returnTo) params.set("returnTo", returnTo);
+  const target =
+    returnTo ??
+    `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (target) params.set("returnTo", target);
   window.location.assign(`/api/auth/login?${params.toString()}`);
 }


### PR DESCRIPTION
## What

When a user authenticates with EVE Online SSO, they are now redirected back to the page they were on when they started login, instead of always landing on the homepage.

## Why

The `returnTo` plumbing already existed end-to-end:

`loginWithEveOnline()` → `/api/auth/login` (seals `returnTo` into the flow cookie) → EVE SSO → `/api/auth/callback/eveonline` (reads it back) → `/login/complete` (`router.replace(returnTo)`)

…with open-redirect guards at both ends (`sanitizeReturnTo` server-side, `safeReturnTo` client-side). The only gap: **no caller ever passed `returnTo`**, so it defaulted to `undefined` → sanitized to `/` → homepage.

## How

`loginWithEveOnline()` now defaults `returnTo` to the current page (`pathname + search + hash`) when not explicitly supplied.

This single-point fix covers every call site at once — the two buttons in `LoginModal.tsx` and the one in `RequestPermissionsBanner.tsx` — without having to thread the value through Mantine's modal `innerProps`. Since the login modal is an overlay that doesn't change the URL, `window.location` at click time is exactly the page the user was viewing. The explicit `returnTo` parameter still works as an override.

## Reviewer notes

- The existing server-side `sanitizeReturnTo` guard still validates the value is a same-site relative path (rejects absolute / `//` URLs), so this introduces no open-redirect surface — the captured `pathname` always begins with a single `/`.
- Verified `tsc --noEmit` is clean for all touched files. The route/callback/complete tests could not be executed in this environment because the worktree has no populated `.env` (the app validates required env vars at config load) — worth a local test run to confirm redirects land correctly for pages carrying query strings or hash fragments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)