### PR TITLE
refactor(web): convert TypeInventoryBreadcrumbs and TypeMarketBreadcrumbs to server components

### DIFF
--- a/apps/web/app/type/[typeId]/page.client.tsx
+++ b/apps/web/app/type/[typeId]/page.client.tsx
@@ -56,10 +56,6 @@ import {
 } from "@jitaspace/ui";
 
 import { OpenMarketWindowActionIcon } from "~/components/ActionIcon";
-import {
-  TypeInventoryBreadcrumbs,
-  TypeMarketBreadcrumbs,
-} from "~/components/Breadcrumbs";
 import { MailMessageViewer } from "~/components/EveMail";
 import {
   CategoryName,
@@ -74,6 +70,8 @@ export interface PageProps {
   ogImageUrl?: string;
   typeName?: string;
   typeDescription?: string;
+  inventoryBreadcrumbs?: ReactNode;
+  marketBreadcrumbs?: ReactNode;
 }
 
 const notAvailableText = "Not available";
@@ -277,6 +275,8 @@ export default function TypePage({
   typeId,
   typeName,
   typeDescription,
+  inventoryBreadcrumbs,
+  marketBreadcrumbs,
 }: PageProps) {
   const character = useSelectedCharacter();
   const { data: type } = useType(typeId);
@@ -544,7 +544,7 @@ export default function TypePage({
             </Box>
 
             <Stack gap="sm" style={{ flex: 1, minWidth: 240 }}>
-              <TypeInventoryBreadcrumbs typeId={typeId} fz="sm" />
+              {inventoryBreadcrumbs}
               <Group gap="sm" align="center">
                 <Title order={2}>{name ?? notAvailableText}</Title>
                 {typeData?.published === false && (
@@ -842,7 +842,7 @@ export default function TypePage({
           {hasMarket && (
             <Tabs.Panel value="market" pt="lg">
               <Stack gap="lg">
-                <TypeMarketBreadcrumbs typeId={typeId} fz="sm" />
+                {marketBreadcrumbs}
                 <Stack gap="sm">
                   <SectionHeading icon={<IconCoin size={18} />}>
                     Jita / The Forge

--- a/apps/web/app/type/[typeId]/page.tsx
+++ b/apps/web/app/type/[typeId]/page.tsx
@@ -6,6 +6,10 @@ import { Loader } from "@mantine/core";
 
 import { prisma } from "@jitaspace/db";
 
+import {
+  TypeInventoryBreadcrumbs,
+  TypeMarketBreadcrumbs,
+} from "~/components/Breadcrumbs";
 import TypePage from "./page.client";
 import type { PageProps } from "./page.client";
 
@@ -56,7 +60,13 @@ async function PageContent({
 
   try {
     const props = await getTypeData(typeId);
-    return <TypePage {...props} />;
+    return (
+      <TypePage
+        {...props}
+        inventoryBreadcrumbs={<TypeInventoryBreadcrumbs typeId={typeId} fz="sm" />}
+        marketBreadcrumbs={<TypeMarketBreadcrumbs typeId={typeId} fz="sm" />}
+      />
+    );
   } catch {
     notFound();
   }

--- a/apps/web/components/Breadcrumbs/TypeInventoryBreadcrumbs.tsx
+++ b/apps/web/components/Breadcrumbs/TypeInventoryBreadcrumbs.tsx
@@ -1,8 +1,6 @@
-"use client";
-
-import { memo } from "react";
 import { type BreadcrumbsProps } from "@mantine/core";
-import { useCategory, useGroup, useType } from "@jitaspace/hooks";
+
+import { prisma } from "@jitaspace/db";
 import { TypeInventoryBreadcrumbs as UITypeInventoryBreadcrumbs } from "@jitaspace/ui";
 
 export type TypeInventoryBreadcrumbsProps = Omit<BreadcrumbsProps, "children"> & {
@@ -10,27 +8,43 @@ export type TypeInventoryBreadcrumbsProps = Omit<BreadcrumbsProps, "children"> &
   showType?: boolean;
 };
 
-export const TypeInventoryBreadcrumbs = memo(
-  ({ typeId, showType, ...otherProps }: TypeInventoryBreadcrumbsProps) => {
-    const typeIdNum =
-      typeof typeId === "string" ? Number.parseInt(typeId) : typeId;
-    const { data: type } = useType(typeIdNum ?? 0);
-    const groupId = type?.data.group_id;
-    const { data: group } = useGroup(groupId ?? 0);
-    const categoryId = group?.data.category_id;
-    const { data: category } = useCategory(categoryId ?? 0);
+export async function TypeInventoryBreadcrumbs({
+  typeId,
+  showType,
+  ...otherProps
+}: TypeInventoryBreadcrumbsProps) {
+  const typeIdNum =
+    typeof typeId === "string" ? Number.parseInt(typeId) : typeId;
 
-    return (
-      <UITypeInventoryBreadcrumbs
-        typeId={typeId}
-        groupId={groupId}
-        groupName={group?.data.name}
-        categoryId={categoryId}
-        categoryName={category?.data.name}
-        showType={showType}
-        {...otherProps}
-      />
-    );
-  },
-);
-TypeInventoryBreadcrumbs.displayName = "TypeInventoryBreadcrumbs";
+  const type = typeIdNum
+    ? await prisma.type.findUnique({
+        where: { typeId: typeIdNum },
+        select: {
+          group: {
+            select: {
+              groupId: true,
+              name: true,
+              category: {
+                select: {
+                  categoryId: true,
+                  name: true,
+                },
+              },
+            },
+          },
+        },
+      })
+    : null;
+
+  return (
+    <UITypeInventoryBreadcrumbs
+      typeId={typeId}
+      groupId={type?.group?.groupId}
+      groupName={type?.group?.name}
+      categoryId={type?.group?.category?.categoryId}
+      categoryName={type?.group?.category?.name}
+      showType={showType}
+      {...otherProps}
+    />
+  );
+}

--- a/apps/web/components/Breadcrumbs/TypeMarketBreadcrumbs.tsx
+++ b/apps/web/components/Breadcrumbs/TypeMarketBreadcrumbs.tsx
@@ -1,8 +1,6 @@
-"use client";
-
-import { memo, useMemo } from "react";
 import { type BreadcrumbsProps } from "@mantine/core";
-import { useMarketGroup, useType } from "@jitaspace/hooks";
+
+import { prisma } from "@jitaspace/db";
 import { TypeMarketBreadcrumbs as UITypeMarketBreadcrumbs } from "@jitaspace/ui";
 
 export type TypeMarketBreadcrumbsProps = Omit<BreadcrumbsProps, "children"> & {
@@ -10,48 +8,71 @@ export type TypeMarketBreadcrumbsProps = Omit<BreadcrumbsProps, "children"> & {
   showType?: boolean;
 };
 
-export const TypeMarketBreadcrumbs = memo(
-  ({ typeId, showType, ...otherProps }: TypeMarketBreadcrumbsProps) => {
-    const typeIdNum =
-      typeof typeId === "string" ? Number.parseInt(typeId) : typeId;
-    const { data: type } = useType(typeIdNum ?? 0);
+export async function TypeMarketBreadcrumbs({
+  typeId,
+  showType,
+  ...otherProps
+}: TypeMarketBreadcrumbsProps) {
+  const typeIdNum =
+    typeof typeId === "string" ? Number.parseInt(typeId) : typeId;
 
-    const level1Id = type?.data.market_group_id ?? 0;
-    const level1 = useMarketGroup(level1Id);
-    const level2Id = (level1Id && level1?.parent_group_id) ?? 0;
-    const level2 = useMarketGroup(level2Id);
-    const level3Id = (level2Id && level2?.parent_group_id) ?? 0;
-    const level3 = useMarketGroup(level3Id);
-    const level4Id = (level3Id && level3?.parent_group_id) ?? 0;
-    const level4 = useMarketGroup(level4Id);
-    const level5Id = (level4Id && level4?.parent_group_id) ?? 0;
-    const level5 = useMarketGroup(level5Id);
+  const type = typeIdNum
+    ? await prisma.type.findUnique({
+        where: { typeId: typeIdNum },
+        select: {
+          marketGroup: {
+            select: {
+              marketGroupId: true,
+              name: true,
+              parent: {
+                select: {
+                  marketGroupId: true,
+                  name: true,
+                  parent: {
+                    select: {
+                      marketGroupId: true,
+                      name: true,
+                      parent: {
+                        select: {
+                          marketGroupId: true,
+                          name: true,
+                          parent: {
+                            select: {
+                              marketGroupId: true,
+                              name: true,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    : null;
 
-    const marketGroups = useMemo(() => {
-      const groups: { market_group_id: number; name: string }[] = [];
-      const levels = [
-        { id: level5Id, data: level5 },
-        { id: level4Id, data: level4 },
-        { id: level3Id, data: level3 },
-        { id: level2Id, data: level2 },
-        { id: level1Id, data: level1 },
-      ];
-      for (const { id, data } of levels) {
-        if (id && data?.name) {
-          groups.push({ market_group_id: id, name: data.name });
-        }
-      }
-      return groups.length > 0 ? groups : undefined;
-    }, [level1, level1Id, level2, level2Id, level3, level3Id, level4, level4Id, level5, level5Id]);
+  const mg1 = type?.marketGroup;
+  const mg2 = mg1?.parent;
+  const mg3 = mg2?.parent;
+  const mg4 = mg3?.parent;
+  const mg5 = mg4?.parent;
 
-    return (
-      <UITypeMarketBreadcrumbs
-        typeId={typeId}
-        marketGroups={marketGroups}
-        showType={showType}
-        {...otherProps}
-      />
-    );
-  },
-);
-TypeMarketBreadcrumbs.displayName = "TypeMarketBreadcrumbs";
+  const marketGroups: { market_group_id: number; name: string }[] = [];
+  if (mg5) marketGroups.push({ market_group_id: mg5.marketGroupId, name: mg5.name });
+  if (mg4) marketGroups.push({ market_group_id: mg4.marketGroupId, name: mg4.name });
+  if (mg3) marketGroups.push({ market_group_id: mg3.marketGroupId, name: mg3.name });
+  if (mg2) marketGroups.push({ market_group_id: mg2.marketGroupId, name: mg2.name });
+  if (mg1) marketGroups.push({ market_group_id: mg1.marketGroupId, name: mg1.name });
+
+  return (
+    <UITypeMarketBreadcrumbs
+      typeId={typeId}
+      marketGroups={marketGroups.length > 0 ? marketGroups : undefined}
+      showType={showType}
+      {...otherProps}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- **`TypeInventoryBreadcrumbs`** and **`TypeMarketBreadcrumbs`** in `apps/web/components/Breadcrumbs/` are now async server components — no `"use client"`, no React hooks.
- Both components fetch data from Prisma directly: inventory breadcrumbs resolve the type → group → category chain in a single query; market breadcrumbs traverse up to 5 levels of `parent` market group relations in one nested query.
- Because server components cannot be rendered inside a client component, the **slot pattern** is used: `page.tsx` renders the breadcrumbs server-side and passes them as `inventoryBreadcrumbs` / `marketBreadcrumbs` `ReactNode` props to the `TypePage` client component.

## Test plan

- [ ] Navigate to a type page (e.g. `/type/34`) and confirm the Inventory breadcrumb trail renders correctly (category → group labels present).
- [ ] Switch to the Market tab and confirm the market breadcrumb trail renders correctly (full parent chain from root group to leaf).
- [ ] Confirm the breadcrumbs render server-side (visible in page source, not dependent on JS hydration).
- [ ] Check a type with no market group — confirm no errors and the market tab still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)