### PR TITLE
fix(web): suppress Recharts SSR width/height warnings from Sparkline

### DIFF
--- a/.changeset/nine-taxes-divide.md
+++ b/.changeset/nine-taxes-divide.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+fix(web): suppress Recharts SSR width/height warnings from Sparkline

--- a/apps/web/components/Status/EsiRateLimitDashboard.tsx
+++ b/apps/web/components/Status/EsiRateLimitDashboard.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { Sparkline } from "@mantine/charts";
+import dynamic from "next/dynamic";
+
+const Sparkline = dynamic(
+  () => import("@mantine/charts").then((m) => m.Sparkline),
+  { ssr: false },
+);
 import {
   Alert,
   Badge,


### PR DESCRIPTION
## Summary

- Mantine's `Sparkline` component always wraps its chart in Recharts' `ResponsiveContainer`, which reports `width=-1` / `height=-1` during SSR because there is no DOM available to measure.
- `EsiRateLimitDashboard` is a `"use client"` component that still SSRs at build time. It renders placeholder rows derived from static rate-limit config (`RATE_LIMIT_BUCKET_CONFIGS`), so multiple `Sparkline` instances are rendered during the build — each one logging the warning.
- Fix: replaced the static `import { Sparkline }` with `next/dynamic(..., { ssr: false })` so the component only renders client-side where `ResponsiveContainer` can measure real container dimensions.

## Test plan

- [ ] `pnpm build` completes without the `The width(-1) and height(-1) of chart should be greater than 0` warnings
- [ ] `/status` page still renders the ESI rate-limit table with sparklines visible client-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)