### PR TITLE
refactor(db,kv,chat): stop packages reading env; inject config from apps

### DIFF
--- a/.changeset/env-injection-factories.md
+++ b/.changeset/env-injection-factories.md
@@ -1,0 +1,20 @@
+---
+"@jitaspace/db": minor
+"@jitaspace/kv": minor
+"@jitaspace/chat": minor
+"@jitaspace/eve-scrape": patch
+"@jitaspace/web": patch
+---
+
+refactor(db,kv,chat): replace self-initialising singletons with factories
+
+`@jitaspace/db`, `@jitaspace/kv`, and `@jitaspace/chat` previously read
+environment variables at module load. They now export factory functions
+instead of singletons:
+
+- `@jitaspace/db` — `createPrismaClient({ connectionString, logQueries? })`
+- `@jitaspace/kv` — `createKv({ redisUrl })` (async, returns `{ redis, kv }`)
+- `@jitaspace/chat` — `createChat({ discordBotToken?, discordUpdatesChannelId? })`
+
+Apps build the instance from their own validated env in a thin local shim.
+`eve-scrape` and `web` have been updated accordingly.

--- a/apps/web/app/active-wars/page.tsx
+++ b/apps/web/app/active-wars/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
     "Live list of active wars in EVE Online — track ongoing conflicts between corporations and alliances.",
 };
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { WarsIcon } from "@jitaspace/eve-icons";
 
 import { WarsTable } from "~/components/Wars";

--- a/apps/web/app/agents/page.tsx
+++ b/apps/web/app/agents/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
   description: "Browse EVE Online NPC agents and their locations.",
 };
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { AgentFinderIcon } from "@jitaspace/eve-icons";
 import { removeUndefinedFields } from "@jitaspace/utils";
 

--- a/apps/web/app/bloodline/[bloodlineId]/page.tsx
+++ b/apps/web/app/bloodline/[bloodlineId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/categories/page.tsx
+++ b/apps/web/app/categories/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
     "Browse all EVE Online item categories — ships, modules, ammunition, structures, and more.",
 };
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { ItemsIcon } from "@jitaspace/eve-icons";
 import { CategoryAnchor } from "@jitaspace/ui";
 

--- a/apps/web/app/category/[categoryId]/page.tsx
+++ b/apps/web/app/category/[categoryId]/page.tsx
@@ -4,7 +4,7 @@ import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { Container, Group, Loader, SimpleGrid, Stack, Text, Title } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { CategoryBreadcrumbs, GroupAnchor } from "@jitaspace/ui";
 
 interface PageProps {

--- a/apps/web/app/constellation/[constellationId]/page.tsx
+++ b/apps/web/app/constellation/[constellationId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/debug/page.tsx
+++ b/apps/web/app/debug/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { connection } from "next/server";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import DebugPage from "./page.client";
 import type { PageProps } from "./page.client";
@@ -13,10 +13,10 @@ export async function DebugPageContent() {
   }
   await connection();
 
-  // Dynamic import: @jitaspace/kv connects to Redis at module load time via
+  // Dynamic import: ~/lib/kv connects to Redis at module load time via
   // top-level await, so it must not be statically imported at the module level
   // or Next.js will attempt the connection during build-time config collection.
-  const { kv } = await import("@jitaspace/kv");
+  const { kv } = await import("~/lib/kv");
   const queues = Object.values(kv.queues);
 
   const queuesStatus = await Promise.all(

--- a/apps/web/app/dogma/attribute/[attributeId]/page.tsx
+++ b/apps/web/app/dogma/attribute/[attributeId]/page.tsx
@@ -4,7 +4,7 @@ import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import type { PageProps } from "./page.client";
 import DogmaAttributePage from "./page.client";

--- a/apps/web/app/dogma/attributes/page.tsx
+++ b/apps/web/app/dogma/attributes/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 export const metadata = {
   title: "Dogma Attributes",

--- a/apps/web/app/dogma/effect/[effectId]/page.tsx
+++ b/apps/web/app/dogma/effect/[effectId]/page.tsx
@@ -4,7 +4,7 @@ import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import DogmaEffectPage from "./page.client";
 import type { PageProps } from "./page.client";

--- a/apps/web/app/dogma/effects/page.tsx
+++ b/apps/web/app/dogma/effects/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 export const metadata = {
   title: "Dogma Effects",

--- a/apps/web/app/faction/[factionId]/page.tsx
+++ b/apps/web/app/faction/[factionId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/group/[groupId]/page.tsx
+++ b/apps/web/app/group/[groupId]/page.tsx
@@ -4,7 +4,7 @@ import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { Container, Group, Loader, SimpleGrid, Stack, Text, Title } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { TypeAnchor, TypeAvatar } from "@jitaspace/ui";
 
 import { GroupBreadcrumbs } from "~/components/Breadcrumbs";

--- a/apps/web/app/lp-store/[corporationId]/page.tsx
+++ b/apps/web/app/lp-store/[corporationId]/page.tsx
@@ -4,7 +4,7 @@ import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import LPStoreCorporationPage from "./page.client";
 import type { LPStoreCorporationPageProps } from "./page.client";

--- a/apps/web/app/lp-store/all/page.tsx
+++ b/apps/web/app/lp-store/all/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 export const metadata = {
   title: "All LP Store Offers",

--- a/apps/web/app/lp-store/page.tsx
+++ b/apps/web/app/lp-store/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import LPStorePage from "./page.client";
 import type { LPStorePageProps } from "./page.client";

--- a/apps/web/app/planet/[planetId]/page.tsx
+++ b/apps/web/app/planet/[planetId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/race/[raceId]/page.tsx
+++ b/apps/web/app/race/[raceId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/region/[regionId]/page.tsx
+++ b/apps/web/app/region/[regionId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/regions/page.tsx
+++ b/apps/web/app/regions/page.tsx
@@ -9,7 +9,7 @@ export const metadata = {
     "Browse all regions in the EVE Online universe — New Eden's star clusters, systems, and constellations.",
 };
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { MapIcon } from "@jitaspace/eve-icons";
 import { RegionAnchor } from "@jitaspace/ui";
 

--- a/apps/web/app/ship-scanner/page.tsx
+++ b/apps/web/app/ship-scanner/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import ShipScannerPage from "./page.client";
 import type { PageProps } from "./page.client";

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -2,7 +2,7 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { MetadataRoute } from "next";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import { CONFIG } from "~/config/constants.ts";
 

--- a/apps/web/app/skills/page.tsx
+++ b/apps/web/app/skills/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import SkillsPage from "./page.client";
 import type { SkillsPageProps } from "./page.client";

--- a/apps/web/app/star/[starId]/page.tsx
+++ b/apps/web/app/star/[starId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/station/[stationId]/page.tsx
+++ b/apps/web/app/station/[stationId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/system/[systemId]/page.tsx
+++ b/apps/web/app/system/[systemId]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
 

--- a/apps/web/app/travel/[[...waypoints]]/page.tsx
+++ b/apps/web/app/travel/[[...waypoints]]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 import { toArrayIfNot } from "@jitaspace/utils";
 
 import TravelPage from "./page.client";

--- a/apps/web/app/type/[typeId]/page.tsx
+++ b/apps/web/app/type/[typeId]/page.tsx
@@ -5,7 +5,7 @@ import type { Metadata } from "next";
 import { HttpStatusCode } from "axios";
 import { Loader } from "@mantine/core";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import TypePage from "./page.client";
 import type { PageProps } from "./page.client";

--- a/apps/web/components/Market/MarketGroupsNavigation.tsx
+++ b/apps/web/components/Market/MarketGroupsNavigation.tsx
@@ -1,6 +1,6 @@
 import { cacheLife } from "next/cache";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "~/lib/db";
 
 import { MarketGroupNavLink } from "./MarketGroupNavLink";
 

--- a/apps/web/lib/db.ts
+++ b/apps/web/lib/db.ts
@@ -1,0 +1,28 @@
+import type { Db } from "@jitaspace/db";
+import { createPrismaClient } from "@jitaspace/db";
+
+import { env } from "~/env";
+
+/**
+ * App-level Prisma singleton.
+ *
+ * `@jitaspace/db` reads no environment variables; we build the client here from
+ * the web app's validated env. We re-export everything from `@jitaspace/db` so
+ * callers can get both the client and the generated types/models from a single
+ * module (`import { prisma } from "~/lib/db"`).
+ *
+ * The instance is cached on `globalThis` (under a shared key) to avoid creating
+ * a new client/connection pool on every hot reload in development.
+ */
+const globalForPrisma = globalThis as { __jitaspacePrisma?: Db };
+
+export const prisma =
+  globalForPrisma.__jitaspacePrisma ??
+  createPrismaClient({
+    connectionString: env.DATABASE_URL,
+    logQueries: env.NODE_ENV === "development",
+  });
+
+if (env.NODE_ENV !== "production") globalForPrisma.__jitaspacePrisma = prisma;
+
+export * from "@jitaspace/db";

--- a/apps/web/lib/kv.ts
+++ b/apps/web/lib/kv.ts
@@ -1,0 +1,17 @@
+import { createKv } from "@jitaspace/kv";
+
+import { env } from "~/env";
+
+/**
+ * App-level Redis/queues singleton.
+ *
+ * `@jitaspace/kv` reads no environment variables; we build the client and queues
+ * here from the web app's validated env. We re-export everything from
+ * `@jitaspace/kv` so callers get the client, queues and types from one module.
+ *
+ * Note: this module connects to Redis at load time (top-level await), so import
+ * it dynamically where you must defer the connection (see app/debug/page.tsx).
+ */
+export const { redis, kv } = await createKv({ redisUrl: env.REDIS_URL });
+
+export * from "@jitaspace/kv";

--- a/apps/web/tests/debug.test.tsx
+++ b/apps/web/tests/debug.test.tsx
@@ -9,11 +9,11 @@ import {
 
 import { env } from "~/env.ts";
 
-jest.mock("@jitaspace/db", () => ({
+jest.mock("~/lib/db", () => ({
   prisma: {},
 }));
 
-jest.mock("@jitaspace/kv", () => ({
+jest.mock("~/lib/kv", () => ({
   kv: {
     queues: {},
   },

--- a/apps/web/tests/groupPage.test.tsx
+++ b/apps/web/tests/groupPage.test.tsx
@@ -18,7 +18,7 @@ const mockNotFound = jest.fn(() => {
   throw new Error("NEXT_NOT_FOUND");
 });
 
-jest.mock("@jitaspace/db", () => ({
+jest.mock("~/lib/db", () => ({
   prisma: {
     group: {
       findUniqueOrThrow: (...args: unknown[]) =>

--- a/apps/web/tests/seoMetadataEntities.test.ts
+++ b/apps/web/tests/seoMetadataEntities.test.ts
@@ -36,7 +36,7 @@ const mockDogmaAttributeFindUnique = jest.fn();
 const mockDogmaEffectFindUnique = jest.fn();
 const mockCorporationFindUnique = jest.fn();
 
-jest.mock("@jitaspace/db", () => ({
+jest.mock("~/lib/db", () => ({
   prisma: {
     race: { findUnique: (...a: unknown[]) => mockRaceFindUnique(...a) },
     bloodline: { findUnique: (...a: unknown[]) => mockBloodlineFindUnique(...a) },

--- a/apps/web/tests/seoMetadataUniverse.test.ts
+++ b/apps/web/tests/seoMetadataUniverse.test.ts
@@ -25,7 +25,7 @@ const mockStarFindUnique = jest.fn();
 const mockPlanetFindUnique = jest.fn();
 const mockStationFindUnique = jest.fn();
 
-jest.mock("@jitaspace/db", () => ({
+jest.mock("~/lib/db", () => ({
   prisma: {
     region: { findUnique: (...a: unknown[]) => mockRegionFindUnique(...a) },
     constellation: { findUnique: (...a: unknown[]) => mockConstellationFindUnique(...a) },

--- a/apps/web/tests/systemPage.test.tsx
+++ b/apps/web/tests/systemPage.test.tsx
@@ -13,7 +13,7 @@ const mockUseSolarSystemCostIndices = jest.fn();
 const mockUseGetSolarSystemById = jest.fn();
 
 // system/[systemId]/page.tsx now imports prisma for generateMetadata
-jest.mock("@jitaspace/db", () => ({
+jest.mock("~/lib/db", () => ({
   prisma: {
     solarSystem: { findUnique: jest.fn().mockResolvedValue(null) },
   },

--- a/packages/chat/index.tsx
+++ b/packages/chat/index.tsx
@@ -52,7 +52,9 @@ export function createChat({
   discordBotToken,
   discordUpdatesChannelId,
 }: CreateChatOptions = {}) {
-  const discordAdapter = discordBotToken ? createDiscordAdapter() : undefined;
+  const discordAdapter = discordBotToken
+    ? createDiscordAdapter({ botToken: discordBotToken })
+    : undefined;
 
   const chat = new Chat({
     userName: "JitaSpace",

--- a/packages/chat/index.tsx
+++ b/packages/chat/index.tsx
@@ -1,79 +1,28 @@
+import type { CardChild, FieldElement } from "chat";
 import { createDiscordAdapter } from "@chat-adapter/discord";
 import { createRedisState } from "@chat-adapter/state-redis";
 import {
   Actions,
   Button,
   Card,
-  CardChild,
   CardText,
   Chat,
   Divider,
   Field,
-  FieldElement,
   Fields,
   CardText as Text,
 } from "chat";
 
-const discordAdapter = process.env.DISCORD_BOT_TOKEN
-  ? createDiscordAdapter()
-  : undefined;
-
-export const chat = new Chat({
-  userName: "JitaSpace",
-  adapters: discordAdapter
-    ? {
-        discord: discordAdapter,
-      }
-    : {},
-  state: createRedisState(),
-});
-
-// Respond when someone @mentions the bot
-chat.onNewMention(async (thread) => {
-  await thread.subscribe();
-  await thread.post(
-    Card({
-      title: "Support",
-      children: [
-        Text(
-          "Hey! I'm here to help. Ask your question in this thread and I'll do my best to answer it.",
-        ),
-        Divider(),
-        Actions([
-          Button({
-            id: "escalate",
-            style: "danger",
-            label: "Do not click this test button",
-          }),
-        ]),
-      ],
-    }),
-  );
-});
-
-const updatesChannelId = process.env.DISCORD_UPDATES_CHANNEL_ID;
-
-export const updatesChannel =
-  discordAdapter && updatesChannelId
-    ? chat.channel(`discord:1127970667522949201:${updatesChannelId}`)
-    : null;
-
-// Respond when someone clicks escalate button
-chat.onAction("escalate", async (event) => {
-  await event.thread?.post(
-    `${event.user.fullName} disobeyed and clicked the test button.`,
-  );
-});
-
-// Respond to follow-up messages in subscribed threads
-chat.onSubscribedMessage(async (thread, message) => {
-  await thread.startTyping();
-  await thread.post(`You said: ${message.text}`);
-});
+export interface CreateChatOptions {
+  /** Discord bot token. When absent, the Discord adapter is disabled. */
+  discordBotToken?: string;
+  /** Discord channel id used for posting update cards. */
+  discordUpdatesChannelId?: string;
+}
 
 type UpdateStatus = "success" | "idle" | "rate_limited" | "failed";
 
-type UpdateCardOptions = {
+interface UpdateCardOptions {
   status: UpdateStatus;
   summary: string;
   processed?: number;
@@ -84,7 +33,7 @@ type UpdateCardOptions = {
   attackers?: number;
   victimItems?: number;
   throttledUntil?: string | null;
-};
+}
 
 const STATUS_LABELS: Record<UpdateStatus, string> = {
   success: "Success",
@@ -93,44 +42,108 @@ const STATUS_LABELS: Record<UpdateStatus, string> = {
   failed: "Failed",
 };
 
-export const postUpdateCard = async (options: UpdateCardOptions) => {
-  if (!updatesChannel) {
-    return;
-  }
+/**
+ * Create the chat bot (Discord adapter + handlers) and its helpers.
+ *
+ * This package reads no environment variables: callers (apps) inject the Discord
+ * bot token and updates-channel id from their own validated env.
+ */
+export function createChat({
+  discordBotToken,
+  discordUpdatesChannelId,
+}: CreateChatOptions = {}) {
+  const discordAdapter = discordBotToken ? createDiscordAdapter() : undefined;
 
-  const fields: FieldElement[] = [];
-  const addField = (
-    label: string,
-    value: string | number | bigint | null | undefined,
-  ) => {
-    if (value === null || value === undefined) return;
-    fields.push(
-      Field({
-        label,
-        value: value.toString(),
+  const chat = new Chat({
+    userName: "JitaSpace",
+    adapters: discordAdapter ? { discord: discordAdapter } : {},
+    state: createRedisState(),
+  });
+
+  // Respond when someone @mentions the bot
+  chat.onNewMention(async (thread) => {
+    await thread.subscribe();
+    await thread.post(
+      Card({
+        title: "Support",
+        children: [
+          Text(
+            "Hey! I'm here to help. Ask your question in this thread and I'll do my best to answer it.",
+          ),
+          Divider(),
+          Actions([
+            Button({
+              id: "escalate",
+              style: "danger",
+              label: "Do not click this test button",
+            }),
+          ]),
+        ],
+      }),
+    );
+  });
+
+  const updatesChannel =
+    discordAdapter && discordUpdatesChannelId
+      ? chat.channel(`discord:1127970667522949201:${discordUpdatesChannelId}`)
+      : null;
+
+  // Respond when someone clicks escalate button
+  chat.onAction("escalate", async (event) => {
+    await event.thread?.post(
+      `${event.user.fullName} disobeyed and clicked the test button.`,
+    );
+  });
+
+  // Respond to follow-up messages in subscribed threads
+  chat.onSubscribedMessage(async (thread, message) => {
+    await thread.startTyping();
+    await thread.post(`You said: ${message.text}`);
+  });
+
+  const postUpdateCard = async (options: UpdateCardOptions) => {
+    if (!updatesChannel) {
+      return;
+    }
+
+    const fields: FieldElement[] = [];
+    const addField = (
+      label: string,
+      value: string | number | bigint | null | undefined,
+    ) => {
+      if (value === null || value === undefined) return;
+      fields.push(
+        Field({
+          label,
+          value: value.toString(),
+        }),
+      );
+    };
+
+    addField("Processed", options.processed);
+    addField("Range", options.range);
+    addField("Lag", options.lag);
+    addField("Latest cursor", options.latestSequence ?? null);
+    addField("Next cursor", options.nextSequence ?? null);
+    addField("Attackers", options.attackers);
+    addField("Victim items", options.victimItems);
+    addField("Throttled until", options.throttledUntil ?? null);
+
+    const children: CardChild[] = [CardText(options.summary)];
+    if (fields.length > 0) {
+      children.push(Divider(), Fields(fields));
+    }
+
+    await updatesChannel.post(
+      Card({
+        title: "scrapeRecentKills",
+        subtitle: STATUS_LABELS[options.status],
+        children,
       }),
     );
   };
 
-  addField("Processed", options.processed);
-  addField("Range", options.range);
-  addField("Lag", options.lag);
-  addField("Latest cursor", options.latestSequence ?? null);
-  addField("Next cursor", options.nextSequence ?? null);
-  addField("Attackers", options.attackers);
-  addField("Victim items", options.victimItems);
-  addField("Throttled until", options.throttledUntil ?? null);
+  return { chat, updatesChannel, postUpdateCard };
+}
 
-  const children: CardChild[] = [CardText(options.summary)];
-  if (fields.length > 0) {
-    children.push(Divider(), Fields(fields));
-  }
-
-  await updatesChannel.post(
-    Card({
-      title: "scrapeRecentKills",
-      subtitle: STATUS_LABELS[options.status],
-      children,
-    }),
-  );
-};
+export type ChatInstance = ReturnType<typeof createChat>;

--- a/packages/chat/jest.config.ts
+++ b/packages/chat/jest.config.ts
@@ -1,0 +1,43 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  testEnvironment: "node",
+  testEnvironmentOptions: {
+    customExportConditions: ["require", "node", "default"],
+  },
+  testMatch: ["<rootDir>/tests/**/*.test.ts", "<rootDir>/tests/**/*.test.tsx"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "es2022",
+          parser: { syntax: "typescript", tsx: true },
+        },
+        module: { type: "commonjs" },
+      },
+    ],
+  },
+  // `chat`, `@chat-adapter/discord`, and `@chat-adapter/state-redis` are
+  // ESM-only packages (their exports map only has "import", no "require").
+  // Jest runs in CJS mode and Node's exports resolver throws
+  // ERR_PACKAGE_PATH_NOT_EXPORTED for them. We bypass the exports map by
+  // pointing directly at the dist entry point.
+  moduleNameMapper: {
+    "^chat$":
+      "<rootDir>/../../node_modules/chat/dist/index.js",
+    "^@chat-adapter/discord$":
+      "<rootDir>/../../node_modules/@chat-adapter/discord/dist/index.js",
+    "^@chat-adapter/state-redis$":
+      "<rootDir>/../../node_modules/@chat-adapter/state-redis/dist/index.js",
+  },
+  transformIgnorePatterns: ["/node_modules/(?!(@jitaspace))"],
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  coverageReporters: ["lcovonly", "text"],
+  collectCoverageFrom: ["index.tsx"],
+  clearMocks: true,
+  restoreMocks: true,
+};
+
+export default config;

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -11,6 +11,7 @@
     "clean": "rm -rf .turbo node_modules",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
+    "test": "jest",
     "type-check": "tsc --jsx react-jsx --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
@@ -22,12 +23,16 @@
     "pg": "^8.21.0"
   },
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
     "@jitaspace/eslint-config": "workspace:*",
     "@jitaspace/prettier-config": "workspace:*",
     "@jitaspace/tsconfig": "workspace:*",
+    "@swc/jest": "^0.2.39",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.12.4",
     "@types/pg": "^8.20.0",
     "eslint": "^9.39.4",
+    "jest": "^30.4.2",
     "prettier": "^3.8.3",
     "typescript": "^5.9.3"
   },

--- a/packages/chat/tests/createChat.test.ts
+++ b/packages/chat/tests/createChat.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for createChat() in packages/chat/index.tsx.
+ *
+ * Key invariant: the caller-supplied Discord bot token must be forwarded to
+ * createDiscordAdapter({ botToken }) so the adapter never falls back to
+ * process.env.DISCORD_BOT_TOKEN.
+ */
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+// ---------------------------------------------------------------------------
+// Mock external chat packages — the real ones hit Discord / Redis.
+// ---------------------------------------------------------------------------
+
+const mockChatInstance = {
+  onNewMention: jest.fn(),
+  onAction: jest.fn(),
+  onSubscribedMessage: jest.fn(),
+  channel: jest.fn().mockReturnValue({ post: jest.fn() }),
+};
+
+jest.mock("chat", () => ({
+  Chat: jest.fn().mockImplementation(() => mockChatInstance),
+  Card: jest.fn(),
+  CardText: jest.fn(),
+  Divider: jest.fn(),
+  Actions: jest.fn(),
+  Button: jest.fn(),
+  Field: jest.fn(),
+  Fields: jest.fn(),
+}));
+
+const mockCreateDiscordAdapter = jest.fn().mockReturnValue({});
+jest.mock("@chat-adapter/discord", () => ({
+  createDiscordAdapter: (...args: unknown[]) =>
+    mockCreateDiscordAdapter(...args),
+}));
+
+jest.mock("@chat-adapter/state-redis", () => ({
+  createRedisState: jest.fn().mockReturnValue({}),
+}));
+
+// ---------------------------------------------------------------------------
+
+describe("createChat", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockCreateDiscordAdapter.mockClear();
+  });
+
+  it("passes the injected botToken to createDiscordAdapter", async () => {
+    const { createChat } = await import("../index.tsx");
+    createChat({ discordBotToken: "tok-abc-123" });
+    expect(mockCreateDiscordAdapter).toHaveBeenCalledTimes(1);
+    expect(mockCreateDiscordAdapter).toHaveBeenCalledWith({
+      botToken: "tok-abc-123",
+    });
+  });
+
+  it("does not call createDiscordAdapter when no token is provided", async () => {
+    const { createChat } = await import("../index.tsx");
+    createChat({});
+    expect(mockCreateDiscordAdapter).not.toHaveBeenCalled();
+  });
+
+  it("does not call createDiscordAdapter when called with no arguments", async () => {
+    const { createChat } = await import("../index.tsx");
+    createChat();
+    expect(mockCreateDiscordAdapter).not.toHaveBeenCalled();
+  });
+
+  it("sets updatesChannel when both token and channelId are provided", async () => {
+    const { createChat } = await import("../index.tsx");
+    const { updatesChannel } = createChat({
+      discordBotToken: "tok-abc-123",
+      discordUpdatesChannelId: "chan-999",
+    });
+    expect(updatesChannel).not.toBeNull();
+  });
+
+  it("sets updatesChannel to null when token is absent", async () => {
+    const { createChat } = await import("../index.tsx");
+    const { updatesChannel } = createChat({
+      discordUpdatesChannelId: "chan-999",
+    });
+    expect(updatesChannel).toBeNull();
+  });
+
+  it("sets updatesChannel to null when channelId is absent", async () => {
+    const { createChat } = await import("../index.tsx");
+    const { updatesChannel } = createChat({ discordBotToken: "tok-abc-123" });
+    expect(updatesChannel).toBeNull();
+  });
+
+  it("returns chat, updatesChannel, and postUpdateCard", async () => {
+    const { createChat } = await import("../index.tsx");
+    const result = createChat();
+    expect(result).toHaveProperty("chat");
+    expect(result).toHaveProperty("updatesChannel");
+    expect(result).toHaveProperty("postUpdateCard");
+    expect(typeof result.postUpdateCard).toBe("function");
+  });
+});

--- a/packages/db/index.ts
+++ b/packages/db/index.ts
@@ -2,20 +2,32 @@ import { PrismaPg } from "@prisma/adapter-pg";
 
 import { PrismaClient } from "./prisma/generated/client";
 
-const globalForPrisma = globalThis as { prisma?: PrismaClient };
+export interface CreatePrismaClientOptions {
+  /** PostgreSQL/CockroachDB connection string. */
+  connectionString: string;
+  /** Log every query (handy in development). Defaults to `false`. */
+  logQueries?: boolean;
+}
 
-const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
-
-export const prisma =
-  globalForPrisma.prisma ||
-  new PrismaClient({
+/**
+ * Create a {@link PrismaClient}.
+ *
+ * This package intentionally reads no environment variables: callers (apps)
+ * inject the connection string and options from their own validated env. See
+ * `apps/web/lib/db.ts` and `packages/eve-scrape/db.ts` for the per-consumer
+ * singletons.
+ */
+export function createPrismaClient({
+  connectionString,
+  logQueries = false,
+}: CreatePrismaClientOptions) {
+  const adapter = new PrismaPg({ connectionString });
+  return new PrismaClient({
     adapter,
-    log:
-      process.env.NODE_ENV === "development"
-        ? ["query", "info", "error", "warn"]
-        : ["error"],
+    log: logQueries ? ["query", "info", "error", "warn"] : ["error"],
   });
+}
 
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+export type Db = ReturnType<typeof createPrismaClient>;
 
 export * from "./prisma/generated/client";

--- a/packages/db/prisma.config.ts
+++ b/packages/db/prisma.config.ts
@@ -1,6 +1,4 @@
-import "dotenv/config";
-
-import { defineConfig, env } from "prisma/config";
+import { defineConfig } from "prisma/config";
 
 export default defineConfig({
   schema: "prisma/schema.prisma",
@@ -8,6 +6,6 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
-    url: env("DATABASE_URL"),
+    url: process.env.DATABASE_URL ?? "",
   },
 });

--- a/packages/eve-scrape/chat.ts
+++ b/packages/eve-scrape/chat.ts
@@ -1,0 +1,22 @@
+import { createChat } from "@jitaspace/chat";
+
+import { env } from "./env";
+
+/**
+ * Per-package chat bot singleton.
+ *
+ * `@jitaspace/chat` reads no environment variables; we build the bot here from
+ * this package's validated env. We re-export everything from `@jitaspace/chat`
+ * so callers get the helpers and types from one module
+ * (`import { postUpdateCard } from "../../../chat"`).
+ */
+// `@jitaspace/chat` is fully typed and type-checks, but eve-scrape's
+// type-aware lint resolves this workspace import as `any` — a pre-existing
+// cross-package limitation that affects other imports in this package too.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+export const { chat, updatesChannel, postUpdateCard } = createChat({
+  discordBotToken: env.DISCORD_BOT_TOKEN,
+  discordUpdatesChannelId: env.DISCORD_UPDATES_CHANNEL_ID,
+});
+
+export * from "@jitaspace/chat";

--- a/packages/eve-scrape/db.ts
+++ b/packages/eve-scrape/db.ts
@@ -1,0 +1,29 @@
+import type { Db } from "@jitaspace/db";
+import { createPrismaClient } from "@jitaspace/db";
+
+import { env } from "./env";
+
+/**
+ * Per-package Prisma singleton.
+ *
+ * `@jitaspace/db` reads no environment variables; we build the client here from
+ * this package's validated env. We re-export everything from `@jitaspace/db` so
+ * callers can get both the client and the generated types/models from a single
+ * module (`import { prisma, Prisma } from "../../../db"`).
+ *
+ * The instance is cached on `globalThis` under a shared key so that, in a single
+ * process (e.g. local dev / the Next.js Inngest route), this package and the web
+ * app reuse one client/connection pool instead of opening two.
+ */
+const globalForPrisma = globalThis as { __jitaspacePrisma?: Db };
+
+export const prisma =
+  globalForPrisma.__jitaspacePrisma ??
+  createPrismaClient({
+    connectionString: env.DATABASE_URL,
+    logQueries: env.NODE_ENV === "development",
+  });
+
+if (env.NODE_ENV !== "production") globalForPrisma.__jitaspacePrisma = prisma;
+
+export * from "@jitaspace/db";

--- a/packages/eve-scrape/env.ts
+++ b/packages/eve-scrape/env.ts
@@ -6,6 +6,10 @@ import { z } from "zod";
  */
 const server = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).optional(),
+  DATABASE_URL: z.string().url(),
+  REDIS_URL: z.string(),
+  DISCORD_BOT_TOKEN: z.string().optional(),
+  DISCORD_UPDATES_CHANNEL_ID: z.string().optional(),
   INNGEST_EVENT_KEY:
     process.env.NODE_ENV === "production"
       ? z.string().min(1)
@@ -28,6 +32,10 @@ const client = z.object({});
  */
 const processEnv = {
   NODE_ENV: process.env.NODE_ENV,
+  DATABASE_URL: process.env.DATABASE_URL,
+  REDIS_URL: process.env.REDIS_URL,
+  DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN,
+  DISCORD_UPDATES_CHANNEL_ID: process.env.DISCORD_UPDATES_CHANNEL_ID,
   INNGEST_EVENT_KEY: process.env.INNGEST_EVENT_KEY,
   INNGEST_SIGNING_KEY: process.env.INNGEST_SIGNING_KEY,
 };

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiAncestries.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiAncestries.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseAncestries } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiBloodlines.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiBloodlines.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseBloodlines } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiCategories.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiCategories.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getUniverseCategories,
   getUniverseCategoriesCategoryId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiConstellations.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiConstellations.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getUniverseConstellations,
   getUniverseConstellationsConstellationId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiCorporations.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiCorporations.ts
@@ -1,7 +1,7 @@
 import { eventType, NonRetriableError, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getCharactersCharacterId,
   getCorporationsCorporationId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiDogmaAttributes.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiDogmaAttributes.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getDogmaAttributes,
   getDogmaAttributesAttributeId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiDogmaEffects.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiDogmaEffects.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getDogmaEffects,
   getDogmaEffectsEffectId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiFactions.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiFactions.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseFactions } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiGraphics.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiGraphics.ts
@@ -1,5 +1,5 @@
 import { eventType, staticSchema } from "inngest";
-import {prisma} from "@jitaspace/db";
+import {prisma} from "../../../db";
 import {getUniverseGraphics, getUniverseGraphicsGraphicId,} from "@jitaspace/esi-client";
 import axios from "axios";
 import pLimit from "p-limit";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiGroups.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiGroups.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getUniverseGroups,
   getUniverseGroupsGroupId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiLoyaltyStoreOffers.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiLoyaltyStoreOffers.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getCorporationsNpccorps,
   getLoyaltyStoresCorporationIdOffers,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiMarketGroups.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiMarketGroups.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema, NonRetriableError } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getMarketsGroups,
   getMarketsGroupsMarketGroupId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiMoons.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiMoons.ts
@@ -1,7 +1,7 @@
 import { eventType, NonRetriableError, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseMoonsMoonId } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiNpcCorporations.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiNpcCorporations.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getCharactersCharacterId,
   getCorporationsCorporationId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiPlanets.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiPlanets.ts
@@ -1,7 +1,7 @@
 import { eventType, NonRetriableError, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniversePlanetsPlanetId } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiRaces.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiRaces.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseRaces } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiRegions.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiRegions.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getUniverseRegions,
   getUniverseRegionsRegionId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiSolarSystems.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiSolarSystems.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { Prisma, prisma } from "@jitaspace/db";
+import { Prisma, prisma } from "../../../db";
 import {
   getUniverseAsteroidBeltsAsteroidBeltId,
   getUniverseMoonsMoonId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiStargates.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiStargates.ts
@@ -1,7 +1,7 @@
 import { eventType, NonRetriableError, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseStargatesStargateId } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiStations.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiStations.ts
@@ -1,7 +1,7 @@
 import { eventType, NonRetriableError, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getUniverseStationsStationId } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiTypes.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiTypes.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getUniverseTypes,
   getUniverseTypesTypeId,

--- a/packages/eve-scrape/functions/scrape/esi/scrapeEsiWars.ts
+++ b/packages/eve-scrape/functions/scrape/esi/scrapeEsiWars.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getWars, getWarsWarId } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/esi/updateWars.ts
+++ b/packages/eve-scrape/functions/scrape/esi/updateWars.ts
@@ -1,4 +1,4 @@
-import { prisma, War } from "@jitaspace/db";
+import { prisma, War } from "../../../db";
 import { getWars, getWarsWarId } from "@jitaspace/esi-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/evekill/backfillAllianceIds.ts
+++ b/packages/eve-scrape/functions/scrape/evekill/backfillAllianceIds.ts
@@ -1,6 +1,6 @@
 import { eventType, staticSchema } from "inngest";
 
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 

--- a/packages/eve-scrape/functions/scrape/evekill/backfillCharacterIds.ts
+++ b/packages/eve-scrape/functions/scrape/evekill/backfillCharacterIds.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 

--- a/packages/eve-scrape/functions/scrape/evekill/backfillCorporationIds.ts
+++ b/packages/eve-scrape/functions/scrape/evekill/backfillCorporationIds.ts
@@ -1,6 +1,6 @@
 import { eventType, staticSchema } from "inngest";
 
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 

--- a/packages/eve-scrape/functions/scrape/everef/backfillWars.ts
+++ b/packages/eve-scrape/functions/scrape/everef/backfillWars.ts
@@ -5,7 +5,7 @@ import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
 import { GetWarsWarId200 } from "@jitaspace/esi-client";
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 import { BatchStepResult } from "../../../types";

--- a/packages/eve-scrape/functions/scrape/hoboleaks/scrapeHoboleaksAgentTypes.ts
+++ b/packages/eve-scrape/functions/scrape/hoboleaks/scrapeHoboleaksAgentTypes.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 
 import { client } from "../../../client";
 import { excludeObjectKeys, updateTable } from "../../../utils";

--- a/packages/eve-scrape/functions/scrape/hoboleaks/scrapeHoboleaksDogmaEffectCategories.ts
+++ b/packages/eve-scrape/functions/scrape/hoboleaks/scrapeHoboleaksDogmaEffectCategories.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 
 import { client } from "../../../client";
 import { excludeObjectKeys, updateTable } from "../../../utils";

--- a/packages/eve-scrape/functions/scrape/hoboleaks/scrapeHoboleaksDogmaUnits.ts
+++ b/packages/eve-scrape/functions/scrape/hoboleaks/scrapeHoboleaksDogmaUnits.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 
 import { client } from "../../../client";
 import { excludeObjectKeys, updateTable } from "../../../utils";

--- a/packages/eve-scrape/functions/scrape/redis/processAllianceIdsQueue.ts
+++ b/packages/eve-scrape/functions/scrape/redis/processAllianceIdsQueue.ts
@@ -1,6 +1,6 @@
 import { eventType, staticSchema } from "inngest";
 
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 import { createCorpAndItsRefRecords } from "../../../helpers/createCorpAndItsRefs.ts";

--- a/packages/eve-scrape/functions/scrape/redis/processCharacterIdsQueue.ts
+++ b/packages/eve-scrape/functions/scrape/redis/processCharacterIdsQueue.ts
@@ -3,7 +3,7 @@ import { eventType, staticSchema } from "inngest";
 /**
  * Thanks to Karbowiak for the original code that this is based on!
  */
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 import { createCorpAndItsRefRecords } from "../../../helpers/createCorpAndItsRefs.ts";

--- a/packages/eve-scrape/functions/scrape/redis/processCorporationIdsQueue.ts
+++ b/packages/eve-scrape/functions/scrape/redis/processCorporationIdsQueue.ts
@@ -1,6 +1,6 @@
 import { eventType, staticSchema } from "inngest";
 
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 import { createCorpAndItsRefRecords } from "../../../helpers/createCorpAndItsRefs.ts";

--- a/packages/eve-scrape/functions/scrape/redis/processWarsQueue.ts
+++ b/packages/eve-scrape/functions/scrape/redis/processWarsQueue.ts
@@ -4,9 +4,9 @@ import { eventType, staticSchema } from "inngest";
  */
 import pLimit from "p-limit";
 
-import { prisma, War } from "@jitaspace/db";
+import { prisma, War } from "../../../db";
 import { getWarsWarId } from "@jitaspace/esi-client";
-import { kv } from "@jitaspace/kv";
+import { kv } from "../../../kv";
 
 import { client } from "../../../client";
 import { createCorpAndItsRefRecords } from "../../../helpers/createCorpAndItsRefs.ts";

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeAgents.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeAgents.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getCharactersCharacterId } from "@jitaspace/esi-client";
 import {
   getAgentInSpaceById,

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeDogmaAttributeCategories.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeDogmaAttributeCategories.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getAllDogmaAttributeCategoryIds,
   getDogmaAttributeCategoryById,

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeDogmaEffectModifiers.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeDogmaEffectModifiers.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getAllDogmaEffectIds,
   getDogmaEffectById,

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeIcons.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeIcons.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getAllIconIds, getIconById } from "@jitaspace/sde-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeNpcCorporationDivisions.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeNpcCorporationDivisions.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getAllNpcCorporationDivisionIds,
   getNpcCorporationDivisionById,

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeRaces.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeRaces.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import { getAllRaceIds, getRaceById } from "@jitaspace/sde-client";
 
 import { client } from "../../../client";

--- a/packages/eve-scrape/functions/scrape/sde/scrapeSdeStationServices.ts
+++ b/packages/eve-scrape/functions/scrape/sde/scrapeSdeStationServices.ts
@@ -1,7 +1,7 @@
 import { eventType, staticSchema } from "inngest";
 import pLimit from "p-limit";
 
-import { prisma } from "@jitaspace/db";
+import { prisma } from "../../../db";
 import {
   getAllStationServiceIds,
   getStationServiceById,

--- a/packages/eve-scrape/functions/scrape/zkillboard/scrapeRecentKills.ts
+++ b/packages/eve-scrape/functions/scrape/zkillboard/scrapeRecentKills.ts
@@ -1,10 +1,10 @@
 import { eventType, staticSchema } from "inngest";
 
-import type { Prisma } from "@jitaspace/db";
-import { postUpdateCard } from "@jitaspace/chat";
-import { prisma } from "@jitaspace/db";
+import type { Prisma } from "../../../db";
+import { postUpdateCard } from "../../../chat";
+import { prisma } from "../../../db";
 import { GetKillmailsKillmailIdKillmailHash200 } from "@jitaspace/esi-client";
-import { redis } from "@jitaspace/kv";
+import { redis } from "../../../kv";
 
 import { client } from "../../../client";
 import { createCorpAndItsRefRecords } from "../../../helpers/createCorpAndItsRefs.ts";

--- a/packages/eve-scrape/helpers/createCorpAndItsRefs.ts
+++ b/packages/eve-scrape/helpers/createCorpAndItsRefs.ts
@@ -22,7 +22,7 @@ import {
   Race,
   Station,
   War,
-} from "@jitaspace/db";
+} from "../db";
 import {
   getAlliancesAllianceId,
   getCharactersCharacterId,

--- a/packages/eve-scrape/helpers/mergeEntriesIntoCharactersTable.ts
+++ b/packages/eve-scrape/helpers/mergeEntriesIntoCharactersTable.ts
@@ -1,6 +1,6 @@
 import pLimit from "p-limit";
 
-import { Character, prisma } from "@jitaspace/db";
+import { Character, prisma } from "../db";
 import { GetCharactersCharacterIdQueryResponse } from "@jitaspace/esi-client";
 
 import { MAX_DB_PARALLELISM } from "../config";

--- a/packages/eve-scrape/helpers/mergeEntriesIntoCorporationsTable.ts
+++ b/packages/eve-scrape/helpers/mergeEntriesIntoCorporationsTable.ts
@@ -1,6 +1,6 @@
 import pLimit, { LimitFunction } from "p-limit";
 
-import { Corporation, prisma } from "@jitaspace/db";
+import { Corporation, prisma } from "../db";
 import { GetCorporationsCorporationIdQueryResponse } from "@jitaspace/esi-client";
 
 import { MAX_DB_PARALLELISM } from "../config";

--- a/packages/eve-scrape/kv.ts
+++ b/packages/eve-scrape/kv.ts
@@ -1,0 +1,15 @@
+import { createKv } from "@jitaspace/kv";
+
+import { env } from "./env";
+
+/**
+ * Per-package Redis/queues singleton.
+ *
+ * `@jitaspace/kv` reads no environment variables; we build the client and queues
+ * here from this package's validated env. We re-export everything from
+ * `@jitaspace/kv` so callers get the client, queues and types from one module
+ * (`import { kv, redis } from "../../../kv"`).
+ */
+export const { redis, kv } = await createKv({ redisUrl: env.REDIS_URL });
+
+export * from "@jitaspace/kv";

--- a/packages/eve-scrape/tests/registry.test.ts
+++ b/packages/eve-scrape/tests/registry.test.ts
@@ -7,11 +7,11 @@ import type { client as Client, functions as Functions } from "../index";
 // executes the declarative Inngest config (eventType / triggers) we care about
 // here. Mocks are registered before the dynamic import below, so the registry
 // resolves these stubs instead of the real modules.
-jest.mock("@jitaspace/kv", () => ({ redis: {}, kv: { queues: {} } }));
-jest.mock("@jitaspace/db", () => ({ prisma: {}, Prisma: {} }));
+jest.mock("../kv", () => ({ redis: {}, kv: { queues: {} } }));
+jest.mock("../db", () => ({ prisma: {}, Prisma: {} }));
 jest.mock("@jitaspace/esi-client", () => ({}));
 jest.mock("@jitaspace/sde-client", () => ({}));
-jest.mock("@jitaspace/chat", () => ({ postUpdateCard: jest.fn() }));
+jest.mock("../chat", () => ({ postUpdateCard: jest.fn() }));
 // p-limit is ESM-only and only used inside handlers, not in the registry config.
 jest.mock("p-limit", () => ({
   __esModule: true,

--- a/packages/kv/index.ts
+++ b/packages/kv/index.ts
@@ -1,31 +1,39 @@
 import Queue from "bull";
 import { createClient } from "redis";
 
-import { GetWarsWarId200 } from "@jitaspace/esi-client";
+import type { GetWarsWarId200 } from "@jitaspace/esi-client";
 
-export const redis = await createClient({
-  url: process.env.REDIS_URL,
-}).connect();
+export interface CreateKvOptions {
+  /** Redis connection URL. */
+  redisUrl: string;
+}
 
-const keys = {
-  killmails: "killmails",
-  wars: "wars",
-};
+/**
+ * Create the Redis client and Bull queues.
+ *
+ * This package reads no environment variables: callers (apps) inject the Redis
+ * URL from their own validated env. The Redis client is connected eagerly, so
+ * this is async — callers typically `await` it once and re-export the result.
+ */
+export async function createKv({ redisUrl }: CreateKvOptions) {
+  const redis = await createClient({ url: redisUrl }).connect();
 
-export const kv = {
-  queues: {
-    allianceIds: new Queue<{ allianceIds: number[] }>(
-      "allianceIds",
-      process.env.REDIS_URL as string,
-    ),
-    characterIds: new Queue<{ characterIds: number[] }>(
-      "characterIds",
-      process.env.REDIS_URL as string,
-    ),
-    corporationIds: new Queue<{ corporationIds: number[] }>(
-      "corporationIds",
-      process.env.REDIS_URL as string,
-    ),
-    war: new Queue<GetWarsWarId200[]>("wars", process.env.REDIS_URL as string),
-  },
-};
+  const kv = {
+    queues: {
+      allianceIds: new Queue<{ allianceIds: number[] }>("allianceIds", redisUrl),
+      characterIds: new Queue<{ characterIds: number[] }>(
+        "characterIds",
+        redisUrl,
+      ),
+      corporationIds: new Queue<{ corporationIds: number[] }>(
+        "corporationIds",
+        redisUrl,
+      ),
+      war: new Queue<GetWarsWarId200[]>("wars", redisUrl),
+    },
+  };
+
+  return { redis, kv };
+}
+
+export type Kv = Awaited<ReturnType<typeof createKv>>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1
       '@jitaspace/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -557,6 +560,12 @@ importers:
       '@jitaspace/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.40)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -566,6 +575,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3))
       prettier:
         specifier: ^3.8.3
         version: 3.8.3


### PR DESCRIPTION
## What & why

`@jitaspace/db`, `@jitaspace/kv` and `@jitaspace/chat` each read `process.env` at module load (`DATABASE_URL`, `REDIS_URL`, `DISCORD_*`). That:

- forced every consumer to have those vars present at **import time**,
- made the packages violate the shared `restrictEnvAccess` ESLint rule (so they couldn't lint clean), and
- broke `prisma generate` in any environment without a root `.env` (e.g. a fresh `git worktree`), because Prisma 7's `env()` helper **throws** when `DATABASE_URL` is unset — which there cascaded into broken `pnpm install` / `lint` / `type-check`.

This moves env-reading out of those packages and into the apps that consume them.

## How

Each package now exposes a **factory** instead of a self-initialising singleton:

| Package | New API |
|---|---|
| `@jitaspace/db` | `createPrismaClient({ connectionString, logQueries })` |
| `@jitaspace/kv` | `createKv({ redisUrl })` |
| `@jitaspace/chat` | `createChat({ discordBotToken, discordUpdatesChannelId })` |

Consumers build the instance from their **own validated env** in a thin local shim that `export *`s the package, so call-sites only change the import path (combined `value + type` imports keep working):

- `apps/web/lib/{db,kv}.ts` — from web's `~/env`
- `packages/eve-scrape/{db,kv,chat}.ts` — from eve-scrape's `env.ts` (added `REDIS_URL`, `DISCORD_BOT_TOKEN`, `DISCORD_UPDATES_CHANNEL_ID`)

`restrictEnvAccess` is **kept** on all three packages — they now comply. The rewrites also clear each package's other pre-existing lint errors (kv's dead `keys` map and `as string` casts; chat's `type`→`interface` and type-import nits).

## Reviewer notes

- **`prisma.config.ts` still reads `DATABASE_URL`** — intentional. It's the Prisma **CLI** datasource config (a `*.config.*` file, already ESLint-exempt) and isn't imported by app runtime. It now uses `process.env.DATABASE_URL ?? ""` so `prisma generate` no longer throws without a DB URL.
- **eve-scrape still reads env** to build its own db/kv/chat instances (it already had an `env.ts`). Fully removing env from it — injecting these from the web app into its Inngest functions — is a **separate, larger migration** and intentionally out of scope. The three *packages* are now env-free, which was the goal.
- **One `eslint-disable`** in `packages/eve-scrape/chat.ts` (`no-unsafe-*`): eve-scrape's type-aware lint resolves the `@jitaspace/chat` import as `any` — a pre-existing cross-package limitation there (it already produces 284 errors; `scrapeRecentKills` alone had 14 at HEAD). The chat package itself is fully typed and type-checks.
- Most of the 78 files are **one-line import-path swaps** in consumers (+ `jest.mock` retargets). The substance is the 3 package factories and 5 shims.

## Verification

- **db / kv / chat**: `type-check` ✅ and `lint` ✅ clean (with `restrictEnvAccess` kept).
- **eve-scrape**: `type-check` ✅, tests ✅; lint at its **pre-existing baseline** (311 problems — zero net new).
- **web**: `type-check` at its **pre-existing baseline** (267 errors — zero net new, confirmed via a stash baseline diff), and the web db/kv jest tests pass (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
