### PR TITLE
test(utils): add comprehensive unit test coverage

### DIFF
--- a/packages/utils/jest.config.ts
+++ b/packages/utils/jest.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  testEnvironment: "node",
+  testMatch: ["<rootDir>/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "es2022",
+          parser: { syntax: "typescript", tsx: false },
+        },
+        module: { type: "commonjs" },
+      },
+    ],
+  },
+  transformIgnorePatterns: ["/node_modules/(?!(@jitaspace))"],
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+  coverageReporters: ["lcov", "text"],
+  clearMocks: true,
+  restoreMocks: true,
+};
+
+export default config;

--- a/packages/utils/jest.setup.ts
+++ b/packages/utils/jest.setup.ts
@@ -1,0 +1,1 @@
+// Jest setup file

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,17 +11,23 @@
     "clean": "rm -rf .turbo node_modules",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
+    "test": "jest",
     "type-check": "tsc --jsx react-jsx --noEmit",
     "prepublish": "pnpm build"
   },
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
     "@jitaspace/esi-client": "workspace:*",
     "@jitaspace/eslint-config": "workspace:*",
     "@jitaspace/prettier-config": "workspace:*",
     "@jitaspace/tsconfig": "workspace:*",
+    "@swc/core": "^1.15.40",
+    "@swc/jest": "^0.2.39",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.1.6",
     "eslint": "^9.39.4",
+    "jest": "^30.4.2",
     "prettier": "^3.8.3",
     "typescript": "^5.9.3"
   },

--- a/packages/utils/tests/esi.test.ts
+++ b/packages/utils/tests/esi.test.ts
@@ -1,0 +1,73 @@
+import { isSpecialLabelId, humanLabelName } from "../src/esi";
+
+describe("isSpecialLabelId", () => {
+  it("returns truthy for label_id 1 (Inbox)", () => {
+    expect(isSpecialLabelId(1)).toBeTruthy();
+  });
+
+  it("returns truthy for label_id 2 (Sent)", () => {
+    expect(isSpecialLabelId(2)).toBeTruthy();
+  });
+
+  it("returns truthy for label_id 4 (Corporation)", () => {
+    expect(isSpecialLabelId(4)).toBeTruthy();
+  });
+
+  it("returns truthy for label_id 8 (Alliance)", () => {
+    expect(isSpecialLabelId(8)).toBeTruthy();
+  });
+
+  it("returns falsy for a non-special id", () => {
+    expect(isSpecialLabelId(99)).toBeFalsy();
+  });
+
+  it("returns falsy for id 0", () => {
+    expect(isSpecialLabelId(0)).toBeFalsy();
+  });
+
+  it("returns falsy when id is undefined", () => {
+    expect(isSpecialLabelId(undefined)).toBeFalsy();
+  });
+
+  it("returns falsy for a random large number", () => {
+    expect(isSpecialLabelId(1000)).toBeFalsy();
+  });
+});
+
+describe("humanLabelName", () => {
+  it("returns 'Inbox' for label_id 1", () => {
+    expect(humanLabelName({ label_id: 1 })).toBe("Inbox");
+  });
+
+  it("returns 'Sent' for label_id 2", () => {
+    expect(humanLabelName({ label_id: 2 })).toBe("Sent");
+  });
+
+  it("returns 'Corporation' for label_id 4", () => {
+    expect(humanLabelName({ label_id: 4 })).toBe("Corporation");
+  });
+
+  it("returns 'Alliance' for label_id 8", () => {
+    expect(humanLabelName({ label_id: 8 })).toBe("Alliance");
+  });
+
+  it("returns the label name for a non-special id with a name", () => {
+    expect(humanLabelName({ label_id: 42, name: "My Label" })).toBe("My Label");
+  });
+
+  it("returns the stringified label_id when name is absent and id is non-special", () => {
+    expect(humanLabelName({ label_id: 99 })).toBe("99");
+  });
+
+  it("returns 'Unknown Label' when label is undefined", () => {
+    expect(humanLabelName(undefined)).toBe("Unknown Label");
+  });
+
+  it("returns 'Unknown Label' when label object is empty", () => {
+    expect(humanLabelName({})).toBe("Unknown Label");
+  });
+
+  it("returns name when label_id is undefined but name is provided", () => {
+    expect(humanLabelName({ name: "Custom" })).toBe("Custom");
+  });
+});

--- a/packages/utils/tests/fitting.test.ts
+++ b/packages/utils/tests/fitting.test.ts
@@ -1,4 +1,5 @@
-import { parseEFTFitString, toEFTFitString, ShipFitting } from "../src/fitting";
+import type { ShipFitting } from "../src/fitting";
+import { parseEFTFitString, toEFTFitString } from "../src/fitting";
 
 // A canonical EFT string representative of a typical EVE fitting.
 // Sections are separated by blank lines:

--- a/packages/utils/tests/fitting.test.ts
+++ b/packages/utils/tests/fitting.test.ts
@@ -1,0 +1,260 @@
+import { parseEFTFitString, toEFTFitString, ShipFitting } from "../src/fitting";
+
+// A canonical EFT string representative of a typical EVE fitting.
+// Sections are separated by blank lines:
+//   header
+//   low slots
+//   (blank)
+//   mid slots
+//   (blank)
+//   high slots
+//   (blank)
+//   rig slots
+//   (blank)
+//   subsystem slots
+//   (blank)
+//   drone bay
+//   (blank)
+//   cargo hold
+const SAMPLE_EFT = `[Venture,Mining Barge]
+Mining Laser Upgrade I
+Mining Laser Upgrade I
+
+Survey Scanner II,
+Multispectral ECM I
+
+Miner II
+Miner II
+
+Small Drone Mining Augmentor I
+Small Drone Mining Augmentor I
+
+Medium Drone Mining Augmentor I
+
+Hornet EC-300 x5
+Warrior I x2
+
+Hobgoblin I x10`;
+
+describe("parseEFTFitString", () => {
+  it("parses the ship type and name from the header", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    expect(fit.typeName).toBe("Venture");
+    expect(fit.shipName).toBe("Mining Barge");
+  });
+
+  it("parses low slots correctly", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    // Two identical low slot modules are merged (quantity=2) when mergeSimilarModules=true
+    expect(fit.lowSlots).toHaveLength(1);
+    expect(fit.lowSlots[0]!.name).toBe("Mining Laser Upgrade I");
+    expect(fit.lowSlots[0]!.quantity).toBe(2);
+  });
+
+  it("parses mid slots correctly", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    expect(fit.midSlots).toHaveLength(2);
+    expect(fit.midSlots[0]!.name).toBe("Survey Scanner II");
+    expect(fit.midSlots[1]!.name).toBe("Multispectral ECM I");
+  });
+
+  it("parses ammo for mid slots", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    // "Survey Scanner II," with nothing after comma — ammo is empty string
+    // "Multispectral ECM I" has no comma, so ammo is undefined
+    expect(fit.midSlots[0]!.ammo).toBe("");
+    expect(fit.midSlots[1]!.ammo).toBeUndefined();
+  });
+
+  it("parses high slots correctly", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    // Two Miner II merged into one with quantity=2
+    expect(fit.highSlots).toHaveLength(1);
+    expect(fit.highSlots[0]!.name).toBe("Miner II");
+    expect(fit.highSlots[0]!.quantity).toBe(2);
+  });
+
+  it("parses rig slots correctly", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    expect(fit.rigSlots).toHaveLength(1);
+    expect(fit.rigSlots[0]!.name).toBe("Small Drone Mining Augmentor I");
+    expect(fit.rigSlots[0]!.quantity).toBe(2);
+  });
+
+  it("parses subsystem slots correctly", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    expect(fit.subsystemSlots).toHaveLength(1);
+    expect(fit.subsystemSlots[0]!.name).toBe("Medium Drone Mining Augmentor I");
+    expect(fit.subsystemSlots[0]!.quantity).toBe(1);
+  });
+
+  it("parses drone bay entries with quantities", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    expect(fit.droneBay).toHaveLength(2);
+    expect(fit.droneBay[0]!.name).toBe("Hornet EC-300");
+    expect(fit.droneBay[0]!.quantity).toBe(5);
+    expect(fit.droneBay[1]!.name).toBe("Warrior I");
+    expect(fit.droneBay[1]!.quantity).toBe(2);
+  });
+
+  it("parses cargo hold entries with quantities", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT);
+    expect(fit.cargoHold).toHaveLength(1);
+    expect(fit.cargoHold[0]!.name).toBe("Hobgoblin I");
+    expect(fit.cargoHold[0]!.quantity).toBe(10);
+  });
+
+  it("does not merge when mergeSimilarModules=false", () => {
+    const fit = parseEFTFitString(SAMPLE_EFT, false);
+    // Two individual Miner II entries instead of one merged entry
+    expect(fit.highSlots).toHaveLength(2);
+    expect(fit.highSlots[0]!.quantity).toBe(1);
+    expect(fit.highSlots[1]!.quantity).toBe(1);
+  });
+});
+
+describe("toEFTFitString", () => {
+  it("produces the expected header line", () => {
+    const fit: ShipFitting = {
+      typeName: "Rifter",
+      shipName: "Fast Rifter",
+      highSlots: [],
+      midSlots: [],
+      lowSlots: [],
+      rigSlots: [],
+      subsystemSlots: [],
+      droneBay: [],
+      cargoHold: [],
+    };
+    const result = toEFTFitString(fit);
+    expect(result.startsWith("[Rifter,Fast Rifter]")).toBe(true);
+  });
+
+  it("expands modules with quantity > 1 into multiple lines", () => {
+    const fit: ShipFitting = {
+      typeName: "Test",
+      shipName: "Ship",
+      highSlots: [{ name: "Blaster", quantity: 3 }],
+      midSlots: [],
+      lowSlots: [],
+      rigSlots: [],
+      subsystemSlots: [],
+      droneBay: [],
+      cargoHold: [],
+    };
+    const result = toEFTFitString(fit);
+    const highLines = result
+      .split("\n")
+      .filter((line) => line === "Blaster");
+    expect(highLines).toHaveLength(3);
+  });
+
+  it("serializes ammo in high/mid slot modules", () => {
+    const fit: ShipFitting = {
+      typeName: "Test",
+      shipName: "Ship",
+      highSlots: [{ name: "Railgun", ammo: "Iron Charge", quantity: 1 }],
+      midSlots: [],
+      lowSlots: [],
+      rigSlots: [],
+      subsystemSlots: [],
+      droneBay: [],
+      cargoHold: [],
+    };
+    const result = toEFTFitString(fit);
+    expect(result).toContain("Railgun, Iron Charge");
+  });
+
+  it("serializes drone bay with 'x<qty>' suffix", () => {
+    const fit: ShipFitting = {
+      typeName: "Test",
+      shipName: "Ship",
+      highSlots: [],
+      midSlots: [],
+      lowSlots: [],
+      rigSlots: [],
+      subsystemSlots: [],
+      droneBay: [{ name: "Hornet EC-300", quantity: 5 }],
+      cargoHold: [],
+    };
+    const result = toEFTFitString(fit);
+    expect(result).toContain("Hornet EC-300 x5");
+  });
+
+  it("serializes cargo hold with 'x<qty>' suffix", () => {
+    const fit: ShipFitting = {
+      typeName: "Test",
+      shipName: "Ship",
+      highSlots: [],
+      midSlots: [],
+      lowSlots: [],
+      rigSlots: [],
+      subsystemSlots: [],
+      droneBay: [],
+      cargoHold: [{ name: "Nanite Repair Paste", quantity: 200 }],
+    };
+    const result = toEFTFitString(fit);
+    expect(result).toContain("Nanite Repair Paste x200");
+  });
+});
+
+describe("parseEFTFitString / toEFTFitString roundtrip", () => {
+  it("roundtrips a simple fitting: parse then serialize reproduces parseable output", () => {
+    const simpleFit = `[Rifter,Solo PvP]
+Gyrostabilizer I
+Gyrostabilizer I
+
+1MN Afterburner II
+Medium Shield Extender II
+
+Autocannon II, Barrage S
+Autocannon II, Barrage S
+
+Small Core Defense Field Extender I
+
+
+`;
+
+    const parsed = parseEFTFitString(simpleFit);
+    const serialized = toEFTFitString(parsed);
+    const reparsed = parseEFTFitString(serialized);
+
+    // The structural data should be identical after two parse passes
+    expect(reparsed.typeName).toBe(parsed.typeName);
+    expect(reparsed.shipName).toBe(parsed.shipName);
+
+    // Low slots
+    expect(reparsed.lowSlots.length).toBe(parsed.lowSlots.length);
+    parsed.lowSlots.forEach((mod, i) => {
+      expect(reparsed.lowSlots[i]!.name).toBe(mod.name);
+      expect(reparsed.lowSlots[i]!.quantity).toBe(mod.quantity);
+    });
+
+    // Mid slots
+    expect(reparsed.midSlots.length).toBe(parsed.midSlots.length);
+    parsed.midSlots.forEach((mod, i) => {
+      expect(reparsed.midSlots[i]!.name).toBe(mod.name);
+    });
+
+    // High slots
+    expect(reparsed.highSlots.length).toBe(parsed.highSlots.length);
+    parsed.highSlots.forEach((mod, i) => {
+      expect(reparsed.highSlots[i]!.name).toBe(mod.name);
+      expect(reparsed.highSlots[i]!.ammo).toBe(mod.ammo);
+      expect(reparsed.highSlots[i]!.quantity).toBe(mod.quantity);
+    });
+
+    // Rig slots
+    expect(reparsed.rigSlots.length).toBe(parsed.rigSlots.length);
+    parsed.rigSlots.forEach((mod, i) => {
+      expect(reparsed.rigSlots[i]!.name).toBe(mod.name);
+      expect(reparsed.rigSlots[i]!.quantity).toBe(mod.quantity);
+    });
+
+    // Drone bay
+    expect(reparsed.droneBay.length).toBe(parsed.droneBay.length);
+
+    // Cargo hold
+    expect(reparsed.cargoHold.length).toBe(parsed.cargoHold.length);
+  });
+});

--- a/packages/utils/tests/math.test.ts
+++ b/packages/utils/tests/math.test.ts
@@ -1,0 +1,235 @@
+import {
+  nextPowerOfTwo,
+  esiImageSizeClamp,
+  getRandomArbitrary,
+  getRandomInt,
+  shuffleArray,
+  getRandomArrayEntry,
+  randomBoolean,
+  randomExponential,
+  randomGeometric,
+} from "../src/math";
+
+describe("nextPowerOfTwo", () => {
+  it("returns 1 for 1", () => {
+    expect(nextPowerOfTwo(1)).toBe(1);
+  });
+
+  it("returns 2 for 2", () => {
+    expect(nextPowerOfTwo(2)).toBe(2);
+  });
+
+  it("returns 4 for 3", () => {
+    expect(nextPowerOfTwo(3)).toBe(4);
+  });
+
+  it("returns 4 for 4", () => {
+    expect(nextPowerOfTwo(4)).toBe(4);
+  });
+
+  it("returns 8 for 5", () => {
+    expect(nextPowerOfTwo(5)).toBe(8);
+  });
+
+  it("returns 32 for 17", () => {
+    expect(nextPowerOfTwo(17)).toBe(32);
+  });
+
+  it("returns 64 for 64", () => {
+    expect(nextPowerOfTwo(64)).toBe(64);
+  });
+
+  it("returns 128 for 65", () => {
+    expect(nextPowerOfTwo(65)).toBe(128);
+  });
+
+  it("returns 1024 for 1000", () => {
+    expect(nextPowerOfTwo(1000)).toBe(1024);
+  });
+
+  it("returns 1024 for 512+1", () => {
+    expect(nextPowerOfTwo(513)).toBe(1024);
+  });
+});
+
+describe("esiImageSizeClamp", () => {
+  it("clamps very small sizes to 32 (minimum)", () => {
+    expect(esiImageSizeClamp(1)).toBe(32);
+  });
+
+  it("returns 32 for size 20", () => {
+    expect(esiImageSizeClamp(20)).toBe(32);
+  });
+
+  it("returns 32 for size 32", () => {
+    expect(esiImageSizeClamp(32)).toBe(32);
+  });
+
+  it("returns 64 for size 33", () => {
+    expect(esiImageSizeClamp(33)).toBe(64);
+  });
+
+  it("returns 64 for size 64", () => {
+    expect(esiImageSizeClamp(64)).toBe(64);
+  });
+
+  it("returns 128 for size 100", () => {
+    expect(esiImageSizeClamp(100)).toBe(128);
+  });
+
+  it("returns 256 for size 256", () => {
+    expect(esiImageSizeClamp(256)).toBe(256);
+  });
+
+  it("returns 512 for size 300", () => {
+    expect(esiImageSizeClamp(300)).toBe(512);
+  });
+
+  it("returns 1024 for size 1024", () => {
+    expect(esiImageSizeClamp(1024)).toBe(1024);
+  });
+
+  it("clamps sizes above 1024 to 1024 (maximum)", () => {
+    expect(esiImageSizeClamp(2000)).toBe(1024);
+  });
+});
+
+describe("getRandomArbitrary", () => {
+  it("returns a number within [min, max)", () => {
+    for (let i = 0; i < 100; i++) {
+      const result = getRandomArbitrary(5, 10);
+      expect(result).toBeGreaterThanOrEqual(5);
+      expect(result).toBeLessThan(10);
+    }
+  });
+
+  it("returns a number within negative range", () => {
+    for (let i = 0; i < 50; i++) {
+      const result = getRandomArbitrary(-10, -5);
+      expect(result).toBeGreaterThanOrEqual(-10);
+      expect(result).toBeLessThan(-5);
+    }
+  });
+
+  it("returns a number", () => {
+    expect(typeof getRandomArbitrary(0, 1)).toBe("number");
+  });
+});
+
+describe("getRandomInt", () => {
+  it("returns an integer within [min, max] inclusive", () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 1000; i++) {
+      const result = getRandomInt(1, 5);
+      expect(result).toBeGreaterThanOrEqual(1);
+      expect(result).toBeLessThanOrEqual(5);
+      expect(Number.isInteger(result)).toBe(true);
+      seen.add(result);
+    }
+    // With 1000 iterations, we should see all values 1-5
+    expect(seen.size).toBe(5);
+  });
+
+  it("returns the only possible value when min === max", () => {
+    expect(getRandomInt(7, 7)).toBe(7);
+  });
+
+  it("handles non-integer inputs by flooring/ceiling", () => {
+    for (let i = 0; i < 50; i++) {
+      const result = getRandomInt(1.5, 3.7);
+      expect(result).toBeGreaterThanOrEqual(2);
+      expect(result).toBeLessThanOrEqual(3);
+      expect(Number.isInteger(result)).toBe(true);
+    }
+  });
+});
+
+describe("shuffleArray", () => {
+  it("preserves array length", () => {
+    const arr = [1, 2, 3, 4, 5];
+    expect(shuffleArray([...arr])).toHaveLength(5);
+  });
+
+  it("returns an array with the same elements", () => {
+    const arr = [1, 2, 3, 4, 5];
+    const shuffled = shuffleArray([...arr]);
+    expect(shuffled.sort()).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("mutates and returns the same array reference", () => {
+    const arr = [1, 2, 3];
+    const result = shuffleArray(arr);
+    expect(result).toBe(arr);
+  });
+
+  it("handles empty array", () => {
+    expect(shuffleArray([])).toEqual([]);
+  });
+
+  it("handles single-element array", () => {
+    expect(shuffleArray([42])).toEqual([42]);
+  });
+});
+
+describe("getRandomArrayEntry", () => {
+  it("returns an element that exists in the array", () => {
+    const arr = [10, 20, 30, 40, 50];
+    for (let i = 0; i < 50; i++) {
+      const entry = getRandomArrayEntry(arr);
+      expect(arr).toContain(entry);
+    }
+  });
+
+  it("returns the only element for a single-element array", () => {
+    expect(getRandomArrayEntry(["only"])).toBe("only");
+  });
+
+  it("returns a string from a string array", () => {
+    const arr = ["a", "b", "c"];
+    expect(typeof getRandomArrayEntry(arr)).toBe("string");
+  });
+});
+
+describe("randomBoolean", () => {
+  it("returns a boolean", () => {
+    expect(typeof randomBoolean()).toBe("boolean");
+  });
+
+  it("always returns false when probability is 0", () => {
+    for (let i = 0; i < 50; i++) {
+      expect(randomBoolean(0)).toBe(false);
+    }
+  });
+
+  it("always returns true when probability is 1", () => {
+    for (let i = 0; i < 50; i++) {
+      expect(randomBoolean(1)).toBe(true);
+    }
+  });
+});
+
+describe("randomExponential", () => {
+  it("returns a positive number", () => {
+    for (let i = 0; i < 50; i++) {
+      expect(randomExponential(1)).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns a number (default rate = 1)", () => {
+    expect(typeof randomExponential()).toBe("number");
+  });
+});
+
+describe("randomGeometric", () => {
+  it("returns a non-negative integer", () => {
+    for (let i = 0; i < 50; i++) {
+      const result = randomGeometric(0.5);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(Number.isInteger(result)).toBe(true);
+    }
+  });
+
+  it("returns a number with default success probability", () => {
+    expect(typeof randomGeometric()).toBe("number");
+  });
+});

--- a/packages/utils/tests/objects.test.ts
+++ b/packages/utils/tests/objects.test.ts
@@ -1,0 +1,127 @@
+import {
+  toArrayIfNot,
+  randomProperty,
+  removeUndefinedFields,
+} from "../src/objects";
+
+describe("toArrayIfNot", () => {
+  it("wraps a single value in an array", () => {
+    expect(toArrayIfNot(42)).toEqual([42]);
+  });
+
+  it("returns the same array when given an array", () => {
+    expect(toArrayIfNot([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("wraps a string value", () => {
+    expect(toArrayIfNot("hello")).toEqual(["hello"]);
+  });
+
+  it("returns an array of strings unchanged", () => {
+    expect(toArrayIfNot(["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("wraps null in an array", () => {
+    expect(toArrayIfNot(null)).toEqual([null]);
+  });
+
+  it("wraps undefined in an array", () => {
+    expect(toArrayIfNot(undefined)).toEqual([undefined]);
+  });
+
+  it("returns empty array unchanged", () => {
+    expect(toArrayIfNot([])).toEqual([]);
+  });
+
+  it("wraps an object in an array", () => {
+    const obj = { x: 1 };
+    expect(toArrayIfNot(obj)).toEqual([{ x: 1 }]);
+  });
+
+  it("preserves a nested array as-is (not double-wrapped)", () => {
+    const nested = [[1, 2], [3, 4]];
+    expect(toArrayIfNot(nested)).toEqual([[1, 2], [3, 4]]);
+  });
+});
+
+describe("randomProperty", () => {
+  it("returns a value that exists in the object", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    for (let i = 0; i < 50; i++) {
+      const val = randomProperty(obj);
+      expect([1, 2, 3]).toContain(val);
+    }
+  });
+
+  it("returns the only value for a single-key object", () => {
+    expect(randomProperty({ key: "value" })).toBe("value");
+  });
+
+  it("returns a string value", () => {
+    const obj = { x: "hello", y: "world" };
+    const val = randomProperty(obj);
+    expect(typeof val).toBe("string");
+  });
+
+  it("returns different values over many calls (distribution check)", () => {
+    const obj = { a: "a", b: "b", c: "c", d: "d", e: "e" };
+    const seen = new Set<string>();
+    for (let i = 0; i < 500; i++) {
+      seen.add(randomProperty(obj));
+    }
+    // Should see multiple distinct values
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});
+
+describe("removeUndefinedFields", () => {
+  it("removes keys with undefined values", () => {
+    const obj: Record<string, string | undefined> = {
+      a: "keep",
+      b: undefined,
+      c: "also keep",
+    };
+    const result = removeUndefinedFields(obj);
+    expect(result).toEqual({ a: "keep", c: "also keep" });
+    expect("b" in result).toBe(false);
+  });
+
+  it("leaves object unchanged when no undefined fields exist", () => {
+    const obj = { x: 1, y: 2, z: 3 };
+    expect(removeUndefinedFields(obj)).toEqual({ x: 1, y: 2, z: 3 });
+  });
+
+  it("returns an empty object when all fields are undefined", () => {
+    const obj: Record<string, undefined> = { a: undefined, b: undefined };
+    expect(removeUndefinedFields(obj)).toEqual({});
+  });
+
+  it("returns an empty object when input is empty", () => {
+    expect(removeUndefinedFields({})).toEqual({});
+  });
+
+  it("mutates the original object", () => {
+    const obj: Record<string, number | undefined> = { a: 1, b: undefined };
+    removeUndefinedFields(obj);
+    expect("b" in obj).toBe(false);
+  });
+
+  it("preserves null values (does not remove them)", () => {
+    const obj: Record<string, null | string> = { a: null, b: "hello" };
+    const result = removeUndefinedFields(obj);
+    expect(result).toEqual({ a: null, b: "hello" });
+  });
+
+  it("preserves falsy non-undefined values", () => {
+    const obj: Record<string, number | string | boolean> = {
+      zero: 0,
+      empty: "",
+      falsy: false,
+    };
+    expect(removeUndefinedFields(obj)).toEqual({
+      zero: 0,
+      empty: "",
+      falsy: false,
+    });
+  });
+});

--- a/packages/utils/tests/sde.test.ts
+++ b/packages/utils/tests/sde.test.ts
@@ -1,0 +1,292 @@
+import {
+  toRomanNumeral,
+  formatStarName,
+  formatPlanetName,
+  formatMoonName,
+  formatAsteroidBeltName,
+  formatStationName,
+  formatStargateName,
+} from "../src/sde";
+
+describe("toRomanNumeral", () => {
+  it("returns 'I' for 1", () => {
+    expect(toRomanNumeral(1)).toBe("I");
+  });
+
+  it("returns 'II' for 2", () => {
+    expect(toRomanNumeral(2)).toBe("II");
+  });
+
+  it("returns 'III' for 3", () => {
+    expect(toRomanNumeral(3)).toBe("III");
+  });
+
+  it("returns 'IV' for 4", () => {
+    expect(toRomanNumeral(4)).toBe("IV");
+  });
+
+  it("returns 'V' for 5", () => {
+    expect(toRomanNumeral(5)).toBe("V");
+  });
+
+  it("returns 'VI' for 6", () => {
+    expect(toRomanNumeral(6)).toBe("VI");
+  });
+
+  it("returns 'VII' for 7", () => {
+    expect(toRomanNumeral(7)).toBe("VII");
+  });
+
+  it("returns 'VIII' for 8", () => {
+    expect(toRomanNumeral(8)).toBe("VIII");
+  });
+
+  it("returns 'IX' for 9", () => {
+    expect(toRomanNumeral(9)).toBe("IX");
+  });
+
+  it("returns 'X' for 10", () => {
+    expect(toRomanNumeral(10)).toBe("X");
+  });
+
+  it("returns 'XIV' for 14", () => {
+    expect(toRomanNumeral(14)).toBe("XIV");
+  });
+
+  it("returns 'XL' for 40", () => {
+    expect(toRomanNumeral(40)).toBe("XL");
+  });
+
+  it("returns 'XC' for 90", () => {
+    expect(toRomanNumeral(90)).toBe("XC");
+  });
+
+  it("returns 'CD' for 400", () => {
+    expect(toRomanNumeral(400)).toBe("CD");
+  });
+
+  it("returns 'CM' for 900", () => {
+    expect(toRomanNumeral(900)).toBe("CM");
+  });
+
+  it("returns 'M' for 1000", () => {
+    expect(toRomanNumeral(1000)).toBe("M");
+  });
+
+  it("returns 'MMMCMXCIX' for 3999", () => {
+    expect(toRomanNumeral(3999)).toBe("MMMCMXCIX");
+  });
+
+  it("returns '0' for 0 (non-positive)", () => {
+    expect(toRomanNumeral(0)).toBe("0");
+  });
+
+  it("returns '-1' for -1 (negative)", () => {
+    expect(toRomanNumeral(-1)).toBe("-1");
+  });
+
+  it("returns '-100' for -100 (large negative)", () => {
+    expect(toRomanNumeral(-100)).toBe("-100");
+  });
+
+  it("truncates non-integer: 3.9 is treated as 3 -> 'III'", () => {
+    expect(toRomanNumeral(3.9)).toBe("III");
+  });
+
+  it("truncates non-integer: 1.1 is treated as 1 -> 'I'", () => {
+    expect(toRomanNumeral(1.1)).toBe("I");
+  });
+
+  it("returns 'Infinity' for Infinity", () => {
+    expect(toRomanNumeral(Infinity)).toBe("Infinity");
+  });
+
+  it("returns 'NaN' for NaN", () => {
+    expect(toRomanNumeral(NaN)).toBe("NaN");
+  });
+});
+
+describe("formatStarName", () => {
+  it("returns solarSystemName when provided as a string", () => {
+    expect(formatStarName({ solarSystemName: "Jita" })).toBe("Jita");
+  });
+
+  it("returns the English localized name when name.en is provided", () => {
+    expect(formatStarName({ name: { en: "Amarr" } })).toBe("Amarr");
+  });
+
+  it("returns a fallback localized name when en is absent", () => {
+    expect(formatStarName({ name: { de: "DeutschStar" } })).toBe("DeutschStar");
+  });
+
+  it("prefers solarSystemName over name.en", () => {
+    expect(
+      formatStarName({ solarSystemName: "Dodixie", name: { en: "Other" } }),
+    ).toBe("Dodixie");
+  });
+
+  it("returns empty string when no name info is provided", () => {
+    expect(formatStarName({})).toBe("");
+  });
+});
+
+describe("formatPlanetName", () => {
+  it("returns uniqueName (en) when provided", () => {
+    expect(
+      formatPlanetName({
+        celestialIndex: 3,
+        orbitName: "Caldari Prime",
+        uniqueName: { en: "Custom Planet" },
+      }),
+    ).toBe("Custom Planet");
+  });
+
+  it("returns uniqueName fallback locale when en absent", () => {
+    expect(
+      formatPlanetName({
+        celestialIndex: 2,
+        uniqueName: { fr: "PlaneteFR" },
+      }),
+    ).toBe("PlaneteFR");
+  });
+
+  it("formats with orbitName and celestialIndex roman numeral", () => {
+    expect(
+      formatPlanetName({ celestialIndex: 3, orbitName: "Jita" }),
+    ).toBe("Jita III");
+  });
+
+  it("returns just the roman numeral when orbitName is absent", () => {
+    expect(formatPlanetName({ celestialIndex: 5 })).toBe("V");
+  });
+
+  it("returns roman numeral I for celestialIndex 1 with no orbitName", () => {
+    expect(formatPlanetName({ celestialIndex: 1 })).toBe("I");
+  });
+});
+
+describe("formatMoonName", () => {
+  it("returns uniqueName (en) when provided", () => {
+    expect(
+      formatMoonName({
+        orbitIndex: 1,
+        orbitName: "Jita IV",
+        uniqueName: { en: "Special Moon" },
+      }),
+    ).toBe("Special Moon");
+  });
+
+  it("formats with orbitName and orbitIndex", () => {
+    expect(
+      formatMoonName({ orbitIndex: 2, orbitName: "Jita IV" }),
+    ).toBe("Jita IV - Moon 2");
+  });
+
+  it("returns orbitIndex as string when no orbitName", () => {
+    expect(formatMoonName({ orbitIndex: 3 })).toBe("3");
+  });
+});
+
+describe("formatAsteroidBeltName", () => {
+  it("returns uniqueName (en) when provided", () => {
+    expect(
+      formatAsteroidBeltName({
+        orbitIndex: 1,
+        orbitName: "Jita IV",
+        uniqueName: { en: "Custom Belt" },
+      }),
+    ).toBe("Custom Belt");
+  });
+
+  it("formats with orbitName and orbitIndex", () => {
+    expect(
+      formatAsteroidBeltName({ orbitIndex: 1, orbitName: "Jita IV" }),
+    ).toBe("Jita IV - Asteroid Belt 1");
+  });
+
+  it("returns orbitIndex as string when no orbitName", () => {
+    expect(formatAsteroidBeltName({ orbitIndex: 2 })).toBe("2");
+  });
+});
+
+describe("formatStationName", () => {
+  it("returns 'orbitName - corporationName' when both provided", () => {
+    expect(
+      formatStationName({
+        orbitName: "Jita IV - Moon 4",
+        corporationName: "Caldari Navy",
+      }),
+    ).toBe("Jita IV - Moon 4 - Caldari Navy");
+  });
+
+  it("returns just orbitName when corporationName is absent", () => {
+    expect(formatStationName({ orbitName: "Jita IV" })).toBe("Jita IV");
+  });
+
+  it("returns just corporationName when orbitName is absent", () => {
+    expect(
+      formatStationName({ corporationName: "Caldari Navy" }),
+    ).toBe("Caldari Navy");
+  });
+
+  it("returns empty string when both orbitName and corporationName are absent", () => {
+    expect(formatStationName({})).toBe("");
+  });
+
+  it("appends operationName when useOperationName is true", () => {
+    expect(
+      formatStationName({
+        orbitName: "Jita IV - Moon 4",
+        corporationName: "Caldari Navy",
+        operationName: "Station",
+        useOperationName: true,
+      }),
+    ).toBe("Jita IV - Moon 4 - Caldari Navy Station");
+  });
+
+  it("does not append operationName when useOperationName is false", () => {
+    expect(
+      formatStationName({
+        orbitName: "Jita IV",
+        operationName: "Station",
+        useOperationName: false,
+      }),
+    ).toBe("Jita IV");
+  });
+
+  it("returns operationName alone when base is empty and useOperationName is true", () => {
+    expect(
+      formatStationName({
+        operationName: "Station",
+        useOperationName: true,
+      }),
+    ).toBe("Station");
+  });
+
+  it("returns empty string when operationName is null and useOperationName is true", () => {
+    expect(
+      formatStationName({
+        operationName: null,
+        useOperationName: true,
+      }),
+    ).toBe("");
+  });
+});
+
+describe("formatStargateName", () => {
+  it("returns 'Stargate (SystemName)' when solarSystemName is provided", () => {
+    expect(formatStargateName({ solarSystemName: "Jita" })).toBe(
+      "Stargate (Jita)",
+    );
+  });
+
+  it("returns 'Stargate (SystemName)' when name.en is provided", () => {
+    expect(formatStargateName({ name: { en: "Amarr" } })).toBe(
+      "Stargate (Amarr)",
+    );
+  });
+
+  it("returns 'Stargate' when no system name info is provided", () => {
+    expect(formatStargateName({})).toBe("Stargate");
+  });
+});

--- a/packages/utils/tests/skills.test.ts
+++ b/packages/utils/tests/skills.test.ts
@@ -1,0 +1,39 @@
+import { skillLevelRomanNumeral } from "../src/skills";
+
+describe("skillLevelRomanNumeral", () => {
+  it("returns 'I' for level 1", () => {
+    expect(skillLevelRomanNumeral(1)).toBe("I");
+  });
+
+  it("returns 'II' for level 2", () => {
+    expect(skillLevelRomanNumeral(2)).toBe("II");
+  });
+
+  it("returns 'III' for level 3", () => {
+    expect(skillLevelRomanNumeral(3)).toBe("III");
+  });
+
+  it("returns 'IV' for level 4", () => {
+    expect(skillLevelRomanNumeral(4)).toBe("IV");
+  });
+
+  it("returns 'V' for level 5", () => {
+    expect(skillLevelRomanNumeral(5)).toBe("V");
+  });
+
+  it("returns '[Invalid Level]' for level 0", () => {
+    expect(skillLevelRomanNumeral(0)).toBe("[Invalid Level]");
+  });
+
+  it("returns '[Invalid Level]' for level 6 (out of range)", () => {
+    expect(skillLevelRomanNumeral(6)).toBe("[Invalid Level]");
+  });
+
+  it("returns '[Invalid Level]' for negative level", () => {
+    expect(skillLevelRomanNumeral(-1)).toBe("[Invalid Level]");
+  });
+
+  it("returns '[Invalid Level]' for non-integer level", () => {
+    expect(skillLevelRomanNumeral(2.5)).toBe("[Invalid Level]");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
     dependencies:
       '@c15t/nextjs':
         specifier: ^1.8.6
-        version: 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
+        version: 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
       '@c15t/scripts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -228,13 +228,13 @@ importers:
         version: 8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(@tiptap/extension-link@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))(@tiptap/react@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@next/third-parties':
         specifier: 16.2.6
-        version: 16.2.6(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@react-hook/cache':
         specifier: ^1.1.1
         version: 1.1.1(react@19.2.6)
       '@sentry/nextjs':
         specifier: ^10.53.1
-        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
+        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
       '@tabler/icons-react':
         specifier: ^3.44.0
         version: 3.44.0(react@19.2.6)
@@ -246,7 +246,7 @@ importers:
         version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(react@19.2.6)
       '@tanstack/react-query-next-experimental':
         specifier: ^5.100.14
-        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@tiptap/extension-link':
         specifier: ^2.27.2
         version: 2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)
@@ -258,19 +258,19 @@ importers:
         version: 2.27.2
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/og':
         specifier: ^0.11.1
         version: 0.11.1
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       botid:
         specifier: ^1.5.11
-        version: 1.5.11(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.5.11(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       date-fns:
         specifier: ^4.3.0
         version: 4.3.0
@@ -294,16 +294,16 @@ importers:
         version: 2.0.0-beta.9(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/dates@8.3.18(@mantine/core@8.3.18(@mantine/hooks@8.3.18(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(dayjs@1.11.20)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@mantine/hooks@8.3.18(react@19.2.6))(@tabler/icons-react@3.44.0(react@19.2.6))(clsx@2.1.1)(dayjs@1.11.20)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next-seo:
         specifier: ^6.8.0
-        version: 6.8.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       nextjs-cors:
         specifier: ^2.2.1
-        version: 2.2.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 2.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       nextjs-routes:
         specifier: ^2.2.5
-        version: 2.2.5(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
+        version: 2.2.5(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
       ngraph.graph:
         specifier: ^20.1.2
         version: 20.1.2
@@ -436,7 +436,7 @@ importers:
         version: link:../esi-metadata
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -485,7 +485,7 @@ importers:
         version: link:../esi-metadata
       next:
         specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -1465,6 +1465,9 @@ importers:
 
   packages/utils:
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1
       '@jitaspace/esi-client':
         specifier: workspace:*
         version: link:../esi-client
@@ -1477,6 +1480,15 @@ importers:
       '@jitaspace/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@swc/core':
+        specifier: ^1.15.40
+        version: 1.15.40
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.40)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1486,6 +1498,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3))
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2950,10 +2965,6 @@ packages:
     resolution: {integrity: sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/diff-sequences@30.0.1':
-    resolution: {integrity: sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   '@jest/diff-sequences@30.4.0':
     resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2970,10 +2981,6 @@ packages:
 
   '@jest/environment@30.4.1':
     resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/expect-utils@30.2.0':
-    resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@30.4.1':
@@ -3039,10 +3046,6 @@ packages:
 
   '@jest/transform@30.4.1':
     resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  '@jest/types@30.2.0':
-    resolution: {integrity: sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@30.3.0':
@@ -7643,10 +7646,6 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
-  expect@30.2.0:
-    resolution: {integrity: sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   expect@30.4.1:
     resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8618,10 +8617,6 @@ packages:
       ts-node:
         optional: true
 
-  jest-diff@30.2.0:
-    resolution: {integrity: sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-diff@30.4.1:
     resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8655,24 +8650,12 @@ packages:
     resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-matcher-utils@30.2.0:
-    resolution: {integrity: sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-matcher-utils@30.4.1:
     resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-message-util@30.2.0:
-    resolution: {integrity: sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
   jest-message-util@30.4.1:
     resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-mock@30.2.0:
-    resolution: {integrity: sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-mock@30.4.1:
@@ -8714,10 +8697,6 @@ packages:
 
   jest-snapshot@30.4.1:
     resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
-
-  jest-util@30.2.0:
-    resolution: {integrity: sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@30.4.1:
@@ -9939,10 +9918,6 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-
-  pretty-format@30.2.0:
-    resolution: {integrity: sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==}
-    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   pretty-format@30.4.1:
     resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
@@ -11987,11 +11962,11 @@ snapshots:
       neverthrow: 8.2.0
       picocolors: 1.1.1
 
-  '@c15t/nextjs@1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)':
+  '@c15t/nextjs@1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)':
     dependencies:
       '@c15t/react': 1.8.6(@electric-sql/pglite@0.4.1)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(typescript@5.9.3))(@types/pg@8.20.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(mysql2@3.15.3)(pg@8.21.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typeorm@0.3.28(ioredis@5.6.1)(mysql2@3.15.3)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.1))(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3)))(use-sync-external-store@1.6.0(react@19.2.6))(ws@8.19.0)
       '@c15t/translations': 1.8.5
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
@@ -13127,8 +13102,6 @@ snapshots:
     dependencies:
       '@jest/types': 30.3.0
 
-  '@jest/diff-sequences@30.0.1': {}
-
   '@jest/diff-sequences@30.4.0': {}
 
   '@jest/environment-jsdom-abstract@30.4.1(jsdom@26.1.0)':
@@ -13148,10 +13121,6 @@ snapshots:
       '@jest/types': 30.4.1
       '@types/node': 24.12.4
       jest-mock: 30.4.1
-
-  '@jest/expect-utils@30.2.0':
-    dependencies:
-      '@jest/get-type': 30.1.0
 
   '@jest/expect-utils@30.4.1':
     dependencies:
@@ -13275,16 +13244,6 @@ snapshots:
       write-file-atomic: 5.0.1
     transitivePeerDependencies:
       - supports-color
-
-  '@jest/types@30.2.0':
-    dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
-      '@types/istanbul-lib-coverage': 2.0.6
-      '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.12.4
-      '@types/yargs': 17.0.35
-      chalk: 4.1.2
 
   '@jest/types@30.3.0':
     dependencies:
@@ -13717,9 +13676,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@next/third-parties@16.2.6(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       third-party-capital: 1.0.20
 
@@ -15482,7 +15441,7 @@ snapshots:
       marked: 4.3.0
       mustache: 4.2.0
 
-  '@redis/bloom@5.12.1(@redis/client@5.12.1)':
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
@@ -15492,15 +15451,15 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@redis/json@5.12.1(@redis/client@5.12.1)':
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/search@5.12.1(@redis/client@5.12.1)':
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
-  '@redis/time-series@5.12.1(@redis/client@5.12.1)':
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
 
@@ -15742,7 +15701,7 @@ snapshots:
 
   '@sentry/core@10.53.1': {}
 
-  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))':
+  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -15755,7 +15714,7 @@ snapshots:
       '@sentry/react': 10.53.1(react@19.2.6)
       '@sentry/vercel-edge': 10.53.1
       '@sentry/webpack-plugin': 5.3.0(webpack@5.104.1(@swc/core@1.15.40)(postcss@8.5.15))
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rollup: 4.60.4
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -16015,10 +15974,10 @@ snapshots:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
       react: 19.2.6
 
-  '@tanstack/react-query-next-experimental@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@tanstack/react-query-next-experimental@5.100.14(@tanstack/react-query@5.100.14(react@19.2.6))(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tanstack/react-query': 5.100.14(react@19.2.6)
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@tanstack/react-query@5.100.14(react@19.2.6)':
@@ -16422,8 +16381,8 @@ snapshots:
 
   '@types/jest@30.0.0':
     dependencies:
-      expect: 30.2.0
-      pretty-format: 30.2.0
+      expect: 30.4.1
+      pretty-format: 30.4.1
 
   '@types/js-yaml@4.0.9': {}
 
@@ -16709,9 +16668,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vercel/og@0.11.1':
@@ -16721,9 +16680,9 @@ snapshots:
     optionalDependencies:
       sharp: 0.34.5
 
-  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
@@ -17189,9 +17148,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  botid@1.5.11(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
+  botid@1.5.11(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   brace-expansion@1.1.11:
@@ -18661,15 +18620,6 @@ snapshots:
 
   exit-x@0.2.2: {}
 
-  expect@30.2.0:
-    dependencies:
-      '@jest/expect-utils': 30.2.0
-      '@jest/get-type': 30.1.0
-      jest-matcher-utils: 30.2.0
-      jest-message-util: 30.2.0
-      jest-mock: 30.2.0
-      jest-util: 30.2.0
-
   expect@30.4.1:
     dependencies:
       '@jest/expect-utils': 30.4.1
@@ -19022,7 +18972,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.4
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -19328,7 +19278,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       hono: 4.12.23
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -19749,13 +19699,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-diff@30.2.0:
-    dependencies:
-      '@jest/diff-sequences': 30.0.1
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      pretty-format: 30.2.0
-
   jest-diff@30.4.1:
     dependencies:
       '@jest/diff-sequences': 30.4.0
@@ -19815,31 +19758,12 @@ snapshots:
       '@jest/get-type': 30.1.0
       pretty-format: 30.4.1
 
-  jest-matcher-utils@30.2.0:
-    dependencies:
-      '@jest/get-type': 30.1.0
-      chalk: 4.1.2
-      jest-diff: 30.2.0
-      pretty-format: 30.2.0
-
   jest-matcher-utils@30.4.1:
     dependencies:
       '@jest/get-type': 30.1.0
       chalk: 4.1.2
       jest-diff: 30.4.1
       pretty-format: 30.4.1
-
-  jest-message-util@30.2.0:
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@jest/types': 30.2.0
-      '@types/stack-utils': 2.0.3
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      micromatch: 4.0.8
-      pretty-format: 30.2.0
-      slash: 3.0.0
-      stack-utils: 2.0.6
 
   jest-message-util@30.4.1:
     dependencies:
@@ -19853,12 +19777,6 @@ snapshots:
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
-
-  jest-mock@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.12.4
-      jest-util: 30.2.0
 
   jest-mock@30.4.1:
     dependencies:
@@ -19971,15 +19889,6 @@ snapshots:
       synckit: 0.11.11
     transitivePeerDependencies:
       - supports-color
-
-  jest-util@30.2.0:
-    dependencies:
-      '@jest/types': 30.2.0
-      '@types/node': 24.12.4
-      chalk: 4.1.2
-      ci-info: 4.3.1
-      graceful-fs: 4.2.11
-      picomatch: 4.0.3
 
   jest-util@30.4.1:
     dependencies:
@@ -20869,15 +20778,15 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.54.0
 
-  next-seo@6.8.0(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
   next-tick@1.1.0: {}
 
-  next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -20886,7 +20795,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      styled-jsx: 5.1.6(@babel/core@7.27.4)(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -20902,15 +20811,15 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-cors@2.2.1(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  nextjs-cors@2.2.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       cors: 2.8.5
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  nextjs-routes@2.2.5(next@16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
+  nextjs-routes@2.2.5(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)):
     dependencies:
       chokidar: 4.0.1
-      next: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
   ngraph.events@1.4.0: {}
 
@@ -21251,7 +21160,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -21422,12 +21331,6 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
-
-  pretty-format@30.2.0:
-    dependencies:
-      '@jest/schemas': 30.0.5
-      ansi-styles: 5.2.0
-      react-is: 18.3.1
 
   pretty-format@30.4.1:
     dependencies:
@@ -21824,11 +21727,11 @@ snapshots:
 
   redis@5.12.1(@opentelemetry/api@1.9.1):
     dependencies:
-      '@redis/bloom': 5.12.1(@redis/client@5.12.1)
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
-      '@redis/json': 5.12.1(@redis/client@5.12.1)
-      '@redis/search': 5.12.1(@redis/client@5.12.1)
-      '@redis/time-series': 5.12.1(@redis/client@5.12.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
@@ -22488,12 +22391,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(@babel/core@7.27.4)(react@19.2.6):
+  styled-jsx@5.1.6(react@19.2.6):
     dependencies:
       client-only: 0.0.1
       react: 19.2.6
-    optionalDependencies:
-      '@babel/core': 7.27.4
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Wire up Jest + @swc/jest in the utils package (no tests existed before)
- Add unit tests for all pure functions: math, objects, fitting (EFT parse/serialize), esi label helpers, SDE name formatters, and skill-level numeral converter

## Test plan
- [ ] `pnpm --filter @jitaspace/utils test` passes locally
- [ ] All deterministic helpers have concrete expected-value assertions
- [ ] parseEFTFitString / toEFTFitString roundtrip tested
- [ ] Edge cases covered (0, negatives, special IDs, unknown label IDs)