### PR TITLE
test(eve-data): add data structure validation tests

### DIFF
--- a/packages/eve-data/jest.config.ts
+++ b/packages/eve-data/jest.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "es2022",
+          parser: { syntax: "typescript", tsx: false },
+        },
+        module: { type: "commonjs" },
+      },
+    ],
+  },
+  transformIgnorePatterns: ["/node_modules/(?!(@jitaspace))"],
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+  coverageReporters: ["lcov", "text"],
+  clearMocks: true,
+  restoreMocks: true,
+};
+
+export default config;

--- a/packages/eve-data/package.json
+++ b/packages/eve-data/package.json
@@ -16,16 +16,22 @@
     "clean": "rm -rf .turbo node_modules dist",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
+    "test": "jest",
     "type-check": "tsc --jsx react-jsx --noEmit",
     "prepublish": "pnpm build"
   },
   "dependencies": {},
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
     "@jitaspace/eslint-config": "workspace:*",
     "@jitaspace/prettier-config": "workspace:*",
     "@jitaspace/tsconfig": "workspace:*",
+    "@swc/core": "^1.15.40",
+    "@swc/jest": "^0.2.39",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.12.4",
     "eslint": "^9.39.4",
+    "jest": "^30.4.2",
     "prettier": "^3.8.3",
     "typescript": "^5.9.3",
     "tsup": "^8.5.1"

--- a/packages/eve-data/tests/incursions.test.ts
+++ b/packages/eve-data/tests/incursions.test.ts
@@ -180,7 +180,7 @@ describe("incursion_constellations", () => {
 
   describe("known constellation regression tests", () => {
     it("Algintal has the expected solar systems", () => {
-      const c = incursion_constellations["Algintal"];
+      const c = incursion_constellations["Algintal"]!;
       expect(c).toBeDefined();
       expect(c.Staging).toBe("Barmalie");
       expect(c.Vanguards).toEqual(
@@ -195,7 +195,7 @@ describe("incursion_constellations", () => {
     });
 
     it("Ihilakken has the expected solar systems", () => {
-      const c = incursion_constellations["Ihilakken"];
+      const c = incursion_constellations["Ihilakken"]!;
       expect(c).toBeDefined();
       expect(c.Staging).toBe("Sakenta");
       expect(c.Vanguards).toEqual(
@@ -210,7 +210,7 @@ describe("incursion_constellations", () => {
     });
 
     it("Sanctum has the expected solar systems", () => {
-      const c = incursion_constellations["Sanctum"];
+      const c = incursion_constellations["Sanctum"]!;
       expect(c).toBeDefined();
       expect(c.Staging).toBe("Yulai");
       expect(c.Vanguards).toEqual(
@@ -225,7 +225,7 @@ describe("incursion_constellations", () => {
     });
 
     it("stub entry Ananah has Staging but empty Headquarters", () => {
-      const c = incursion_constellations["Ananah"];
+      const c = incursion_constellations["Ananah"]!;
       expect(c).toBeDefined();
       expect(c.Staging).toBe("Mifrata");
       expect(c.Headquarters).toBe("");

--- a/packages/eve-data/tests/incursions.test.ts
+++ b/packages/eve-data/tests/incursions.test.ts
@@ -17,56 +17,42 @@ describe("incursion_constellations", () => {
 
     it("has all 4 required keys on every entry", () => {
       const required = ["Staging", "Vanguards", "Assaults", "Headquarters"] as const;
-      for (const [name, entry] of Object.entries(incursion_constellations)) {
+      for (const [, entry] of Object.entries(incursion_constellations)) {
         for (const key of required) {
-          if (!Object.prototype.hasOwnProperty.call(entry, key)) {
-            throw new Error(`${name}: missing required key "${key}"`);
-          }
+          expect(Object.prototype.hasOwnProperty.call(entry, key)).toBe(true);
         }
       }
     });
 
     it("has no empty constellation names as keys", () => {
       for (const name of Object.keys(incursion_constellations)) {
-        if (name.trim().length === 0) {
-          throw new Error(`found an empty constellation name in keys`);
-        }
+        expect(name.trim().length).toBeGreaterThan(0);
       }
     });
   });
 
   describe("field types (all entries)", () => {
     it("Staging is always a string", () => {
-      for (const [name, entry] of Object.entries(incursion_constellations)) {
-        if (typeof entry.Staging !== "string") {
-          throw new Error(`${name}: Staging should be string, got ${typeof entry.Staging}`);
-        }
+      for (const [, entry] of Object.entries(incursion_constellations)) {
+        expect(typeof entry.Staging).toBe("string");
       }
     });
 
     it("Headquarters is always a string", () => {
-      for (const [name, entry] of Object.entries(incursion_constellations)) {
-        if (typeof entry.Headquarters !== "string") {
-          throw new Error(
-            `${name}: Headquarters should be string, got ${typeof entry.Headquarters}`,
-          );
-        }
+      for (const [, entry] of Object.entries(incursion_constellations)) {
+        expect(typeof entry.Headquarters).toBe("string");
       }
     });
 
     it("Vanguards is always an array", () => {
-      for (const [name, entry] of Object.entries(incursion_constellations)) {
-        if (!Array.isArray(entry.Vanguards)) {
-          throw new Error(`${name}: Vanguards should be array`);
-        }
+      for (const [, entry] of Object.entries(incursion_constellations)) {
+        expect(Array.isArray(entry.Vanguards)).toBe(true);
       }
     });
 
     it("Assaults is always an array", () => {
-      for (const [name, entry] of Object.entries(incursion_constellations)) {
-        if (!Array.isArray(entry.Assaults)) {
-          throw new Error(`${name}: Assaults should be array`);
-        }
+      for (const [, entry] of Object.entries(incursion_constellations)) {
+        expect(Array.isArray(entry.Assaults)).toBe(true);
       }
     });
   });
@@ -77,18 +63,14 @@ describe("incursion_constellations", () => {
     });
 
     it("Staging is a non-empty string", () => {
-      for (const [name, entry] of fullEntries) {
-        if (entry.Staging.trim().length === 0) {
-          throw new Error(`${name}: Staging should be non-empty`);
-        }
+      for (const [, entry] of fullEntries) {
+        expect(entry.Staging.trim().length).toBeGreaterThan(0);
       }
     });
 
     it("Headquarters is a non-empty string", () => {
-      for (const [name, entry] of fullEntries) {
-        if (entry.Headquarters.trim().length === 0) {
-          throw new Error(`${name}: Headquarters should be non-empty`);
-        }
+      for (const [, entry] of fullEntries) {
+        expect(entry.Headquarters.trim().length).toBeGreaterThan(0);
       }
     });
 
@@ -96,37 +78,28 @@ describe("incursion_constellations", () => {
       // Some entries have a non-empty HQ but stub-like empty Vanguard arrays
       // (e.g. "2747-4" has HQ "A-" but Vanguards: [""]).
       // We only enforce non-empty Vanguards where actual system names are present.
-      for (const [name, entry] of fullEntries) {
+      for (const [, entry] of fullEntries) {
         const populatedVanguards = entry.Vanguards.filter((s) => s.trim().length > 0);
         if (entry.Vanguards.length > 0 && populatedVanguards.length === 0) {
           // skip — entry has placeholder empty strings in Vanguards
           continue;
         }
-        if (entry.Vanguards.length === 0) {
-          throw new Error(`${name}: Vanguards should have at least one element`);
-        }
+        expect(entry.Vanguards.length).toBeGreaterThan(0);
       }
     });
 
-    it("every non-empty Vanguard element is a non-empty string", () => {
-      // Filter out known placeholder entries where all Vanguards are empty strings.
-      for (const [name, entry] of fullEntries) {
+    it("every Vanguard element is a string", () => {
+      for (const [, entry] of fullEntries) {
         for (const system of entry.Vanguards) {
-          if (typeof system !== "string") {
-            throw new Error(`${name}: Vanguards element must be a string`);
-          }
-          // Empty strings indicate incomplete data entries — skip them but don't fail.
-          // See entries like "2747-4" which have placeholder values.
+          expect(typeof system).toBe("string");
         }
       }
     });
 
-    it("every non-empty Assault element is a non-empty string", () => {
-      for (const [name, entry] of fullEntries) {
+    it("every Assault element is a string", () => {
+      for (const [, entry] of fullEntries) {
         for (const system of entry.Assaults) {
-          if (typeof system !== "string") {
-            throw new Error(`${name}: Assaults element must be a string`);
-          }
+          expect(typeof system).toBe("string");
         }
       }
     });
@@ -134,46 +107,27 @@ describe("incursion_constellations", () => {
 
   describe("uniqueness constraints (full entries)", () => {
     it("no two full constellations share the same Headquarters", () => {
-      const hqToConstellation = new Map<string, string>();
-      for (const [name, entry] of fullEntries) {
-        const existing = hqToConstellation.get(entry.Headquarters);
-        if (existing !== undefined) {
-          throw new Error(
-            `Headquarters "${entry.Headquarters}" is shared by "${existing}" and "${name}"`,
-          );
-        }
-        hqToConstellation.set(entry.Headquarters, name);
-      }
+      const hqs = fullEntries.map(([, entry]) => entry.Headquarters);
+      expect(new Set(hqs).size).toBe(hqs.length);
     });
 
     it("Staging and Headquarters are different solar systems within each full constellation", () => {
-      for (const [name, entry] of fullEntries) {
-        // Skip entries where Staging is empty (incomplete data)
+      for (const [, entry] of fullEntries) {
         if (entry.Staging.trim().length === 0) continue;
-        if (entry.Staging === entry.Headquarters) {
-          throw new Error(`${name}: Staging and Headquarters must differ ("${entry.Staging}")`);
-        }
+        expect(entry.Staging).not.toBe(entry.Headquarters);
       }
     });
 
     it("Staging does not appear in Assaults within each full constellation", () => {
-      for (const [name, entry] of fullEntries) {
+      for (const [, entry] of fullEntries) {
         if (entry.Staging.trim().length === 0) continue;
-        if (entry.Assaults.includes(entry.Staging)) {
-          throw new Error(
-            `${name}: Staging "${entry.Staging}" must not appear in Assaults`,
-          );
-        }
+        expect(entry.Assaults).not.toContain(entry.Staging);
       }
     });
 
     it("Headquarters does not appear in Assaults within each full constellation", () => {
-      for (const [name, entry] of fullEntries) {
-        if (entry.Assaults.includes(entry.Headquarters)) {
-          throw new Error(
-            `${name}: Headquarters "${entry.Headquarters}" must not appear in Assaults`,
-          );
-        }
+      for (const [, entry] of fullEntries) {
+        expect(entry.Assaults).not.toContain(entry.Headquarters);
       }
     });
   });

--- a/packages/eve-data/tests/incursions.test.ts
+++ b/packages/eve-data/tests/incursions.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "@jest/globals";
+import { incursion_constellations } from "../src/incursions";
+
+// Full entries have a non-empty Headquarters. Entries with an empty Headquarters
+// are placeholder stubs and are excluded from data-quality assertions.
+const fullEntries = Object.entries(incursion_constellations).filter(
+  ([, v]) => v.Headquarters !== "",
+);
+
+describe("incursion_constellations", () => {
+  describe("export shape", () => {
+    it("is a non-empty object", () => {
+      expect(typeof incursion_constellations).toBe("object");
+      expect(incursion_constellations).not.toBeNull();
+      expect(Object.keys(incursion_constellations).length).toBeGreaterThan(0);
+    });
+
+    it("has all 4 required keys on every entry", () => {
+      const required = ["Staging", "Vanguards", "Assaults", "Headquarters"] as const;
+      for (const [name, entry] of Object.entries(incursion_constellations)) {
+        for (const key of required) {
+          if (!Object.prototype.hasOwnProperty.call(entry, key)) {
+            throw new Error(`${name}: missing required key "${key}"`);
+          }
+        }
+      }
+    });
+
+    it("has no empty constellation names as keys", () => {
+      for (const name of Object.keys(incursion_constellations)) {
+        if (name.trim().length === 0) {
+          throw new Error(`found an empty constellation name in keys`);
+        }
+      }
+    });
+  });
+
+  describe("field types (all entries)", () => {
+    it("Staging is always a string", () => {
+      for (const [name, entry] of Object.entries(incursion_constellations)) {
+        if (typeof entry.Staging !== "string") {
+          throw new Error(`${name}: Staging should be string, got ${typeof entry.Staging}`);
+        }
+      }
+    });
+
+    it("Headquarters is always a string", () => {
+      for (const [name, entry] of Object.entries(incursion_constellations)) {
+        if (typeof entry.Headquarters !== "string") {
+          throw new Error(
+            `${name}: Headquarters should be string, got ${typeof entry.Headquarters}`,
+          );
+        }
+      }
+    });
+
+    it("Vanguards is always an array", () => {
+      for (const [name, entry] of Object.entries(incursion_constellations)) {
+        if (!Array.isArray(entry.Vanguards)) {
+          throw new Error(`${name}: Vanguards should be array`);
+        }
+      }
+    });
+
+    it("Assaults is always an array", () => {
+      for (const [name, entry] of Object.entries(incursion_constellations)) {
+        if (!Array.isArray(entry.Assaults)) {
+          throw new Error(`${name}: Assaults should be array`);
+        }
+      }
+    });
+  });
+
+  describe("full (non-stub) entries", () => {
+    it("there is at least one full entry", () => {
+      expect(fullEntries.length).toBeGreaterThan(0);
+    });
+
+    it("Staging is a non-empty string", () => {
+      for (const [name, entry] of fullEntries) {
+        if (entry.Staging.trim().length === 0) {
+          throw new Error(`${name}: Staging should be non-empty`);
+        }
+      }
+    });
+
+    it("Headquarters is a non-empty string", () => {
+      for (const [name, entry] of fullEntries) {
+        if (entry.Headquarters.trim().length === 0) {
+          throw new Error(`${name}: Headquarters should be non-empty`);
+        }
+      }
+    });
+
+    it("Vanguards is a non-empty array (when HQ and Vanguards are both populated)", () => {
+      // Some entries have a non-empty HQ but stub-like empty Vanguard arrays
+      // (e.g. "2747-4" has HQ "A-" but Vanguards: [""]).
+      // We only enforce non-empty Vanguards where actual system names are present.
+      for (const [name, entry] of fullEntries) {
+        const populatedVanguards = entry.Vanguards.filter((s) => s.trim().length > 0);
+        if (entry.Vanguards.length > 0 && populatedVanguards.length === 0) {
+          // skip — entry has placeholder empty strings in Vanguards
+          continue;
+        }
+        if (entry.Vanguards.length === 0) {
+          throw new Error(`${name}: Vanguards should have at least one element`);
+        }
+      }
+    });
+
+    it("every non-empty Vanguard element is a non-empty string", () => {
+      // Filter out known placeholder entries where all Vanguards are empty strings.
+      for (const [name, entry] of fullEntries) {
+        for (const system of entry.Vanguards) {
+          if (typeof system !== "string") {
+            throw new Error(`${name}: Vanguards element must be a string`);
+          }
+          // Empty strings indicate incomplete data entries — skip them but don't fail.
+          // See entries like "2747-4" which have placeholder values.
+        }
+      }
+    });
+
+    it("every non-empty Assault element is a non-empty string", () => {
+      for (const [name, entry] of fullEntries) {
+        for (const system of entry.Assaults) {
+          if (typeof system !== "string") {
+            throw new Error(`${name}: Assaults element must be a string`);
+          }
+        }
+      }
+    });
+  });
+
+  describe("uniqueness constraints (full entries)", () => {
+    it("no two full constellations share the same Headquarters", () => {
+      const hqToConstellation = new Map<string, string>();
+      for (const [name, entry] of fullEntries) {
+        const existing = hqToConstellation.get(entry.Headquarters);
+        if (existing !== undefined) {
+          throw new Error(
+            `Headquarters "${entry.Headquarters}" is shared by "${existing}" and "${name}"`,
+          );
+        }
+        hqToConstellation.set(entry.Headquarters, name);
+      }
+    });
+
+    it("Staging and Headquarters are different solar systems within each full constellation", () => {
+      for (const [name, entry] of fullEntries) {
+        // Skip entries where Staging is empty (incomplete data)
+        if (entry.Staging.trim().length === 0) continue;
+        if (entry.Staging === entry.Headquarters) {
+          throw new Error(`${name}: Staging and Headquarters must differ ("${entry.Staging}")`);
+        }
+      }
+    });
+
+    it("Staging does not appear in Assaults within each full constellation", () => {
+      for (const [name, entry] of fullEntries) {
+        if (entry.Staging.trim().length === 0) continue;
+        if (entry.Assaults.includes(entry.Staging)) {
+          throw new Error(
+            `${name}: Staging "${entry.Staging}" must not appear in Assaults`,
+          );
+        }
+      }
+    });
+
+    it("Headquarters does not appear in Assaults within each full constellation", () => {
+      for (const [name, entry] of fullEntries) {
+        if (entry.Assaults.includes(entry.Headquarters)) {
+          throw new Error(
+            `${name}: Headquarters "${entry.Headquarters}" must not appear in Assaults`,
+          );
+        }
+      }
+    });
+  });
+
+  describe("known constellation regression tests", () => {
+    it("Algintal has the expected solar systems", () => {
+      const c = incursion_constellations["Algintal"];
+      expect(c).toBeDefined();
+      expect(c.Staging).toBe("Barmalie");
+      expect(c.Vanguards).toEqual(
+        expect.arrayContaining(["Audaerne", "Augnais", "Fluekele", "Jolia"]),
+      );
+      expect(c.Vanguards).toHaveLength(4);
+      expect(c.Assaults).toEqual(
+        expect.arrayContaining(["Alsottobier", "Deltole", "Parchanier"]),
+      );
+      expect(c.Assaults).toHaveLength(3);
+      expect(c.Headquarters).toBe("Colelie");
+    });
+
+    it("Ihilakken has the expected solar systems", () => {
+      const c = incursion_constellations["Ihilakken"];
+      expect(c).toBeDefined();
+      expect(c.Staging).toBe("Sakenta");
+      expect(c.Vanguards).toEqual(
+        expect.arrayContaining(["Ansila", "Aokannitoh", "Hirtamon", "Ikuchi"]),
+      );
+      expect(c.Vanguards).toHaveLength(4);
+      expect(c.Assaults).toEqual(
+        expect.arrayContaining(["Hykkota", "Ohmahailen", "Outuni"]),
+      );
+      expect(c.Assaults).toHaveLength(3);
+      expect(c.Headquarters).toBe("Eskunen");
+    });
+
+    it("Sanctum has the expected solar systems", () => {
+      const c = incursion_constellations["Sanctum"];
+      expect(c).toBeDefined();
+      expect(c.Staging).toBe("Yulai");
+      expect(c.Vanguards).toEqual(
+        expect.arrayContaining(["Esmar", "Kemerk", "Manarq", "Ourapheh"]),
+      );
+      expect(c.Vanguards).toHaveLength(4);
+      expect(c.Assaults).toEqual(
+        expect.arrayContaining(["Pakhshi", "Tar", "Tekaima"]),
+      );
+      expect(c.Assaults).toHaveLength(3);
+      expect(c.Headquarters).toBe("Tarta");
+    });
+
+    it("stub entry Ananah has Staging but empty Headquarters", () => {
+      const c = incursion_constellations["Ananah"];
+      expect(c).toBeDefined();
+      expect(c.Staging).toBe("Mifrata");
+      expect(c.Headquarters).toBe("");
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
     dependencies:
       '@c15t/nextjs':
         specifier: ^1.8.6
-        version: 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
+        version: 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
       '@c15t/scripts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -228,13 +228,13 @@ importers:
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(@tiptap/extension-link@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))(@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@react-hook/cache':
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.6)
       '@sentry/nextjs':
         specifier: ^10.53.1
-        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
+        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
       '@tabler/icons-react':
         specifier: ^3.44.0
         version: 3.44.0(react@19.2.6)
@@ -246,7 +246,7 @@ importers:
         version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query-next-experimental':
         specifier: ^5.100.14
-        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@tiptap/extension-link':
         specifier: ^2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
@@ -258,19 +258,19 @@ importers:
         version: 2.27.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       botid:
         specifier: ^1.5.11
-        version: 1.5.11(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.5.11(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       date-fns:
         specifier: ^4.3.0
         version: 4.3.0
@@ -294,16 +294,16 @@ importers:
         version: 2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(dayjs@1.11.20)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(@tabler/icons-react@3.44.0(react@19.2.6))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-seo:
         specifier: ^6.8.0
-        version: 6.8.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nextjs-cors:
         specifier: ^2.2.1
-        version: 2.2.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 2.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       nextjs-routes:
         specifier: ^2.2.5
-        version: 2.2.5(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 2.2.5(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ngraph.graph:
         specifier: ^20.1.2
         version: 20.1.2
@@ -436,7 +436,7 @@ importers:
         version: link:../esi-metadata
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -485,7 +485,7 @@ importers:
         version: link:../esi-metadata
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -724,6 +724,9 @@ importers:
 
   packages/eve-data:
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1
       '@jitaspace/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -733,12 +736,24 @@ importers:
       '@jitaspace/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@swc/core':
+        specifier: ^1.15.40
+        version: 1.15.40
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.40)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3))
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2950,10 +2965,6 @@ packages:
     resolution: {integrity: sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/diff-sequences@30.0.1':
-    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/diff-sequences@30.4.0':
     resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2970,10 +2981,6 @@ packages:
 
   '@jest/environment@30.4.1':
     resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect-utils@30.2.0':
-    resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@30.4.1':
@@ -3039,10 +3046,6 @@ packages:
 
   '@jest/transform@30.4.1':
     resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.2.0':
-    resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@30.3.0':
@@ -7643,10 +7646,6 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
-  expect@30.2.0:
-    resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8618,10 +8617,6 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.2.0:
-    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-diff@30.4.1:
     resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8655,24 +8650,12 @@ packages:
     resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.2.0:
-    resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-matcher-utils@30.4.1:
     resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.2.0:
-    resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-message-util@30.4.1:
     resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.2.0:
-    resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-mock@30.4.1:
@@ -8714,10 +8697,6 @@ packages:
 
   jest-snapshot@30.4.1:
     resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-util@30.2.0:
-    resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@30.4.1:
@@ -9939,10 +9918,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-format@30.2.0:
-    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   pretty-format@30.4.1:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
@@ -11987,11 +11962,11 @@ snapshots:
       neverthrow: 8.2.0
       picocolors: 1.1.1
 
-  '@c15t/nextjs@1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)':
+  '@c15t/nextjs@1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)':
     dependencies:
       '@c15t/react': 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
       '@c15t/translations': 1.8.5
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -13127,8 +13102,6 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
 
-  '@jest/diff-sequences@30.0.1': {}
-
   '@jest/diff-sequences@30.4.0': {}
 
   '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
@@ -13148,10 +13121,6 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 24.12.4
       jest-mock: 30.4.1
-
-  '@jest/expect-utils@30.2.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
 
   '@jest/expect-utils@30.4.1':
     dependencies:
@@ -13275,16 +13244,6 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/types@30.2.0':
-    dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.4
-      '@types/yargs': 17.0.35
-      chalk: 4.1.2
 
   '@jest/types@30.3.0':
     dependencies:
@@ -13717,9 +13676,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       third-party-capital: 1.0.20
 
@@ -15482,7 +15441,7 @@ snapshots:
       marked: 4.3.0
       mustache: 4.2.0
 
-  '@redis/bloom@5.12.1(@redis/client@5.12.1)':
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
@@ -15492,15 +15451,15 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@redis/json@5.12.1(@redis/client@5.12.1)':
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/search@5.12.1(@redis/client@5.12.1)':
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/time-series@5.12.1(@redis/client@5.12.1)':
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
@@ -15742,7 +15701,7 @@ snapshots:
 
   '@sentry/core@10.53.1': {}
 
-  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))':
+  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -15755,7 +15714,7 @@ snapshots:
       '@sentry/react': 10.53.1(react@19.2.6)
       '@sentry/vercel-edge': 10.53.1
       '@sentry/webpack-plugin': 5.3.0(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rollup: 4.60.4
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -16015,10 +15974,10 @@ snapshots:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query-next-experimental@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-next-experimental@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@tanstack/react-query@5.100.14(react@19.2.6)':
@@ -16422,8 +16381,8 @@ snapshots:
 
   '@types/jest@30.0.0':
     dependencies:
-      expect: 30.2.0
-      pretty-format: 30.2.0
+      expect: 30.4.1
+      pretty-format: 30.4.1
 
   '@types/js-yaml@4.0.9': {}
 
@@ -16709,9 +16668,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/og@0.11.1':
@@ -16721,9 +16680,9 @@ snapshots:
     optionalDependencies:
       sharp: 0.34.5
 
-  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
@@ -17189,9 +17148,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  botid@1.5.11(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  botid@1.5.11(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   brace-expansion@1.1.11:
@@ -18661,15 +18620,6 @@ snapshots:
 
   exit-x@0.2.2: {}
 
-  expect@30.2.0:
-    dependencies:
-      '@jest/expect-utils': 30.2.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.2.0
-      jest-message-util: 30.2.0
-      jest-mock: 30.2.0
-      jest-util: 30.2.0
-
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -19022,7 +18972,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -19328,7 +19278,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       hono: 4.12.23
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19749,13 +19699,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.2.0:
-    dependencies:
-      '@jest/diff-sequences': 30.0.1
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.2.0
-
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -19815,31 +19758,12 @@ snapshots:
       '@jest/get-type': 30.1.0
       pretty-format: 30.4.1
 
-  jest-matcher-utils@30.2.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.2.0
-      pretty-format: 30.2.0
-
   jest-matcher-utils@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
       jest-diff: 30.4.1
       pretty-format: 30.4.1
-
-  jest-message-util@30.2.0:
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@jest/types': 30.2.0
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
 
   jest-message-util@30.4.1:
     dependencies:
@@ -19853,12 +19777,6 @@ snapshots:
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
-
-  jest-mock@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.12.4
-      jest-util: 30.2.0
 
   jest-mock@30.4.1:
     dependencies:
@@ -19971,15 +19889,6 @@ snapshots:
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
-
-  jest-util@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.12.4
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      graceful-fs: 4.2.11
-      picomatch: 4.0.3
 
   jest-util@30.4.1:
     dependencies:
@@ -20869,15 +20778,15 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.54.0
 
-  next-seo@6.8.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -20886,7 +20795,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.27.4)(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -20902,15 +20811,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-cors@2.2.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  nextjs-cors@2.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       cors: 2.8.5
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  nextjs-routes@2.2.5(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  nextjs-routes@2.2.5(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       chokidar: 4.0.1
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   ngraph.events@1.4.0: {}
 
@@ -21251,7 +21160,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -21422,12 +21331,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty-format@30.2.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
 
   pretty-format@30.4.1:
     dependencies:
@@ -21824,11 +21727,11 @@ snapshots:
 
   redis@5.12.1(@opentelemetry/api@1.9.1):
     dependencies:
-      '@redis/bloom': 5.12.1(@redis/client@5.12.1)
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-      '@redis/json': 5.12.1(@redis/client@5.12.1)
-      '@redis/search': 5.12.1(@redis/client@5.12.1)
-      '@redis/time-series': 5.12.1(@redis/client@5.12.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
@@ -22488,12 +22391,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.27.4)(react@19.2.6):
+  styled-jsx@5.1.6(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
-    optionalDependencies:
-      '@babel/core': 7.27.4
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Wire up Jest in the eve-data package (no tests existed)
- Validate incursion_constellations structure: required fields, type correctness, no duplicate Headquarters, no intra-constellation role collisions

## Test plan
- [ ] `pnpm --filter @jitaspace/eve-data test` passes
- [ ] All ~50+ constellation entries pass structural validation
- [ ] Two or three concrete constellation snapshots guard against regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)