### PR TITLE
fix(web): show category name in category page breadcrumbs

### DIFF
--- a/.changeset/fix-category-breadcrumbs-name.md
+++ b/.changeset/fix-category-breadcrumbs-name.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/ui": patch
+"@jitaspace/web": patch
+---
+
+Fix the category page breadcrumbs showing a loading skeleton forever. `CategoryBreadcrumbs` was still passing `categoryId` to the now-presentational `CategoryName`, which only accepts a `name` prop. It now takes a `categoryName` prop (mirroring `GroupBreadcrumbs`), and the category page passes the name it already fetched server-side.

--- a/apps/web/app/category/[categoryId]/page.tsx
+++ b/apps/web/app/category/[categoryId]/page.tsx
@@ -90,7 +90,7 @@ async function PageContent({
         <Group gap="xl">
           <Title order={1}>{name}</Title>
         </Group>
-        <CategoryBreadcrumbs categoryId={categoryId} />
+        <CategoryBreadcrumbs categoryId={categoryId} categoryName={name} />
         <Stack gap="xs">
           <Title order={3}>Groups</Title>
           <SimpleGrid spacing="xs" cols={{ base: 1, xs: 2, md: 3 }}>

--- a/packages/ui/Breadcrumbs/CategoryBreadcrumbs.tsx
+++ b/packages/ui/Breadcrumbs/CategoryBreadcrumbs.tsx
@@ -15,17 +15,18 @@ import { CategoryName } from "../Text";
 
 export type CategoryBreadcrumbsProps = Omit<BreadcrumbsProps, "children"> & {
   categoryId?: number;
+  categoryName?: string;
 };
 
 export const CategoryBreadcrumbs = memo(
-  ({ categoryId, ...otherProps }: CategoryBreadcrumbsProps) => {
+  ({ categoryId, categoryName, ...otherProps }: CategoryBreadcrumbsProps) => {
     return (
       <Breadcrumbs {...otherProps}>
         <Anchor component={Link} href="/categories">
           <Text>Inventory</Text>
         </Anchor>
         <CategoryAnchor categoryId={categoryId}>
-          <CategoryName categoryId={categoryId} />
+          <CategoryName name={categoryName} />
         </CategoryAnchor>
       </Breadcrumbs>
     );

--- a/packages/ui/tests/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/ui/tests/Breadcrumbs/Breadcrumbs.test.tsx
@@ -47,14 +47,26 @@ const renderWithMantine = (ui: ReactNode) =>
   render(<MantineProvider>{ui}</MantineProvider>);
 
 describe("CategoryBreadcrumbs", () => {
-  it("renders the Inventory root link and a category anchor for the given id", () => {
-    const { container } = renderWithMantine(<CategoryBreadcrumbs categoryId={6} />);
+  it("renders Inventory root plus the category name from props", () => {
+    const { container } = renderWithMantine(
+      <CategoryBreadcrumbs categoryId={6} categoryName="Ship" />,
+    );
     // Static root link.
     const inventory = screen.getByText("Inventory");
     expect(inventory).toBeInTheDocument();
     expect(inventory.closest("a")).toHaveAttribute("href", "/categories");
-    // CategoryName here only receives `categoryId` (not a `name`), so it shows
-    // a skeleton placeholder wrapped by a CategoryAnchor -> /category/<id>.
+    // The category segment renders its name and links to the detail page.
+    expect(screen.getByText("Ship")).toBeInTheDocument();
+    expect(screen.getByText("Ship").closest("a")).toHaveAttribute(
+      "href",
+      "/category/6",
+    );
+    expect(container.querySelector(".mantine-Skeleton-root")).toBeFalsy();
+  });
+
+  it("renders a skeleton placeholder when the category name is absent", () => {
+    const { container } = renderWithMantine(<CategoryBreadcrumbs categoryId={6} />);
+    expect(screen.getByText("Inventory")).toBeInTheDocument();
     const categoryLink = container.querySelector('a[href="/category/6"]');
     expect(categoryLink).toBeTruthy();
     expect(


### PR DESCRIPTION
## Summary

Fixes the breadcrumbs on `/category/[categoryId]` (e.g. [jita.space/category/16](https://www.jita.space/category/16)) showing a loading skeleton forever next to "Inventory /", as reported on Discord.

## Root cause

The decoupling refactor (070b967a) converted `CategoryName` in `packages/ui` into a pure presentational component taking a `name` prop instead of fetching by `categoryId`. `GroupBreadcrumbs` was updated accordingly (new `categoryName`/`groupName` props + a connected wrapper in `apps/web/components/Breadcrumbs/`), but **`CategoryBreadcrumbs` was missed**: it kept passing `categoryId` to `CategoryName`, which silently ignores it, so the name was always `undefined` → permanent skeleton. The category page is its only consumer. The previous test codified the broken behavior (asserted the skeleton).

## Fix

- `packages/ui/Breadcrumbs/CategoryBreadcrumbs.tsx`: add `categoryName?: string` prop and pass it as `name` to `CategoryName`, mirroring `GroupBreadcrumbs`.
- `apps/web/app/category/[categoryId]/page.tsx`: pass `categoryName={name}` — the server component already has the name from Prisma, so the breadcrumb renders instantly with no client fetch.
- Updated tests: name provided → renders linked category name with no skeleton; name absent → skeleton (still covered).

## Verification

- Dev server on `/category/16`: breadcrumb renders **Inventory / Skill** with `href="/category/16"`, zero skeletons, no console errors.
- Spot-checked `/type/587` (inventory + market breadcrumbs) and `/group/25` — all resolve correctly (those use the connected wrappers and were unaffected).
- `packages/ui`: 344 tests pass; `apps/web`: 494 tests pass.
- Repo-wide `type-check`/`lint` failures are pre-existing/environmental (identical error count on clean baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)