### PR TITLE
fix(web): make mail message menu work inside the view modal

### DIFF
--- a/apps/web/components/EveMail/MessagePanel.tsx
+++ b/apps/web/components/EveMail/MessagePanel.tsx
@@ -155,7 +155,11 @@ export function MessagePanel({
               <MessageMenu
                 characterId={characterId}
                 data={data}
-                mail={mail.data}
+                mail={{
+                  mail_id: messageId,
+                  is_read: mail.data.read,
+                  labels: mail.data.labels,
+                }}
               />
             </Group>
           )}


### PR DESCRIPTION
## What

Fixes the message-action menu (assign labels, mark as read/unread, delete) inside the **view-message modal** on the `/mail` page. Previously, every action in that modal failed with *"Message ID is undefined."*

## Why

The same `MessageMenu` is rendered in two places:

- **Mail list rows** (`DesktopMailboxTable`) — pass a mail-list *header* object that includes `mail_id`. ✅ Works.
- **View-message modal** (`MessagePanel`) — passed the response from the single-mail ESI endpoint (`useCharacterMail`). That response shape is different: per [`charactersCharacterIdMailMailIdGetSchema`](packages/esi-client/src/generated/zod/charactersCharacterIdMailMailIdGetSchema.ts) it has **no `mail_id`**, and it exposes `read` rather than `is_read`.

So `mail.mail_id` was `undefined` and every menu action tripped the "Message ID is undefined" guard.

## The fix

At the `MessageMenu` call site in `MessagePanel`, build the `mail` object from the values the menu actually needs — sourcing `mail_id` from the `messageId` prop the modal already receives, and mapping `read` → `is_read`:

```tsx
<MessageMenu
  characterId={characterId}
  data={data}
  mail={{
    mail_id: messageId,
    is_read: mail.data.read,
    labels: mail.data.labels,
  }}
/>
```

This also corrects a secondary bug: the **Mark as Read/Unread** item was reading `is_read` (always `undefined` here), so it always displayed/behaved as "unread."

## Notes for the reviewer

- Single-file change in `apps/web/components/EveMail/MessagePanel.tsx`; the two field name/shape facts are verified against the generated zod schema for the single-mail endpoint.
- Existing `MessagePanel` tests mock `useCharacterMail` and don't open the menu dropdown, so they're unaffected.
- I could not run a clean `pnpm type-check` / `pnpm test` in the worktree because the generated API clients aren't built there (postinstall codegen needs `DATABASE_URL` etc.). Please rely on CI, where codegen runs, for full verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)