### PR TITLE
test(esi-metadata): add unit tests for ID ranges and scope data

### DIFF
--- a/packages/esi-metadata/jest.config.ts
+++ b/packages/esi-metadata/jest.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "es2022",
+          parser: { syntax: "typescript", tsx: false },
+        },
+        module: { type: "commonjs" },
+      },
+    ],
+  },
+  transformIgnorePatterns: ["/node_modules/(?!(@jitaspace))"],
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+  coverageReporters: ["lcov", "text"],
+  clearMocks: true,
+  restoreMocks: true,
+};
+
+export default config;

--- a/packages/esi-metadata/package.json
+++ b/packages/esi-metadata/package.json
@@ -12,16 +12,22 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "type-check": "tsc --jsx react-jsx --noEmit",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "test": "jest"
   },
   "dependencies": {},
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
     "@jitaspace/eslint-config": "workspace:*",
     "@jitaspace/prettier-config": "workspace:*",
     "@jitaspace/tsconfig": "workspace:*",
+    "@swc/core": "^1.15.40",
+    "@swc/jest": "^0.2.39",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.1.6",
     "eslint": "^9.39.4",
+    "jest": "^30.4.2",
     "prettier": "^3.8.3",
     "typescript": "^5.9.3"
   },

--- a/packages/esi-metadata/tests/id_ranges.test.ts
+++ b/packages/esi-metadata/tests/id_ranges.test.ts
@@ -1,0 +1,344 @@
+import {
+  isIdInRanges,
+  characterIdRanges,
+  corporationIdRanges,
+  allianceIdRanges,
+  regionIdRanges,
+  constellationIdRanges,
+  solarSystemRanges,
+  stargateRanges,
+  stationRanges,
+  npcCharacterIdRanges,
+} from "../src/id_ranges";
+
+describe("isIdInRanges", () => {
+  it("returns true when id is at the lower boundary of a range", () => {
+    expect(isIdInRanges(10, [[10, 20]])).toBe(true);
+  });
+
+  it("returns true when id is at the upper boundary of a range", () => {
+    expect(isIdInRanges(20, [[10, 20]])).toBe(true);
+  });
+
+  it("returns true when id is strictly inside a range", () => {
+    expect(isIdInRanges(15, [[10, 20]])).toBe(true);
+  });
+
+  it("returns false when id is one below the lower boundary", () => {
+    expect(isIdInRanges(9, [[10, 20]])).toBe(false);
+  });
+
+  it("returns false when id is one above the upper boundary", () => {
+    expect(isIdInRanges(21, [[10, 20]])).toBe(false);
+  });
+
+  it("returns false for empty ranges array", () => {
+    expect(isIdInRanges(15, [])).toBe(false);
+  });
+
+  it("returns true when id matches the second of multiple ranges", () => {
+    expect(
+      isIdInRanges(50, [
+        [10, 20],
+        [40, 60],
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when id falls in the gap between two ranges", () => {
+    expect(
+      isIdInRanges(30, [
+        [10, 20],
+        [40, 60],
+      ]),
+    ).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// characterIdRanges
+// -----------------------------------------------------------------------
+describe("characterIdRanges", () => {
+  // range 1: [3000000, 4000000] – NPC characters
+  it("accepts 3000000 (NPC char range min)", () => {
+    expect(isIdInRanges(3000000, characterIdRanges)).toBe(true);
+  });
+
+  it("accepts 4000000 (NPC char range max)", () => {
+    expect(isIdInRanges(4000000, characterIdRanges)).toBe(true);
+  });
+
+  it("accepts 3500000 (mid NPC char range)", () => {
+    expect(isIdInRanges(3500000, characterIdRanges)).toBe(true);
+  });
+
+  it("rejects 2999999 (one below NPC char range)", () => {
+    expect(isIdInRanges(2999999, characterIdRanges)).toBe(false);
+  });
+
+  // range 2: [90000000, 98000000] – player characters
+  it("accepts 90000000 (player char range min)", () => {
+    expect(isIdInRanges(90000000, characterIdRanges)).toBe(true);
+  });
+
+  it("accepts 98000000 (player char range max)", () => {
+    expect(isIdInRanges(98000000, characterIdRanges)).toBe(true);
+  });
+
+  it("accepts 95000000 (mid player char range)", () => {
+    expect(isIdInRanges(95000000, characterIdRanges)).toBe(true);
+  });
+
+  it("rejects 89999999 (one below player char range)", () => {
+    expect(isIdInRanges(89999999, characterIdRanges)).toBe(false);
+  });
+
+  it("rejects 98000001 (one above player char range but below next range)", () => {
+    expect(isIdInRanges(98000001, characterIdRanges)).toBe(false);
+  });
+
+  // range 3: [2100000000, 2147483647] – new-format player characters
+  it("accepts 2100000000 (new player char range min)", () => {
+    expect(isIdInRanges(2100000000, characterIdRanges)).toBe(true);
+  });
+
+  it("accepts 2147483647 (new player char range max)", () => {
+    expect(isIdInRanges(2147483647, characterIdRanges)).toBe(true);
+  });
+
+  it("rejects 2099999999 (one below new player char range)", () => {
+    expect(isIdInRanges(2099999999, characterIdRanges)).toBe(false);
+  });
+
+  it("rejects 2147483648 (one above new player char range)", () => {
+    expect(isIdInRanges(2147483648, characterIdRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// npcCharacterIdRanges
+// -----------------------------------------------------------------------
+describe("npcCharacterIdRanges", () => {
+  it("accepts an NPC character ID (3000001)", () => {
+    expect(isIdInRanges(3000001, npcCharacterIdRanges)).toBe(true);
+  });
+
+  it("accepts 3000000 (NPC char range min)", () => {
+    expect(isIdInRanges(3000000, npcCharacterIdRanges)).toBe(true);
+  });
+
+  it("accepts 4000000 (NPC char range max)", () => {
+    expect(isIdInRanges(4000000, npcCharacterIdRanges)).toBe(true);
+  });
+
+  it("rejects a player character ID (95000000)", () => {
+    expect(isIdInRanges(95000000, npcCharacterIdRanges)).toBe(false);
+  });
+
+  it("rejects 2999999 (one below NPC range min)", () => {
+    expect(isIdInRanges(2999999, npcCharacterIdRanges)).toBe(false);
+  });
+
+  it("rejects 4000001 (one above NPC range max)", () => {
+    expect(isIdInRanges(4000001, npcCharacterIdRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// corporationIdRanges
+// -----------------------------------------------------------------------
+describe("corporationIdRanges", () => {
+  // range 1: [1000000, 2000000]
+  it("accepts 1000000 (corp range 1 min)", () => {
+    expect(isIdInRanges(1000000, corporationIdRanges)).toBe(true);
+  });
+
+  it("accepts 2000000 (corp range 1 max)", () => {
+    expect(isIdInRanges(2000000, corporationIdRanges)).toBe(true);
+  });
+
+  it("accepts 1500000 (mid corp range 1)", () => {
+    expect(isIdInRanges(1500000, corporationIdRanges)).toBe(true);
+  });
+
+  it("rejects 999999 (one below corp range 1 min)", () => {
+    expect(isIdInRanges(999999, corporationIdRanges)).toBe(false);
+  });
+
+  it("rejects 2000001 (one above corp range 1 max, before range 2)", () => {
+    expect(isIdInRanges(2000001, corporationIdRanges)).toBe(false);
+  });
+
+  // range 2: [98000000, 99000000]
+  it("accepts 98000000 (corp range 2 min)", () => {
+    expect(isIdInRanges(98000000, corporationIdRanges)).toBe(true);
+  });
+
+  it("accepts 99000000 (corp range 2 max)", () => {
+    expect(isIdInRanges(99000000, corporationIdRanges)).toBe(true);
+  });
+
+  it("rejects 97999999 (one below corp range 2 min)", () => {
+    expect(isIdInRanges(97999999, corporationIdRanges)).toBe(false);
+  });
+
+  it("rejects 99000001 (one above corp range 2 max)", () => {
+    expect(isIdInRanges(99000001, corporationIdRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// allianceIdRanges
+// -----------------------------------------------------------------------
+describe("allianceIdRanges", () => {
+  // range: [99000000, 100000000]
+  it("accepts 99000000 (alliance range min)", () => {
+    expect(isIdInRanges(99000000, allianceIdRanges)).toBe(true);
+  });
+
+  it("accepts 100000000 (alliance range max)", () => {
+    expect(isIdInRanges(100000000, allianceIdRanges)).toBe(true);
+  });
+
+  it("accepts 99500000 (mid alliance range)", () => {
+    expect(isIdInRanges(99500000, allianceIdRanges)).toBe(true);
+  });
+
+  it("rejects 98999999 (one below alliance range min)", () => {
+    expect(isIdInRanges(98999999, allianceIdRanges)).toBe(false);
+  });
+
+  it("rejects 100000001 (one above alliance range max)", () => {
+    expect(isIdInRanges(100000001, allianceIdRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// regionIdRanges
+// -----------------------------------------------------------------------
+describe("regionIdRanges", () => {
+  // range: [10000000, 13000000]
+  it("accepts 10000000 (region range min)", () => {
+    expect(isIdInRanges(10000000, regionIdRanges)).toBe(true);
+  });
+
+  it("accepts 13000000 (region range max)", () => {
+    expect(isIdInRanges(13000000, regionIdRanges)).toBe(true);
+  });
+
+  it("accepts 10000002 (The Forge – known region ID)", () => {
+    expect(isIdInRanges(10000002, regionIdRanges)).toBe(true);
+  });
+
+  it("rejects 9999999 (one below region range min)", () => {
+    expect(isIdInRanges(9999999, regionIdRanges)).toBe(false);
+  });
+
+  it("rejects 13000001 (one above region range max)", () => {
+    expect(isIdInRanges(13000001, regionIdRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// constellationIdRanges
+// -----------------------------------------------------------------------
+describe("constellationIdRanges", () => {
+  // range: [20000000, 23000000]
+  it("accepts 20000000 (constellation range min)", () => {
+    expect(isIdInRanges(20000000, constellationIdRanges)).toBe(true);
+  });
+
+  it("accepts 23000000 (constellation range max)", () => {
+    expect(isIdInRanges(23000000, constellationIdRanges)).toBe(true);
+  });
+
+  it("accepts 20000068 (Kimotoro – known constellation ID)", () => {
+    expect(isIdInRanges(20000068, constellationIdRanges)).toBe(true);
+  });
+
+  it("rejects 19999999 (one below constellation range min)", () => {
+    expect(isIdInRanges(19999999, constellationIdRanges)).toBe(false);
+  });
+
+  it("rejects 23000001 (one above constellation range max)", () => {
+    expect(isIdInRanges(23000001, constellationIdRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// solarSystemRanges
+// -----------------------------------------------------------------------
+describe("solarSystemRanges", () => {
+  // range: [30000000, 33000000]
+  it("accepts 30000000 (solar system range min)", () => {
+    expect(isIdInRanges(30000000, solarSystemRanges)).toBe(true);
+  });
+
+  it("accepts 33000000 (solar system range max)", () => {
+    expect(isIdInRanges(33000000, solarSystemRanges)).toBe(true);
+  });
+
+  it("accepts 30000142 (Jita – known solar system ID)", () => {
+    expect(isIdInRanges(30000142, solarSystemRanges)).toBe(true);
+  });
+
+  it("rejects 29999999 (one below solar system range min)", () => {
+    expect(isIdInRanges(29999999, solarSystemRanges)).toBe(false);
+  });
+
+  it("rejects 33000001 (one above solar system range max)", () => {
+    expect(isIdInRanges(33000001, solarSystemRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// stargateRanges
+// -----------------------------------------------------------------------
+describe("stargateRanges", () => {
+  // range: [50000000, 60000000]
+  it("accepts 50000000 (stargate range min)", () => {
+    expect(isIdInRanges(50000000, stargateRanges)).toBe(true);
+  });
+
+  it("accepts 60000000 (stargate range max)", () => {
+    expect(isIdInRanges(60000000, stargateRanges)).toBe(true);
+  });
+
+  it("accepts 50000056 (a known stargate ID in Jita)", () => {
+    expect(isIdInRanges(50000056, stargateRanges)).toBe(true);
+  });
+
+  it("rejects 49999999 (one below stargate range min)", () => {
+    expect(isIdInRanges(49999999, stargateRanges)).toBe(false);
+  });
+
+  it("rejects 60000001 (one above stargate range max)", () => {
+    expect(isIdInRanges(60000001, stargateRanges)).toBe(false);
+  });
+});
+
+// -----------------------------------------------------------------------
+// stationRanges
+// -----------------------------------------------------------------------
+describe("stationRanges", () => {
+  // range: [60000000, 70000000]
+  it("accepts 60000000 (station range min)", () => {
+    expect(isIdInRanges(60000000, stationRanges)).toBe(true);
+  });
+
+  it("accepts 70000000 (station range max)", () => {
+    expect(isIdInRanges(70000000, stationRanges)).toBe(true);
+  });
+
+  it("accepts 60004588 (Jita 4-4 – known station ID)", () => {
+    expect(isIdInRanges(60004588, stationRanges)).toBe(true);
+  });
+
+  it("rejects 59999999 (one below station range min)", () => {
+    expect(isIdInRanges(59999999, stationRanges)).toBe(false);
+  });
+
+  it("rejects 70000001 (one above station range max)", () => {
+    expect(isIdInRanges(70000001, stationRanges)).toBe(false);
+  });
+});

--- a/packages/esi-metadata/tests/scopes.test.ts
+++ b/packages/esi-metadata/tests/scopes.test.ts
@@ -1,0 +1,78 @@
+import { scopes, scopeDescriptions } from "../src/scopes";
+
+const SCOPE_PATTERN = /^esi-[a-z_]+\.[a-z_]+\.v\d+$/;
+
+describe("scopes array", () => {
+  it("is non-empty", () => {
+    expect(scopes.length).toBeGreaterThan(0);
+  });
+
+  it("has no duplicate entries", () => {
+    const unique = new Set(scopes);
+    expect(unique.size).toBe(scopes.length);
+  });
+
+  it("every scope matches the pattern esi-{domain}.{action}.v{N}", () => {
+    for (const scope of scopes) {
+      expect(scope).toMatch(SCOPE_PATTERN);
+    }
+  });
+});
+
+describe("scopeDescriptions", () => {
+  it("has an entry for every scope in the scopes array", () => {
+    for (const scope of scopes) {
+      // Use `in` operator because toHaveProperty treats dots as path separators
+      expect(scope in scopeDescriptions).toBe(true);
+    }
+  });
+
+  it("all description values are non-empty strings", () => {
+    for (const [key, value] of Object.entries(scopeDescriptions)) {
+      expect(typeof value).toBe("string");
+      expect((value as string).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every key in scopeDescriptions is a valid scope", () => {
+    const scopeSet = new Set<string>(scopes);
+    for (const key of Object.keys(scopeDescriptions)) {
+      expect(scopeSet.has(key)).toBe(true);
+    }
+  });
+
+  it("has at least as many entries as the scopes array", () => {
+    expect(Object.keys(scopeDescriptions).length).toBeGreaterThanOrEqual(
+      scopes.length,
+    );
+  });
+
+  it("covers all scopes (100% description coverage)", () => {
+    const missingScopes = scopes.filter(
+      (scope) => !(scope in scopeDescriptions),
+    );
+    expect(missingScopes).toEqual([]);
+  });
+
+  it("contains a known scope description spot-check (esi-wallet.read_character_wallet.v1)", () => {
+    expect(scopeDescriptions["esi-wallet.read_character_wallet.v1"]).toContain(
+      "wallet",
+    );
+  });
+
+  it("contains a known scope description spot-check (esi-location.read_location.v1)", () => {
+    expect(scopeDescriptions["esi-location.read_location.v1"]).toContain(
+      "location",
+    );
+  });
+
+  it("contains a known scope description spot-check (esi-skills.read_skills.v1)", () => {
+    expect(scopeDescriptions["esi-skills.read_skills.v1"]).toContain("skills");
+  });
+
+  it("all description keys match the ESI scope naming pattern", () => {
+    for (const key of Object.keys(scopeDescriptions)) {
+      expect(key).toMatch(SCOPE_PATTERN);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
     dependencies:
       '@c15t/nextjs':
         specifier: ^1.8.6
-        version: 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
+        version: 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
       '@c15t/scripts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -228,13 +228,13 @@ importers:
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(@tiptap/extension-link@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))(@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@react-hook/cache':
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.6)
       '@sentry/nextjs':
         specifier: ^10.53.1
-        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
+        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
       '@tabler/icons-react':
         specifier: ^3.44.0
         version: 3.44.0(react@19.2.6)
@@ -246,7 +246,7 @@ importers:
         version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query-next-experimental':
         specifier: ^5.100.14
-        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@tiptap/extension-link':
         specifier: ^2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
@@ -258,19 +258,19 @@ importers:
         version: 2.27.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       botid:
         specifier: ^1.5.11
-        version: 1.5.11(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.5.11(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       date-fns:
         specifier: ^4.3.0
         version: 4.3.0
@@ -294,16 +294,16 @@ importers:
         version: 2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(dayjs@1.11.20)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(@tabler/icons-react@3.44.0(react@19.2.6))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-seo:
         specifier: ^6.8.0
-        version: 6.8.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nextjs-cors:
         specifier: ^2.2.1
-        version: 2.2.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 2.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       nextjs-routes:
         specifier: ^2.2.5
-        version: 2.2.5(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 2.2.5(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ngraph.graph:
         specifier: ^20.1.2
         version: 20.1.2
@@ -436,7 +436,7 @@ importers:
         version: link:../esi-metadata
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -485,7 +485,7 @@ importers:
         version: link:../esi-metadata
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -697,6 +697,9 @@ importers:
 
   packages/esi-metadata:
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1
       '@jitaspace/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -706,6 +709,15 @@ importers:
       '@jitaspace/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@swc/core':
+        specifier: ^1.15.40
+        version: 1.15.40
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.40)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -715,6 +727,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3))
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2950,10 +2965,6 @@ packages:
     resolution: {integrity: sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/diff-sequences@30.0.1':
-    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/diff-sequences@30.4.0':
     resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2970,10 +2981,6 @@ packages:
 
   '@jest/environment@30.4.1':
     resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect-utils@30.2.0':
-    resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@30.4.1':
@@ -3039,10 +3046,6 @@ packages:
 
   '@jest/transform@30.4.1':
     resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.2.0':
-    resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@30.3.0':
@@ -7643,10 +7646,6 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
-  expect@30.2.0:
-    resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8618,10 +8617,6 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.2.0:
-    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-diff@30.4.1:
     resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8655,24 +8650,12 @@ packages:
     resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.2.0:
-    resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-matcher-utils@30.4.1:
     resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.2.0:
-    resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-message-util@30.4.1:
     resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.2.0:
-    resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-mock@30.4.1:
@@ -8714,10 +8697,6 @@ packages:
 
   jest-snapshot@30.4.1:
     resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-util@30.2.0:
-    resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@30.4.1:
@@ -9939,10 +9918,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-format@30.2.0:
-    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   pretty-format@30.4.1:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
@@ -11987,11 +11962,11 @@ snapshots:
       neverthrow: 8.2.0
       picocolors: 1.1.1
 
-  '@c15t/nextjs@1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)':
+  '@c15t/nextjs@1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)':
     dependencies:
       '@c15t/react': 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
       '@c15t/translations': 1.8.5
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -13127,8 +13102,6 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
 
-  '@jest/diff-sequences@30.0.1': {}
-
   '@jest/diff-sequences@30.4.0': {}
 
   '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
@@ -13148,10 +13121,6 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 24.12.4
       jest-mock: 30.4.1
-
-  '@jest/expect-utils@30.2.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
 
   '@jest/expect-utils@30.4.1':
     dependencies:
@@ -13275,16 +13244,6 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/types@30.2.0':
-    dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.4
-      '@types/yargs': 17.0.35
-      chalk: 4.1.2
 
   '@jest/types@30.3.0':
     dependencies:
@@ -13717,9 +13676,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       third-party-capital: 1.0.20
 
@@ -15482,7 +15441,7 @@ snapshots:
       marked: 4.3.0
       mustache: 4.2.0
 
-  '@redis/bloom@5.12.1(@redis/client@5.12.1)':
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
@@ -15492,15 +15451,15 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@redis/json@5.12.1(@redis/client@5.12.1)':
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/search@5.12.1(@redis/client@5.12.1)':
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/time-series@5.12.1(@redis/client@5.12.1)':
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
@@ -15742,7 +15701,7 @@ snapshots:
 
   '@sentry/core@10.53.1': {}
 
-  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))':
+  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -15755,7 +15714,7 @@ snapshots:
       '@sentry/react': 10.53.1(react@19.2.6)
       '@sentry/vercel-edge': 10.53.1
       '@sentry/webpack-plugin': 5.3.0(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rollup: 4.60.4
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -16015,10 +15974,10 @@ snapshots:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query-next-experimental@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-next-experimental@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@tanstack/react-query@5.100.14(react@19.2.6)':
@@ -16422,8 +16381,8 @@ snapshots:
 
   '@types/jest@30.0.0':
     dependencies:
-      expect: 30.2.0
-      pretty-format: 30.2.0
+      expect: 30.4.1
+      pretty-format: 30.4.1
 
   '@types/js-yaml@4.0.9': {}
 
@@ -16709,9 +16668,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/og@0.11.1':
@@ -16721,9 +16680,9 @@ snapshots:
     optionalDependencies:
       sharp: 0.34.5
 
-  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
@@ -17189,9 +17148,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  botid@1.5.11(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  botid@1.5.11(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   brace-expansion@1.1.11:
@@ -18661,15 +18620,6 @@ snapshots:
 
   exit-x@0.2.2: {}
 
-  expect@30.2.0:
-    dependencies:
-      '@jest/expect-utils': 30.2.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.2.0
-      jest-message-util: 30.2.0
-      jest-mock: 30.2.0
-      jest-util: 30.2.0
-
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -19022,7 +18972,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -19328,7 +19278,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       hono: 4.12.23
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19749,13 +19699,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.2.0:
-    dependencies:
-      '@jest/diff-sequences': 30.0.1
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.2.0
-
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -19815,31 +19758,12 @@ snapshots:
       '@jest/get-type': 30.1.0
       pretty-format: 30.4.1
 
-  jest-matcher-utils@30.2.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.2.0
-      pretty-format: 30.2.0
-
   jest-matcher-utils@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
       jest-diff: 30.4.1
       pretty-format: 30.4.1
-
-  jest-message-util@30.2.0:
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@jest/types': 30.2.0
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
 
   jest-message-util@30.4.1:
     dependencies:
@@ -19853,12 +19777,6 @@ snapshots:
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
-
-  jest-mock@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.12.4
-      jest-util: 30.2.0
 
   jest-mock@30.4.1:
     dependencies:
@@ -19971,15 +19889,6 @@ snapshots:
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
-
-  jest-util@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.12.4
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      graceful-fs: 4.2.11
-      picomatch: 4.0.3
 
   jest-util@30.4.1:
     dependencies:
@@ -20869,15 +20778,15 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.54.0
 
-  next-seo@6.8.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -20886,7 +20795,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.27.4)(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -20902,15 +20811,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-cors@2.2.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  nextjs-cors@2.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       cors: 2.8.5
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  nextjs-routes@2.2.5(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  nextjs-routes@2.2.5(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       chokidar: 4.0.1
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   ngraph.events@1.4.0: {}
 
@@ -21251,7 +21160,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -21422,12 +21331,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty-format@30.2.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
 
   pretty-format@30.4.1:
     dependencies:
@@ -21824,11 +21727,11 @@ snapshots:
 
   redis@5.12.1(@opentelemetry/api@1.9.1):
     dependencies:
-      '@redis/bloom': 5.12.1(@redis/client@5.12.1)
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-      '@redis/json': 5.12.1(@redis/client@5.12.1)
-      '@redis/search': 5.12.1(@redis/client@5.12.1)
-      '@redis/time-series': 5.12.1(@redis/client@5.12.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
@@ -22488,12 +22391,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.27.4)(react@19.2.6):
+  styled-jsx@5.1.6(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
-    optionalDependencies:
-      '@babel/core': 7.27.4
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Wire up Jest in the esi-metadata package (no tests existed before)
- Test isIdInRanges with boundary values across all entity ID range types
- Validate scope list integrity: no duplicates, correct naming pattern, description coverage

## Test plan
- [ ] `pnpm --filter @jitaspace/esi-metadata test` passes
- [ ] Boundary tests for all range types
- [ ] Scope data integrity assertions