### PR TITLE
chore(dev): add .claude/launch.json with dev server configurations

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js Web",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@jitaspace/web", "dev"],
+      "port": 3000,
+      "autoPort": false
+    },
+    {
+      "name": "All (Turbo)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000,
+      "autoPort": false
+    },
+    {
+      "name": "Inngest Dev Server",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@jitaspace/eve-scrape", "dev"],
+      "port": 8288,
+      "autoPort": false
+    },
+    {
+      "name": "Prisma Studio",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": [
+        "--filter",
+        "@jitaspace/db",
+        "exec",
+        "dotenv",
+        "-e",
+        "../../.env",
+        "--",
+        "prisma",
+        "studio",
+        "--browser",
+        "none"
+      ],
+      "port": 5555,
+      "autoPort": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude/launch.json` defining the project's dev servers for the Claude Code dev-server preview tooling, so contributors can start services without remembering the per-package `pnpm` invocations. This is consistent with the repo already tracking `.claude/settings.local.json`.

## Configurations

| Name | Command | Port |
|------|---------|------|
| **Next.js Web** | `pnpm --filter @jitaspace/web dev` | 3000 |
| **All (Turbo)** | `pnpm dev` (`turbo dev --parallel`) | 3000 |
| **Inngest Dev Server** | `pnpm --filter @jitaspace/eve-scrape dev` | 8288 |
| **Prisma Studio** | `prisma studio` via `dotenv -e ../../.env` | 5555 |

## Notes / decisions

- **`autoPort: false` on every entry.** The web app must stay on **:3000** because the EVE Online SSO OAuth callback URL is registered against that exact origin. Inngest and Prisma Studio bind fixed ports through their own CLI flags and don't read the `PORT` env var, so pinning them (and surfacing a clear conflict) is more correct than letting the tooling reassign a port the process will ignore.
- **Prisma Studio is wrapped in `dotenv -e ../../.env`.** The `db:studio` package script (unlike `db:generate`) has no `with-env` wrapper, and `prisma.config.ts` loads `.env` from the cwd (`packages/db`), where there is no `.env`. Without the wrapper Studio launches without `DATABASE_URL`. Verified:
  - `pnpm --filter @jitaspace/db exec node -e "...DATABASE_URL"` → `false`
  - `pnpm --filter @jitaspace/db exec dotenv -e ../../.env -- node -e "...DATABASE_URL"` → `true`

## Verified

- `Next.js Web` and `All (Turbo)` confirmed to start on :3000 during development.
- Prisma Studio env-loading verified via the `dotenv` probe above (Studio itself needs a reachable database to fully launch).
- `launch.json` validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)