### PR TITLE
fix(web): restore Sentry instrumentation files to project root

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,7 +1,3 @@
-// This file configures the initialization of Sentry on the client.
-// The added config here will be used whenever a users loads a page in their browser.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -2,11 +2,11 @@ import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
-    await import("../config/sentry.server.config");
+    await import("./config/sentry.server.config");
   }
 
   if (process.env.NEXT_RUNTIME === "edge") {
-    await import("../config/sentry.edge.config");
+    await import("./config/sentry.edge.config");
   }
 }
 


### PR DESCRIPTION
## Summary

- Moves `instrumentation.ts` and `instrumentation-client.ts` back to `apps/web/` (the project root), where Next.js requires them
- Removes the dead copies from `apps/web/lib/`
- Updates import paths in `instrumentation.ts` (`../config/` → `./config/`) to reflect the new location

## What broke and why

Commit 96517c29 ("cleanup: move sentry files into subfolders", May 11) moved these files into `apps/web/lib/`. Next.js only resolves `instrumentation.ts` and `instrumentation-client.ts` from the project root (or `src/`), so both the server-side and client-side Sentry hooks silently stopped loading. No Sentry events have been received since that date (~28 days).

The `sentry.server.config.ts` and `sentry.edge.config.ts` files are unaffected — they live in `apps/web/config/` and are imported by `instrumentation.ts`, which is fine.

## Test plan

- [ ] Deploy to preview and trigger a test error (e.g. visit a broken route or use `Sentry.captureException` in the browser console) — should appear in Sentry within seconds
- [ ] Verify session replays resume appearing in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)