### PR TITLE
test(eve-scrape): add unit tests for utility functions

### DIFF
--- a/packages/eve-scrape/tests/utils/compareSets.test.ts
+++ b/packages/eve-scrape/tests/utils/compareSets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 
 jest.mock("inngest", () => ({
   NonRetriableError: class NonRetriableError extends Error {

--- a/packages/eve-scrape/tests/utils/compareSets.test.ts
+++ b/packages/eve-scrape/tests/utils/compareSets.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "@jest/globals";
+
+jest.mock("inngest", () => ({
+  NonRetriableError: class NonRetriableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "NonRetriableError";
+    }
+  },
+}));
+jest.mock("../../env", () => ({ env: { NODE_ENV: "test" } }));
+
+import { compareSets } from "../../utils/compareSets";
+
+type Item = { id: number; name: string };
+
+const getId = (item: Item) => item.id;
+const isEqual = (a: Item, b: Item) => a.name === b.name;
+
+describe("compareSets", () => {
+  it("correctly classifies all records as equal when before === after", () => {
+    const records: Item[] = [
+      { id: 1, name: "alpha" },
+      { id: 2, name: "beta" },
+    ];
+    const result = compareSets({
+      recordsBefore: records,
+      recordsAfter: records,
+      getId,
+      recordsAreEqual: isEqual,
+    });
+    expect(result.equal).toHaveLength(2);
+    expect(result.created).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+    expect(result.modified).toHaveLength(0);
+  });
+
+  it("detects newly created records (in after but not in before)", () => {
+    const before: Item[] = [{ id: 1, name: "alpha" }];
+    const after: Item[] = [
+      { id: 1, name: "alpha" },
+      { id: 2, name: "beta" },
+    ];
+    const result = compareSets({
+      recordsBefore: before,
+      recordsAfter: after,
+      getId,
+      recordsAreEqual: isEqual,
+    });
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]).toEqual({ id: 2, name: "beta" });
+    expect(result.equal).toHaveLength(1);
+    expect(result.deleted).toHaveLength(0);
+    expect(result.modified).toHaveLength(0);
+  });
+
+  it("detects deleted records (in before but not in after)", () => {
+    const before: Item[] = [
+      { id: 1, name: "alpha" },
+      { id: 2, name: "beta" },
+    ];
+    const after: Item[] = [{ id: 1, name: "alpha" }];
+    const result = compareSets({
+      recordsBefore: before,
+      recordsAfter: after,
+      getId,
+      recordsAreEqual: isEqual,
+    });
+    expect(result.deleted).toHaveLength(1);
+    expect(result.deleted[0]).toEqual({ id: 2, name: "beta" });
+    expect(result.equal).toHaveLength(1);
+    expect(result.created).toHaveLength(0);
+    expect(result.modified).toHaveLength(0);
+  });
+
+  it("detects modified records (same ID but different field value)", () => {
+    const before: Item[] = [{ id: 1, name: "alpha" }];
+    const after: Item[] = [{ id: 1, name: "alpha-modified" }];
+    const result = compareSets({
+      recordsBefore: before,
+      recordsAfter: after,
+      getId,
+      recordsAreEqual: isEqual,
+    });
+    expect(result.modified).toHaveLength(1);
+    expect(result.modified[0]).toEqual({ id: 1, name: "alpha-modified" });
+    expect(result.equal).toHaveLength(0);
+    expect(result.created).toHaveLength(0);
+    expect(result.deleted).toHaveLength(0);
+  });
+
+  it("handles mixed: some created, deleted, equal, modified in a single call", () => {
+    const before: Item[] = [
+      { id: 1, name: "unchanged" },
+      { id: 2, name: "will-change" },
+      { id: 3, name: "will-delete" },
+    ];
+    const after: Item[] = [
+      { id: 1, name: "unchanged" },
+      { id: 2, name: "changed" },
+      { id: 4, name: "new-record" },
+    ];
+    const result = compareSets({
+      recordsBefore: before,
+      recordsAfter: after,
+      getId,
+      recordsAreEqual: isEqual,
+    });
+    expect(result.equal).toHaveLength(1);
+    expect(result.equal[0]).toEqual({ id: 1, name: "unchanged" });
+    expect(result.modified).toHaveLength(1);
+    expect(result.modified[0]).toEqual({ id: 2, name: "changed" });
+    expect(result.deleted).toHaveLength(1);
+    expect(result.deleted[0]).toEqual({ id: 3, name: "will-delete" });
+    expect(result.created).toHaveLength(1);
+    expect(result.created[0]).toEqual({ id: 4, name: "new-record" });
+  });
+
+  it("throws NonRetriableError when count sanity check fails", () => {
+    // Duplicate IDs in recordsBefore make the deleted array double-count:
+    // both records with id=1 pass the "not in keysAfter" filter, producing
+    // deleted.length=2, while the unique union of IDs is 2 (ids 1 and 2),
+    // so numOutputs (3) !== numInputs (2) and the sanity check fires.
+    const before: Item[] = [
+      { id: 1, name: "a" },
+      { id: 1, name: "a-dup" }, // duplicate id
+    ];
+    const after: Item[] = [{ id: 2, name: "b" }];
+    expect(() =>
+      compareSets({
+        recordsBefore: before,
+        recordsAfter: after,
+        getId,
+        recordsAreEqual: isEqual,
+      }),
+    ).toThrow("compareSets: input and output length do not match");
+  });
+});

--- a/packages/eve-scrape/tests/utils/excludeObjectKeys.test.ts
+++ b/packages/eve-scrape/tests/utils/excludeObjectKeys.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { excludeObjectKeys } from "../../utils/excludeObjectKeys";
+
+describe("excludeObjectKeys", () => {
+  it("removes the specified keys and returns the rest", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = excludeObjectKeys(obj, ["b"]);
+    expect(result).toEqual({ a: 1, c: 3 });
+    expect(result).not.toHaveProperty("b");
+  });
+
+  it("handles an empty keys array (returns full object)", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = excludeObjectKeys(obj, []);
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("handles all keys being removed (returns empty object)", () => {
+    const obj = { a: 1, b: 2 };
+    const result = excludeObjectKeys(obj, ["a", "b"]);
+    expect(result).toEqual({});
+  });
+
+  it("does not mutate the original object", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const original = { ...obj };
+    excludeObjectKeys(obj, ["b"]);
+    expect(obj).toEqual(original);
+  });
+});

--- a/packages/eve-scrape/tests/utils/recordsAreEqual.test.ts
+++ b/packages/eve-scrape/tests/utils/recordsAreEqual.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "@jest/globals";
+import Decimal from "decimal.js";
+
+import { recordsAreEqual } from "../../utils/recordsAreEqual";
+
+describe("recordsAreEqual", () => {
+  it("returns true for identical flat objects", () => {
+    const a = { id: 1, name: "foo", count: 42 };
+    const b = { id: 1, name: "foo", count: 42 };
+    expect(recordsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when a primitive field differs", () => {
+    const a = { id: 1, name: "foo" };
+    const b = { id: 1, name: "bar" };
+    expect(recordsAreEqual(a, b)).toBe(false);
+  });
+
+  it("handles null values: both null -> true", () => {
+    const a = { id: 1, value: null };
+    const b = { id: 1, value: null };
+    expect(recordsAreEqual(a, b)).toBe(true);
+  });
+
+  it("handles null values: one null -> false", () => {
+    const a = { id: 1, value: null };
+    const b = { id: 1, value: "something" };
+    expect(recordsAreEqual(a, b)).toBe(false);
+  });
+
+  it("handles nested objects recursively", () => {
+    const a = { id: 1, meta: { level: 2, tag: "x" } };
+    const b = { id: 1, meta: { level: 2, tag: "x" } };
+    expect(recordsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false for different nested objects", () => {
+    const a = { id: 1, meta: { level: 2 } };
+    const b = { id: 1, meta: { level: 3 } };
+    expect(recordsAreEqual(a, b)).toBe(false);
+  });
+
+  it("respects the ignoreKeys option (ignores the listed key even if it differs)", () => {
+    const a = { id: 1, updatedAt: new Date("2020-01-01"), name: "foo" };
+    const b = { id: 1, updatedAt: new Date("2023-12-31"), name: "foo" };
+    expect(recordsAreEqual(a, b, { ignoreKeys: ["updatedAt"] })).toBe(true);
+  });
+
+  it("Compares Decimal.js values correctly: equal amounts -> true", () => {
+    const a = { price: new Decimal("1.23456789") };
+    const b = { price: new Decimal("1.23456789") };
+    expect(recordsAreEqual(a, b)).toBe(true);
+  });
+
+  it("Compares Decimal.js values correctly: different amounts -> false", () => {
+    const a = { price: new Decimal("1.23") };
+    const b = { price: new Decimal("4.56") };
+    expect(recordsAreEqual(a, b)).toBe(false);
+  });
+
+  it("handles float comparisons via string representation", () => {
+    const a = { ratio: 0.1 + 0.2 };
+    const b = { ratio: 0.1 + 0.2 };
+    expect(recordsAreEqual(a, b)).toBe(true);
+  });
+
+  it("returns false for floats with different string representations", () => {
+    const a = { ratio: 1.1 };
+    const b = { ratio: 1.2 };
+    expect(recordsAreEqual(a, b)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add tests for excludeObjectKeys (key filtering utility)
- Add tests for recordsAreEqual (deep comparison with Decimal.js and null support)
- Add tests for compareSets (created/deleted/equal/modified classification)

## Test plan
- [ ] `pnpm --filter @jitaspace/eve-scrape test` passes (all tests, including existing registry test)
- [ ] inngest and env are mocked to avoid IO at import time
- [ ] Decimal.js equality tested
- [ ] compareSets sanity-check error path tested