### PR TITLE
feat(web): add faction & EVE wallpapers to themed AppShell backgrounds

### DIFF
--- a/.changeset/theme-backgrounds.md
+++ b/.changeset/theme-backgrounds.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": minor
+---
+
+Add per-theme background support via `theme.other.appBackground`.
+
+EVE, Amarr, Caldari, Gallente, and Minmatar themes show a faction wallpaper (from the 2026 Cradle of War pack) with a 55 % black overlay. WHPD uses a solid black background. Themes without an `appBackground` entry are unaffected.

--- a/apps/web/layouts/MainLayout/MainLayout.tsx
+++ b/apps/web/layouts/MainLayout/MainLayout.tsx
@@ -15,7 +15,7 @@ export function MainLayout({
   const matches = useMediaQuery("(max-width: 48em)");
   const { pinned } = useHeadroom({ fixedAt: 120 });
   const theme = useMantineTheme();
-  const wallpaper = theme.other.wallpaper;
+  const appBackground = theme.other.appBackground;
   return (
     <AppShell
       header={{
@@ -28,13 +28,7 @@ export function MainLayout({
         offset: true,
         collapsed: matches && !pinned,
       }}
-      style={
-        wallpaper
-          ? {
-              background: `linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55)), url(${wallpaper}) center / cover fixed no-repeat`,
-            }
-          : undefined
-      }
+      style={appBackground ? { background: appBackground } : undefined}
       {...otherProps}
     >
       <AppShell.Header>

--- a/apps/web/layouts/MainLayout/MainLayout.tsx
+++ b/apps/web/layouts/MainLayout/MainLayout.tsx
@@ -2,7 +2,7 @@
 
 import type { AppShellProps } from "@mantine/core";
 import type { PropsWithChildren } from "react";
-import { AppShell, rem } from "@mantine/core";
+import { AppShell, rem, useMantineTheme } from "@mantine/core";
 import { useHeadroom, useMediaQuery } from "@mantine/hooks";
 
 import { FooterWithLinks } from "~/layouts/MainLayout/FooterWithLinks";
@@ -14,6 +14,8 @@ export function MainLayout({
 }: PropsWithChildren<AppShellProps>) {
   const matches = useMediaQuery("(max-width: 48em)");
   const { pinned } = useHeadroom({ fixedAt: 120 });
+  const theme = useMantineTheme();
+  const wallpaper = theme.other.wallpaper;
   return (
     <AppShell
       header={{
@@ -26,6 +28,13 @@ export function MainLayout({
         offset: true,
         collapsed: matches && !pinned,
       }}
+      style={
+        wallpaper
+          ? {
+              background: `linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55)), url(${wallpaper}) center / cover fixed no-repeat`,
+            }
+          : undefined
+      }
       {...otherProps}
     >
       <AppShell.Header>

--- a/apps/web/themes/index.ts
+++ b/apps/web/themes/index.ts
@@ -4,7 +4,7 @@ import type {} from "@mantine/core";
 
 declare module "@mantine/core" {
   interface MantineThemeOther {
-    wallpaper?: string;
+    appBackground?: string;
   }
 }
 
@@ -80,8 +80,8 @@ const eveTheme = mergeThemeOverrides(
   baseTheme,
   createTheme({
     other: {
-      wallpaper:
-        "/wallpapers/2026-cradle-of-war/cradle-of-war-nologo-compressed.jpeg",
+      appBackground:
+        "linear-gradient(rgba(0,0,0,0.55),rgba(0,0,0,0.55)),url(/wallpapers/2026-cradle-of-war/cradle-of-war-nologo-compressed.jpeg) center/cover fixed no-repeat",
     },
     black: "#04070c",
     white: "#f2f7fb",
@@ -259,7 +259,10 @@ export const themes = {
   amarr: mergeThemeOverrides(
     eveTheme,
     createTheme({
-      other: { wallpaper: "/wallpapers/2026-cradle-of-war/amarr_wallpaper.jpg" },
+      other: {
+        appBackground:
+          "linear-gradient(rgba(0,0,0,0.55),rgba(0,0,0,0.55)),url(/wallpapers/2026-cradle-of-war/amarr_wallpaper.jpg) center/cover fixed no-repeat",
+      },
       primaryColor: "amarr_primary",
       primaryShade: 6,
       colors,
@@ -269,7 +272,8 @@ export const themes = {
     eveTheme,
     createTheme({
       other: {
-        wallpaper: "/wallpapers/2026-cradle-of-war/caldari_wallpaper.jpg",
+        appBackground:
+          "linear-gradient(rgba(0,0,0,0.55),rgba(0,0,0,0.55)),url(/wallpapers/2026-cradle-of-war/caldari_wallpaper.jpg) center/cover fixed no-repeat",
       },
       primaryColor: "caldari_primary",
       colors,
@@ -279,7 +283,8 @@ export const themes = {
     eveTheme,
     createTheme({
       other: {
-        wallpaper: "/wallpapers/2026-cradle-of-war/gallente_wallpaper.jpg",
+        appBackground:
+          "linear-gradient(rgba(0,0,0,0.55),rgba(0,0,0,0.55)),url(/wallpapers/2026-cradle-of-war/gallente_wallpaper.jpg) center/cover fixed no-repeat",
       },
       primaryColor: "gallente_primary",
       colors,
@@ -289,7 +294,8 @@ export const themes = {
     eveTheme,
     createTheme({
       other: {
-        wallpaper: "/wallpapers/2026-cradle-of-war/minmatar_wallpaper.jpg",
+        appBackground:
+          "linear-gradient(rgba(0,0,0,0.55),rgba(0,0,0,0.55)),url(/wallpapers/2026-cradle-of-war/minmatar_wallpaper.jpg) center/cover fixed no-repeat",
       },
       primaryColor: "minmatar_primary",
       colors,
@@ -312,6 +318,7 @@ export const themes = {
   whpd: mergeThemeOverrides(
     eveTheme,
     createTheme({
+      other: { appBackground: "#000" },
       black: "#000002",
       white: "#eef2ff",
       primaryColor: "whpd_primary",

--- a/apps/web/themes/index.ts
+++ b/apps/web/themes/index.ts
@@ -1,5 +1,13 @@
 "use client";
 
+import type {} from "@mantine/core";
+
+declare module "@mantine/core" {
+  interface MantineThemeOther {
+    wallpaper?: string;
+  }
+}
+
 import {
   Avatar,
   Badge,
@@ -71,6 +79,10 @@ const evePanelStyles = {
 const eveTheme = mergeThemeOverrides(
   baseTheme,
   createTheme({
+    other: {
+      wallpaper:
+        "/wallpapers/2026-cradle-of-war/cradle-of-war-nologo-compressed.jpeg",
+    },
     black: "#04070c",
     white: "#f2f7fb",
     primaryColor: "eve_primary",
@@ -247,6 +259,7 @@ export const themes = {
   amarr: mergeThemeOverrides(
     eveTheme,
     createTheme({
+      other: { wallpaper: "/wallpapers/2026-cradle-of-war/amarr_wallpaper.jpg" },
       primaryColor: "amarr_primary",
       primaryShade: 6,
       colors,
@@ -255,6 +268,9 @@ export const themes = {
   caldari: mergeThemeOverrides(
     eveTheme,
     createTheme({
+      other: {
+        wallpaper: "/wallpapers/2026-cradle-of-war/caldari_wallpaper.jpg",
+      },
       primaryColor: "caldari_primary",
       colors,
     }),
@@ -262,6 +278,9 @@ export const themes = {
   gallente: mergeThemeOverrides(
     eveTheme,
     createTheme({
+      other: {
+        wallpaper: "/wallpapers/2026-cradle-of-war/gallente_wallpaper.jpg",
+      },
       primaryColor: "gallente_primary",
       colors,
     }),
@@ -269,6 +288,9 @@ export const themes = {
   minmatar: mergeThemeOverrides(
     eveTheme,
     createTheme({
+      other: {
+        wallpaper: "/wallpapers/2026-cradle-of-war/minmatar_wallpaper.jpg",
+      },
       primaryColor: "minmatar_primary",
       colors,
     }),


### PR DESCRIPTION
## Summary

- Each theme that has a matching wallpaper now declares it via `theme.other.wallpaper`, using a typed `MantineThemeOther` module augmentation in `themes/index.ts`
- `MainLayout` reads `theme.other.wallpaper` with `useMantineTheme()` and applies it as an inline `background` style on the `AppShell` root — inline styles override Mantine's class-based `background: var(--app-shell-bg)`, so no CSS hacks needed
- A 55 % black overlay is layered on top of the image to keep the UI legible

**Themes with wallpapers (all from `public/wallpapers/2026-cradle-of-war/`):**
| Theme | Wallpaper |
|---|---|
| `eve` | `cradle-of-war-nologo-compressed.jpeg` |
| `amarr` | `amarr_wallpaper.jpg` |
| `caldari` | `caldari_wallpaper.jpg` |
| `gallente` | `gallente_wallpaper.jpg` |
| `minmatar` | `minmatar_wallpaper.jpg` |

Themes without an `other.wallpaper` entry (`default`, `whpd`, `carbon`, `photon`, `ore`, `sisters_of_eve`) are unaffected.

## Test plan

- [ ] Switch theme to **Amarr / Caldari / Gallente / Minmatar / EVE** — wallpaper should appear behind the cards, visibly dimmed
- [ ] Switch back to **Default** — solid dark background, no wallpaper
- [ ] Confirm header/footer still have their normal opaque backgrounds
- [ ] Confirm cards/panels remain readable with the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)