### PR TITLE
feat(ui): DateHoverCard — rich date tooltip across the app

### DIFF
--- a/.changeset/date-hover-card.md
+++ b/.changeset/date-hover-card.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/ui": patch
+"@jitaspace/web": patch
+---
+
+feat(ui): add DateHoverCard — rich date tooltip with relative time, local timezone, and EVE Time (UTC)

--- a/apps/web/app/calendar/[eventId]/page.client.tsx
+++ b/apps/web/app/calendar/[eventId]/page.client.tsx
@@ -24,6 +24,7 @@ import {
   CharacterAnchor,
   CharacterAvatar,
   CharacterName,
+  DateHoverCard,
   EveEntityNameAnchor,
   FormattedDateText,
 } from "@jitaspace/ui";
@@ -89,10 +90,14 @@ export default function Page({
           <MailMessageViewer content={event?.data.text ?? ""} />
           <Group justify="space-between" mt="xl">
             <Text>When</Text>
-            <FormattedDateText
+            <DateHoverCard
               date={event?.data.date ? new Date(event?.data.date) : undefined}
-              format="yyyy-MM-dd HH:mm"
-            />
+            >
+              <FormattedDateText
+                date={event?.data.date ? new Date(event?.data.date) : undefined}
+                format="yyyy-MM-dd HH:mm"
+              />
+            </DateHoverCard>
           </Group>
           <Group justify="space-between">
             <Text>Duration</Text>

--- a/apps/web/app/character/[characterId]/page.client.tsx
+++ b/apps/web/app/character/[characterId]/page.client.tsx
@@ -10,6 +10,7 @@ import {
   CharacterName,
   CorporationAvatar,
   CorporationName,
+  DateHoverCard,
   FormattedDateText,
   SolarSystemAnchor,
   SolarSystemName,
@@ -146,7 +147,9 @@ export default function Page() {
         {character?.birthday && (
           <Group justify="space-between">
             <Text>Birthday</Text>
-            <FormattedDateText date={character.birthday} />
+            <DateHoverCard date={character.birthday}>
+              <FormattedDateText date={character.birthday} />
+            </DateHoverCard>
           </Group>
         )}
         <Group justify="space-between">

--- a/apps/web/app/kill/[killId]/page.client.tsx
+++ b/apps/web/app/kill/[killId]/page.client.tsx
@@ -30,10 +30,10 @@ import {
   CorporationAnchor,
   CorporationAvatar,
   CorporationName,
+  DateHoverCard,
   FactionAnchor,
   FactionAvatar,
   FactionName,
-  FormattedDateText,
   ISKAmount,
   SolarSystemAnchor,
   SolarSystemName,
@@ -153,15 +153,13 @@ export default function Page() {
               <Text size="sm" c="dimmed">
                 •
               </Text>
-              <FormattedDateText date={new Date(km.killmail_time)} size="sm" />
-              <Text size="sm" c="dimmed">
-                •
-              </Text>
-              <TimeAgoText
-                date={new Date(km.killmail_time)}
-                addSuffix
-                size="sm"
-              />
+              <DateHoverCard date={new Date(km.killmail_time)}>
+                <TimeAgoText
+                  date={new Date(km.killmail_time)}
+                  addSuffix
+                  size="sm"
+                />
+              </DateHoverCard>
             </Group>
           </Stack>
           <Group gap="xs" wrap="nowrap">

--- a/apps/web/app/notifications/page.tsx
+++ b/apps/web/app/notifications/page.tsx
@@ -7,7 +7,6 @@ import {
   Stack,
   Table,
   Title,
-  Tooltip,
 } from "@mantine/core";
 import { IconMail, IconMailOpened } from "@tabler/icons-react";
 
@@ -17,9 +16,9 @@ import {
   useSelectedCharacter,
 } from "@jitaspace/hooks";
 import {
+  DateHoverCard,
   EveEntityAvatar,
   EveEntityName,
-  FormattedDateText,
   TimeAgoText,
 } from "@jitaspace/ui";
 
@@ -59,21 +58,12 @@ export default function Page() {
                     <JsonInput value={notification.text} cols={80} autosize />
                   </Table.Td>
                   <Table.Td>
-                    <Tooltip
-                      color="dark"
-                      label={
-                        <FormattedDateText
-                          date={new Date(notification.timestamp)}
-                        />
-                      }
-                    >
-                      <div>
-                        <TimeAgoText
-                          date={new Date(notification.timestamp)}
-                          addSuffix
-                        />
-                      </div>
-                    </Tooltip>
+                    <DateHoverCard date={new Date(notification.timestamp)}>
+                      <TimeAgoText
+                        date={new Date(notification.timestamp)}
+                        addSuffix
+                      />
+                    </DateHoverCard>
                   </Table.Td>
                 </Table.Tr>
               ))}

--- a/apps/web/app/status/page.client.tsx
+++ b/apps/web/app/status/page.client.tsx
@@ -27,7 +27,7 @@ import {
 import { getRateLimitBuildDate, useGetMetaCompatibilityDates, useGetMetaStatus } from "@jitaspace/esi-client";
 import { useServerStatus } from "@jitaspace/hooks";
 import { useGetVersion } from "@jitaspace/sde-client";
-import { FormattedDateText } from "@jitaspace/ui";
+import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
 
 import type { SdeLastModifiedResponse, VercelStatusResponse } from "./types";
 import { env } from "~/env";
@@ -157,7 +157,9 @@ export default function StatusPage({
                     <Anchor href="https://sde.jita.space" size="sm">
                       {!sdeApiLastUpdatedDate && <Loader size="xs" />}
                       {sdeApiLastUpdatedDate && (
-                        <FormattedDateText date={sdeApiLastUpdatedDate} />
+                        <DateHoverCard date={sdeApiLastUpdatedDate}>
+                          <FormattedDateText date={sdeApiLastUpdatedDate} />
+                        </DateHoverCard>
                       )}
                     </Anchor>
                     {sdeApiLastUpdatedDate &&
@@ -209,10 +211,12 @@ export default function StatusPage({
                     Start Time
                   </Text>
                   {tqStatus && (
-                    <FormattedDateText
-                      date={new Date(tqStatus.data.start_time)}
-                      size="sm"
-                    />
+                    <DateHoverCard date={new Date(tqStatus.data.start_time)}>
+                      <FormattedDateText
+                        date={new Date(tqStatus.data.start_time)}
+                        size="sm"
+                      />
+                    </DateHoverCard>
                   )}
                 </Group>
                 <Group justify="space-between">
@@ -228,7 +232,9 @@ export default function StatusPage({
                     SDE Last Updated On
                   </Text>
                   {sdeLastModifiedDate && (
-                    <FormattedDateText date={sdeLastModifiedDate} size="sm" />
+                    <DateHoverCard date={sdeLastModifiedDate}>
+                      <FormattedDateText date={sdeLastModifiedDate} size="sm" />
+                    </DateHoverCard>
                   )}
                 </Group>
               </Stack>

--- a/apps/web/app/war/[warId]/page.client.tsx
+++ b/apps/web/app/war/[warId]/page.client.tsx
@@ -18,6 +18,7 @@ import {
   CorporationAnchor,
   CorporationAvatar,
   CorporationName,
+  DateHoverCard,
   FormattedDateText,
   ISKAmount,
 } from "@jitaspace/ui";
@@ -137,25 +138,33 @@ export default function Page() {
         {war && (
           <Group align="center" justify="space-between">
             <Text>Declared on</Text>
-            <FormattedDateText date={new Date(war.data.declared)} />
+            <DateHoverCard date={new Date(war.data.declared)}>
+              <FormattedDateText date={new Date(war.data.declared)} />
+            </DateHoverCard>
           </Group>
         )}
         {war?.data.started && (
           <Group align="center" justify="space-between">
             <Text>Started on</Text>
-            <FormattedDateText date={new Date(war.data.started)} />
+            <DateHoverCard date={new Date(war.data.started)}>
+              <FormattedDateText date={new Date(war.data.started)} />
+            </DateHoverCard>
           </Group>
         )}
         {war?.data.retracted && (
           <Group align="center" justify="space-between">
             <Text>Retracted on</Text>
-            <FormattedDateText date={new Date(war.data.retracted)} />
+            <DateHoverCard date={new Date(war.data.retracted)}>
+              <FormattedDateText date={new Date(war.data.retracted)} />
+            </DateHoverCard>
           </Group>
         )}
         {war?.data.finished && (
           <Group align="center" justify="space-between">
             <Text>Finished on</Text>
-            <FormattedDateText date={new Date(war.data.finished)} />
+            <DateHoverCard date={new Date(war.data.finished)}>
+              <FormattedDateText date={new Date(war.data.finished)} />
+            </DateHoverCard>
           </Group>
         )}
         {war && (

--- a/apps/web/components/Auth/AuthenticatedCharacterTokenDetailsPanel.tsx
+++ b/apps/web/components/Auth/AuthenticatedCharacterTokenDetailsPanel.tsx
@@ -8,14 +8,13 @@ import {
   Stack,
   Text,
   Title,
-  Tooltip,
 } from "@mantine/core";
 
 import { useAuthenticatedCharacter } from "@jitaspace/hooks";
 import {
   CharacterAvatar,
   CharacterName,
-  FormattedDateText,
+  DateHoverCard,
   TimeAgoText,
 } from "@jitaspace/ui";
 
@@ -68,14 +67,9 @@ export const AuthenticatedCharacterTokenDetailsPanel = ({
       {expirationDate && (
         <Group justify="space-between">
           <Text>Token expiration</Text>
-          <Group>
-            <Tooltip
-              color="dark"
-              label={<FormattedDateText size="sm" date={expirationDate} />}
-            >
-              <TimeAgoText date={expirationDate} addSuffix />
-            </Tooltip>
-          </Group>
+          <DateHoverCard date={expirationDate}>
+            <TimeAgoText date={expirationDate} addSuffix />
+          </DateHoverCard>
         </Group>
       )}
 

--- a/apps/web/components/Calendar/CalendarEventDetailsPanel.tsx
+++ b/apps/web/components/Calendar/CalendarEventDetailsPanel.tsx
@@ -9,6 +9,7 @@ import {
   CharacterAnchor,
   CharacterAvatar,
   CharacterName,
+  DateHoverCard,
   EveEntityNameAnchor,
   FormattedDateText,
 } from "@jitaspace/ui";
@@ -68,10 +69,14 @@ export function CalendarEventDetailsPanel({
     <Stack>
       <Group justify="space-between" mt="xl">
         <Text>When</Text>
-        <FormattedDateText
+        <DateHoverCard
           date={event?.data.date ? new Date(event?.data.date) : undefined}
-          format="yyyy-MM-dd HH:mm"
-        />
+        >
+          <FormattedDateText
+            date={event?.data.date ? new Date(event?.data.date) : undefined}
+            format="yyyy-MM-dd HH:mm"
+          />
+        </DateHoverCard>
       </Group>
       <Group justify="space-between">
         <Text>Duration</Text>

--- a/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
@@ -10,7 +10,6 @@ import { CalendarEventOwnerAnchor } from "~/components/Anchor";
 import { CalendarEventOwnerAvatar } from "~/components/Avatar";
 import { CalendarEventAttendeesAvatarGroup } from "~/components/AvatarGroup";
 import { CalendarEventResponseBadge } from "~/components/Badge";
-import { CalendarEventHumanDurationText } from "~/components/DurationText";
 import { CalendarEventOwnerName } from "~/components/Text";
 
 type EventListProps = TableProps & {

--- a/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
@@ -1,5 +1,5 @@
 import type { TableProps } from "@mantine/core";
-import { Anchor, Group, Table, Title } from "@mantine/core";
+import { Anchor, Group, Table, Title, Tooltip } from "@mantine/core";
 import { openContextModal } from "@mantine/modals";
 
 import type { CalendarEvent } from "@jitaspace/hooks";

--- a/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
@@ -1,10 +1,10 @@
 import type { TableProps } from "@mantine/core";
-import { Anchor, Group, Table, Title, Tooltip } from "@mantine/core";
+import { Anchor, Group, Table, Title } from "@mantine/core";
 import { openContextModal } from "@mantine/modals";
 
 import type { CalendarEvent } from "@jitaspace/hooks";
 import { WarningIcon } from "@jitaspace/eve-icons";
-import { FormattedDateText } from "@jitaspace/ui";
+import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
 
 import { CalendarEventOwnerAnchor } from "~/components/Anchor";
 import { CalendarEventOwnerAvatar } from "~/components/Avatar";
@@ -29,20 +29,13 @@ export function DesktopCalendarEventList({
         {events.map((event) => (
           <Table.Tr key={event.event_id}>
             <Table.Td width={10}>
-              <Tooltip
-                label={
-                  <CalendarEventHumanDurationText
-                    characterId={characterId}
-                    eventId={event.event_id}
-                  />
-                }
-              >
+              <DateHoverCard date={new Date(event.event_date ?? 0)}>
                 <FormattedDateText
                   size="sm"
                   date={new Date(event.event_date ?? 0)}
                   format="HH:mm"
                 />
-              </Tooltip>
+              </DateHoverCard>
             </Table.Td>
             <Table.Td>
               <Group wrap="nowrap">

--- a/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
@@ -10,7 +10,6 @@ import { CalendarEventOwnerAnchor } from "~/components/Anchor";
 import { CalendarEventOwnerAvatar } from "~/components/Avatar";
 import { CalendarEventAttendeesAvatarGroup } from "~/components/AvatarGroup";
 import { CalendarEventResponseBadge } from "~/components/Badge";
-import { CalendarEventHumanDurationText } from "~/components/DurationText";
 import { CalendarEventOwnerName } from "~/components/Text";
 
 type EventListProps = TableProps & {

--- a/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
@@ -1,10 +1,10 @@
 import type { TableProps } from "@mantine/core";
-import { Anchor, Group, Stack, Table, Title, Tooltip } from "@mantine/core";
+import { Anchor, Group, Stack, Table, Title } from "@mantine/core";
 import { openContextModal } from "@mantine/modals";
 
 import type { CalendarEvent } from "@jitaspace/hooks";
 import { WarningIcon } from "@jitaspace/eve-icons";
-import { FormattedDateText } from "@jitaspace/ui";
+import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
 
 import { CalendarEventOwnerAnchor } from "~/components/Anchor";
 import { CalendarEventOwnerAvatar } from "~/components/Avatar";
@@ -32,20 +32,13 @@ export function MobileCalendarEventList({
               <Stack>
                 <Group justify="space-between" gap="xs">
                   <Group>
-                    <Tooltip
-                      label={
-                        <CalendarEventHumanDurationText
-                          characterId={characterId}
-                          eventId={event.event_id}
-                        />
-                      }
-                    >
+                    <DateHoverCard date={new Date(event.event_date ?? 0)}>
                       <FormattedDateText
                         size="sm"
                         date={new Date(event.event_date ?? 0)}
                         format="HH:mm"
                       />
-                    </Tooltip>
+                    </DateHoverCard>
                     <Tooltip
                       label={
                         <CalendarEventOwnerName

--- a/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
@@ -1,5 +1,5 @@
 import type { TableProps } from "@mantine/core";
-import { Anchor, Group, Stack, Table, Title } from "@mantine/core";
+import { Anchor, Group, Stack, Table, Title, Tooltip } from "@mantine/core";
 import { openContextModal } from "@mantine/modals";
 
 import type { CalendarEvent } from "@jitaspace/hooks";

--- a/apps/web/components/Card/CorporationCard/CorporationCard.tsx
+++ b/apps/web/components/Card/CorporationCard/CorporationCard.tsx
@@ -24,6 +24,7 @@ import {
   CorporationAnchor,
   CorporationAvatar,
   CorporationName,
+  DateHoverCard,
   FormattedDateText,
 } from "@jitaspace/ui";
 
@@ -168,10 +169,12 @@ export const CorporationCard = memo(
               </Text>
               <Skeleton visible={!corporationData} width="auto">
                 {corporationData?.date_founded ? (
-                  <FormattedDateText
-                    date={new Date(corporationData.date_founded)}
-                    size="xs"
-                  />
+                  <DateHoverCard date={new Date(corporationData.date_founded)}>
+                    <FormattedDateText
+                      date={new Date(corporationData.date_founded)}
+                      size="xs"
+                    />
+                  </DateHoverCard>
                 ) : (
                   <Text size="xs">N/A</Text>
                 )}

--- a/apps/web/components/EveMail/MailboxTable/DesktopMailboxTable.tsx
+++ b/apps/web/components/EveMail/MailboxTable/DesktopMailboxTable.tsx
@@ -7,6 +7,7 @@ import {
   useCharacterMailLabels,
 } from "@jitaspace/hooks";
 import {
+  DateHoverCard,
   EveMailSenderAnchor,
   EveMailSenderAvatar,
   EveMailSenderName,
@@ -117,13 +118,15 @@ export const DesktopMailboxTable = ({
               </Table.Td>
               <Table.Td>
                 {mail.timestamp && (
-                  <FormattedDateText
-                    size="xs"
-                    style={{ whiteSpace: "nowrap" }}
-                    date={new Date(mail.timestamp)}
-                    fw={mail.is_read ? "normal" : "bold"}
-                    format="yyyy-MM-dd HH:mm"
-                  />
+                  <DateHoverCard date={new Date(mail.timestamp)}>
+                    <FormattedDateText
+                      size="xs"
+                      style={{ whiteSpace: "nowrap" }}
+                      date={new Date(mail.timestamp)}
+                      fw={mail.is_read ? "normal" : "bold"}
+                      format="yyyy-MM-dd HH:mm"
+                    />
+                  </DateHoverCard>
                 )}
               </Table.Td>
               <Table.Td>

--- a/apps/web/components/EveMail/MailboxTable/MobileMailboxTable.tsx
+++ b/apps/web/components/EveMail/MailboxTable/MobileMailboxTable.tsx
@@ -7,6 +7,7 @@ import {
   useCharacterMailLabels,
 } from "@jitaspace/hooks";
 import {
+  DateHoverCard,
   EveMailSenderAnchor,
   EveMailSenderAvatar,
   EveMailSenderName,
@@ -75,16 +76,14 @@ export const MobileMailboxTable = ({
                           ),
                       )}
                     {message.timestamp && (
-                      <FormattedDateText
-                        size="sm"
-                        date={
-                          message.timestamp
-                            ? new Date(message.timestamp)
-                            : undefined
-                        }
-                        format="LLL dd"
-                        fw={message.is_read ? "normal" : "bold"}
-                      />
+                      <DateHoverCard date={new Date(message.timestamp)}>
+                        <FormattedDateText
+                          size="sm"
+                          date={new Date(message.timestamp)}
+                          format="LLL dd"
+                          fw={message.is_read ? "normal" : "bold"}
+                        />
+                      </DateHoverCard>
                     )}
                   </Group>
                 </Group>

--- a/apps/web/components/EveMail/MessagePanel.tsx
+++ b/apps/web/components/EveMail/MessagePanel.tsx
@@ -6,6 +6,7 @@ import {
   useCharacterMailLabels,
 } from "@jitaspace/hooks";
 import {
+  DateHoverCard,
   EveEntityAnchor,
   EveEntityAvatar,
   EveEntityName,
@@ -70,11 +71,13 @@ export function MessagePanel({
             </EveMailSenderAnchor>
           </Group>
           {mail?.data.timestamp && (
-            <FormattedDateText
-              span
-              date={new Date(mail?.data.timestamp)}
-              format="yyyy-MM-dd HH:mm"
-            />
+            <DateHoverCard date={new Date(mail?.data.timestamp)}>
+              <FormattedDateText
+                span
+                date={new Date(mail?.data.timestamp)}
+                format="yyyy-MM-dd HH:mm"
+              />
+            </DateHoverCard>
           )}
         </Group>
       )}

--- a/apps/web/components/Market/MarketOrdersDataTable.tsx
+++ b/apps/web/components/Market/MarketOrdersDataTable.tsx
@@ -10,6 +10,7 @@ import {
 
 import type { RegionalMarketOrder } from "@jitaspace/hooks";
 import {
+  DateHoverCard,
   EveEntityAnchor,
   EveEntityName,
   TimeAgoText,
@@ -98,11 +99,13 @@ export const MarketOrdersDataTable = memo(
           header: "Issued",
           accessorKey: "issued",
           Cell: ({ renderedCellValue: _renderedCellValue, row, cell: _cell }) => (
-            <TimeAgoText
-              inherit
-              date={new Date(row.original.issued)}
-              addSuffix
-            />
+            <DateHoverCard date={new Date(row.original.issued)}>
+              <TimeAgoText
+                inherit
+                date={new Date(row.original.issued)}
+                addSuffix
+              />
+            </DateHoverCard>
           ),
         },
         {
@@ -112,7 +115,9 @@ export const MarketOrdersDataTable = memo(
             return addDays(new Date(row.issued), 30);
           },
           Cell: ({ renderedCellValue: _renderedCellValue, row: _row, cell }) => (
-            <TimeAgoText inherit date={cell.getValue<Date>()} addSuffix />
+            <DateHoverCard date={cell.getValue<Date>()}>
+              <TimeAgoText inherit date={cell.getValue<Date>()} addSuffix />
+            </DateHoverCard>
           ),
         },
         /*

--- a/apps/web/components/Travel/KillmailButton.tsx
+++ b/apps/web/components/Travel/KillmailButton.tsx
@@ -18,6 +18,7 @@ import {
   CharacterName,
   CorporationAvatar,
   CorporationName,
+  DateHoverCard,
   FactionAvatar,
   FactionName,
   TimeAgoText,
@@ -169,10 +170,12 @@ export const KillmailButton = memo(
             )}
             <Group>
               {data?.data.killmail_time && (
-                <TimeAgoText
-                  date={new Date(data?.data.killmail_time)}
-                  addSuffix
-                />
+                <DateHoverCard date={new Date(data?.data.killmail_time)}>
+                  <TimeAgoText
+                    date={new Date(data?.data.killmail_time)}
+                    addSuffix
+                  />
+                </DateHoverCard>
               )}
             </Group>
           </Group>

--- a/apps/web/components/Wallet/WalletTable.tsx
+++ b/apps/web/components/Wallet/WalletTable.tsx
@@ -9,6 +9,7 @@ import {
 
 import type { CharacterWalletJournalEntry } from "@jitaspace/hooks";
 import {
+  DateHoverCard,
   EveEntityAnchor,
   EveEntityAvatar,
   EveEntityName,
@@ -45,7 +46,9 @@ export const WalletTable = memo(({ entries }: WalletTableProps) => {
         size: 40,
         enableColumnFilterModes: false, //keep this as only date-range filter with between inclusive filterFn
         Cell: ({ cell }) => (
-          <FormattedDateText size="sm" date={cell.getValue<Date>()} />
+          <DateHoverCard date={cell.getValue<Date>()}>
+            <FormattedDateText size="sm" date={cell.getValue<Date>()} />
+          </DateHoverCard>
         ), //render Date as a string
         Header: ({ column }) => <em>{column.columnDef.header}</em>, //custom header markup
       },

--- a/apps/web/components/Wars/WarsTable.tsx
+++ b/apps/web/components/Wars/WarsTable.tsx
@@ -16,6 +16,7 @@ import {
   CorporationAnchor,
   CorporationAvatar,
   CorporationName,
+  DateHoverCard,
   FormattedDateText,
   TimeAgoText,
   WarAnchor,
@@ -236,10 +237,12 @@ export const WarsTable = ({ wars }: WarsTableProps) => {
         header: "Declared On",
         accessorKey: "declaredDate",
         Cell: ({ renderedCellValue: _renderedCellValue, row, cell: _cell }) => (
-          <FormattedDateText
-            inherit
-            date={new Date(row.original.declaredDate)}
-          />
+          <DateHoverCard date={new Date(row.original.declaredDate)}>
+            <FormattedDateText
+              inherit
+              date={new Date(row.original.declaredDate)}
+            />
+          </DateHoverCard>
         ),
       },
       {
@@ -248,10 +251,12 @@ export const WarsTable = ({ wars }: WarsTableProps) => {
         accessorKey: "startedDate",
         Cell: ({ renderedCellValue: _renderedCellValue, row, cell: _cell }) =>
           row.original.startedDate && (
-            <FormattedDateText
-              inherit
-              date={new Date(row.original.startedDate)}
-            />
+            <DateHoverCard date={new Date(row.original.startedDate)}>
+              <FormattedDateText
+                inherit
+                date={new Date(row.original.startedDate)}
+              />
+            </DateHoverCard>
           ),
       },
       {
@@ -260,10 +265,12 @@ export const WarsTable = ({ wars }: WarsTableProps) => {
         accessorKey: "retractedDate",
         Cell: ({ renderedCellValue: _renderedCellValue, row, cell: _cell }) =>
           row.original.retractedDate && (
-            <FormattedDateText
-              inherit
-              date={new Date(row.original.retractedDate)}
-            />
+            <DateHoverCard date={new Date(row.original.retractedDate)}>
+              <FormattedDateText
+                inherit
+                date={new Date(row.original.retractedDate)}
+              />
+            </DateHoverCard>
           ),
       },
       {
@@ -272,12 +279,12 @@ export const WarsTable = ({ wars }: WarsTableProps) => {
         accessorKey: "finishedDate",
         Cell: ({ renderedCellValue: _renderedCellValue, row, cell: _cell }) =>
           row.original.finishedDate && (
-            <>
+            <DateHoverCard date={new Date(row.original.finishedDate)}>
               <FormattedDateText
                 inherit
                 date={new Date(row.original.finishedDate)}
               />
-            </>
+            </DateHoverCard>
           ),
       },
       {
@@ -286,11 +293,13 @@ export const WarsTable = ({ wars }: WarsTableProps) => {
         accessorKey: "updatedAt",
         Cell: ({ renderedCellValue: _renderedCellValue, row, cell: _cell }) =>
           row.original.updatedAt && (
-            <TimeAgoText
-              inherit
-              date={new Date(row.original.updatedAt)}
-              addSuffix
-            />
+            <DateHoverCard date={new Date(row.original.updatedAt)}>
+              <TimeAgoText
+                inherit
+                date={new Date(row.original.updatedAt)}
+                addSuffix
+              />
+            </DateHoverCard>
           ),
       },
     ],

--- a/apps/web/tests/CalendarComponents.test.tsx
+++ b/apps/web/tests/CalendarComponents.test.tsx
@@ -32,6 +32,7 @@ jest.mock("@mantine/modals", () => ({
 // ---------------------------------------------------------------------------
 
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   CharacterAnchor: ({ children }: { children?: ReactNode }) => (
     <a href="#">{children}</a>
   ),

--- a/apps/web/tests/EveMailComponents.test.tsx
+++ b/apps/web/tests/EveMailComponents.test.tsx
@@ -54,6 +54,7 @@ jest.mock("@jitaspace/utils", () => ({
 
 // Passthrough / simple stubs for UI components
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   EveEntityAnchor: ({ children }: { children?: ReactNode }) => (
     <a href="#">{children}</a>
   ),

--- a/apps/web/tests/calendarEventPage.test.tsx
+++ b/apps/web/tests/calendarEventPage.test.tsx
@@ -29,6 +29,7 @@ jest.mock("@jitaspace/eve-icons", () => ({
 }));
 
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   CharacterAnchor: ({ children }: { children?: ReactNode }) => (
     <a href="#">{children}</a>
   ),

--- a/apps/web/tests/corporationCard.test.tsx
+++ b/apps/web/tests/corporationCard.test.tsx
@@ -12,6 +12,7 @@ jest.mock("@jitaspace/hooks", () => ({
 }));
 
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   AllianceAnchor: ({ children }: { children?: ReactNode }) => <a href="#">{children}</a>,
   CharacterAnchor: ({ children }: { children?: ReactNode }) => <a href="#">{children}</a>,
   CorporationAnchor: ({ children }: { children?: ReactNode }) => <a href="#">{children}</a>,

--- a/apps/web/tests/dataTables.test.tsx
+++ b/apps/web/tests/dataTables.test.tsx
@@ -21,6 +21,7 @@ jest.mock("@jitaspace/hooks", () => ({
 // @jitaspace/ui stubs (used by AgentsTable, MarketOrdersDataTable, CompareTable)
 // ---------------------------------------------------------------------------
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   CharacterAnchor: ({ children }: { children?: ReactNode }) => (
     <span data-testid="char-anchor">{children}</span>
   ),

--- a/apps/web/tests/statusPage.test.tsx
+++ b/apps/web/tests/statusPage.test.tsx
@@ -34,6 +34,7 @@ jest.mock("@jitaspace/sde-client", () => ({
 }));
 
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   FormattedDateText: ({ date }: { date?: Date }) => (
     <span>{date ? `Date ${date.toISOString()}` : "No date"}</span>
   ),

--- a/apps/web/tests/travelComponents.test.tsx
+++ b/apps/web/tests/travelComponents.test.tsx
@@ -32,6 +32,7 @@ jest.mock("@jitaspace/eve-icons", () => ({
 // @jitaspace/ui -> render identifiable text so we can assert on entity ids
 // ---------------------------------------------------------------------------
 jest.mock("@jitaspace/ui", () => ({
+  DateHoverCard: ({ children }: { children?: ReactNode }) => <>{children}</>,
   CharacterAvatar: ({ characterId }: { characterId?: number }) => (
     <span data-testid="char-avatar">{`char-avatar-${characterId ?? "?"}`}</span>
   ),

--- a/packages/ui/DateText/DateHoverCard.tsx
+++ b/packages/ui/DateText/DateHoverCard.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import React, { memo, type ReactNode } from "react";
+import { Group, HoverCard, type HoverCardProps, Stack, Text } from "@mantine/core";
+import { format, formatDistanceToNow } from "date-fns";
+
+type DateHoverCardProps = HoverCardProps & {
+  date?: Date;
+  children: ReactNode;
+};
+
+function padTwo(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatUtc(date: Date): string {
+  return `${date.getUTCFullYear()}-${padTwo(date.getUTCMonth() + 1)}-${padTwo(date.getUTCDate())} ${padTwo(date.getUTCHours())}:${padTwo(date.getUTCMinutes())}:${padTwo(date.getUTCSeconds())}`;
+}
+
+export const DateHoverCard = memo(
+  ({ date, children, ...hoverCardProps }: DateHoverCardProps) => {
+    if (!date) return <>{children}</>;
+
+    return (
+      <HoverCard
+        width={240}
+        shadow="md"
+        withArrow
+        openDelay={200}
+        closeDelay={100}
+        {...hoverCardProps}
+      >
+        <HoverCard.Target>
+          <span style={{ cursor: "default" }}>{children}</span>
+        </HoverCard.Target>
+        <HoverCard.Dropdown>
+          <Stack gap="xs">
+            <Text size="sm" fw={500}>
+              {formatDistanceToNow(date, { addSuffix: true })}
+            </Text>
+            <Group justify="space-between" gap="xs" wrap="nowrap">
+              <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+                Local
+              </Text>
+              <Text size="xs" style={{ textAlign: "right" }}>
+                {format(date, "yyyy-MM-dd HH:mm:ss")}
+              </Text>
+            </Group>
+            <Group justify="space-between" gap="xs" wrap="nowrap">
+              <Text size="xs" c="dimmed" style={{ flexShrink: 0 }}>
+                EVE Time
+              </Text>
+              <Text size="xs" style={{ textAlign: "right" }}>
+                {formatUtc(date)}
+              </Text>
+            </Group>
+          </Stack>
+        </HoverCard.Dropdown>
+      </HoverCard>
+    );
+  },
+);
+DateHoverCard.displayName = "DateHoverCard";

--- a/packages/ui/DateText/index.ts
+++ b/packages/ui/DateText/index.ts
@@ -1,2 +1,3 @@
+export * from "./DateHoverCard";
 export * from "./FormattedDateText";
 export * from "./TimeAgoText";


### PR DESCRIPTION
## Summary

- Adds a new `DateHoverCard` component to `@jitaspace/ui` that wraps any trigger element in a Mantine `HoverCard`
- On hover the card shows three views of the date: **relative time** ("2 days ago"), **local timezone**, and **EVE Time (UTC)**
- Props extend Mantine's `HoverCardProps` so callers can override any hover card setting; sensible defaults are applied (width 240, shadow md, arrow, 200ms open delay)
- Replaces the scattered `Tooltip + FormattedDateText + TimeAgoText` and standalone `FormattedDateText` patterns across **18 files** with `DateHoverCard`, removing redundant wrappers and giving every date a consistent, information-rich hover experience

## Changed files

**New component**
- `packages/ui/DateText/DateHoverCard.tsx` — the component itself
- `packages/ui/DateText/index.ts` — re-exports it

**Updated (app/web)**
- `kill/[killId]` — collapsed `FormattedDateText • TimeAgoText` pair into a single `DateHoverCard`
- `notifications` — replaced `Tooltip{FormattedDateText} + TimeAgoText` with `DateHoverCard`
- `war/[warId]` — wrapped declared / started / retracted / finished dates
- `calendar/[eventId]`, `CalendarEventDetailsPanel` — wrapped event "When" date
- `character/[characterId]` — wrapped birthday
- `status` — wrapped TQ start time and SDE dates
- `Auth/AuthenticatedCharacterTokenDetailsPanel` — replaced `Tooltip{FormattedDateText} + TimeAgoText`
- `EveMail/MailboxTable` (desktop + mobile), `MessagePanel` — wrapped mail timestamps
- `Calendar/CalendarEventList` (desktop + mobile) — replaced duration `Tooltip` + time with `DateHoverCard`
- `Card/CorporationCard` — wrapped founded date
- `Wallet/WalletTable`, `Market/MarketOrdersDataTable`, `Wars/WarsTable`, `Travel/KillmailButton` — wrapped all date cells

## Test plan

- [ ] Hover over any date in the app — card should show relative time, local date, and EVE Time (UTC)
- [ ] Verify dates that can be `undefined` (loading states) render children without a hover card
- [ ] Confirm removed `Tooltip`/duplicate `FormattedDateText` instances no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)