### PR TITLE
test(auth-utils): expand coverage for token payload and refresh utils

### DIFF
--- a/packages/auth-utils/tests/getEveSsoAccessTokenPayload.test.ts
+++ b/packages/auth-utils/tests/getEveSsoAccessTokenPayload.test.ts
@@ -1,0 +1,57 @@
+import { getEveSsoAccessTokenPayload } from "../utils/getEveSsoAccessTokenPayload";
+
+function makeJwt(payload: object): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64");
+  return `${header}.${body}.fakesignature`;
+}
+
+const samplePayload = {
+  scp: ["esi-skills.read_skills.v1"],
+  jti: "jti-test-value",
+  kid: "JWT-Signature-Key",
+  sub: "CHARACTER:EVE:12345678",
+  azp: "myclientid",
+  tenant: "tranquility",
+  tier: "live",
+  region: "world",
+  aud: "EVE Online",
+  name: "Test Character",
+  owner: "abc123",
+  exp: 1717000000,
+  iat: 1716996400,
+  iss: "login.eveonline.com",
+};
+
+describe("getEveSsoAccessTokenPayload", () => {
+  it("returns null for undefined", () => {
+    expect(getEveSsoAccessTokenPayload(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(getEveSsoAccessTokenPayload("")).toBeNull();
+  });
+
+  it("returns null for a non-JWT string with no dots", () => {
+    expect(getEveSsoAccessTokenPayload("notavalidtoken")).toBeNull();
+  });
+
+  it("returns null when there is only one segment (one dot, no second segment)", () => {
+    expect(getEveSsoAccessTokenPayload("header.")).toBeNull();
+  });
+
+  it("decodes and returns the payload object for a valid crafted JWT", () => {
+    const token = makeJwt(samplePayload);
+    const result = getEveSsoAccessTokenPayload(token);
+    expect(result).not.toBeNull();
+    expect(result!.sub).toBe("CHARACTER:EVE:12345678");
+    expect(result!.name).toBe("Test Character");
+    expect(result!.tenant).toBe("tranquility");
+    expect(result!.tier).toBe("live");
+    expect(result!.region).toBe("world");
+    expect(result!.iss).toBe("login.eveonline.com");
+    expect(result!.exp).toBe(1717000000);
+    expect(result!.iat).toBe(1716996400);
+    expect(result!.scp).toEqual(["esi-skills.read_skills.v1"]);
+  });
+});

--- a/packages/auth-utils/tests/refreshEveSsoToken.test.ts
+++ b/packages/auth-utils/tests/refreshEveSsoToken.test.ts
@@ -1,0 +1,88 @@
+import {
+  refreshEveSsoToken,
+  REFRESH_TOKEN_ENDPOINT,
+} from "../utils/refreshEveSsoToken";
+
+const params = {
+  eveClientId: "cid",
+  eveClientSecret: "secret",
+  refreshToken: "rt-abc123",
+};
+
+describe("refreshEveSsoToken", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("posts refresh_token grant with Basic auth and returns tokens on success", async () => {
+    const json = jest.fn().mockResolvedValue({
+      access_token: "NEW_AT",
+      refresh_token: "NEW_RT",
+      expires_in: 1199,
+    });
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await refreshEveSsoToken(params);
+
+    expect(result.access_token).toBe("NEW_AT");
+    expect(result.refresh_token).toBe("NEW_RT");
+    expect(result.expires_in).toBe(1199);
+  });
+
+  it("calls fetch with the correct URL, method, body params, and Authorization header", async () => {
+    const json = jest.fn().mockResolvedValue({
+      access_token: "AT",
+      refresh_token: "RT",
+      expires_in: 1199,
+    });
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, json });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await refreshEveSsoToken(params);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe(REFRESH_TOKEN_ENDPOINT);
+    expect(init.method).toBe("POST");
+
+    const body = init.body as URLSearchParams;
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("rt-abc123");
+
+    const headers = init.headers as Record<string, string>;
+    const expectedAuth = `Basic ${Buffer.from("cid:secret").toString("base64")}`;
+    expect(headers.Authorization).toBe(expectedAuth);
+  });
+
+  it("throws 'error refreshing access token' when response is not ok", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+    }) as unknown as typeof fetch;
+
+    await expect(refreshEveSsoToken(params)).rejects.toThrow(
+      "error refreshing access token",
+    );
+  });
+
+  it("calls console.error when the token endpoint responds with a non-OK status", async () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    }) as unknown as typeof fetch;
+
+    await expect(refreshEveSsoToken(params)).rejects.toThrow();
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Error refreshing EVE SSO token" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for getEveSsoAccessTokenPayload (JWT base64 decode + null-safety)
- Add tests for refreshEveSsoToken (fetch mock for success and error paths)

## Test plan
- [ ] `pnpm --filter @jitaspace/auth-utils test` passes
- [ ] null / malformed token inputs return null without throwing
- [ ] Fetch mock verifies POST body and Authorization header
- [ ] Non-OK response causes the expected thrown error