### PR TITLE
feat(web): Inngest background-jobs dashboard on the status page

### DIFF
--- a/.changeset/inngest-jobs-dashboard.md
+++ b/.changeset/inngest-jobs-dashboard.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+feat(web): add Inngest background-jobs dashboard to the status page — per-job last-run status, durations, 24h counts and run history for jobs with recent runs, fetched through a server function backed by the Inngest REST API (no public endpoint)

--- a/apps/web/app/status/actions.ts
+++ b/apps/web/app/status/actions.ts
@@ -1,0 +1,140 @@
+"use server";
+
+import type {
+  InngestApiEvent,
+  InngestStatusResponse,
+} from "~/lib/inngestStatus";
+import { env } from "~/env";
+import {
+  buildInngestStatusResponse,
+  collectTerminalRuns,
+  INNGEST_STATUS_WINDOW_HOURS,
+} from "~/lib/inngestStatus";
+
+/**
+ * Server function summarizing Inngest background-job runs for the status
+ * page, built from the Inngest REST API (see lib/inngestStatus.ts for the
+ * approach). There is deliberately no public route for this — the data is
+ * only reachable through this server function. Responses are cached briefly
+ * so status-page polling doesn't hammer the Inngest API.
+ *
+ * The signing key authenticates us to the Inngest API and must never reach
+ * the client; this function only returns aggregated run data.
+ */
+
+const CACHE_TTL_MS = 30 * 1000;
+const ERROR_CACHE_TTL_MS = 15 * 1000;
+const PAGE_SIZE = 100;
+const REQUEST_TIMEOUT_MS = 10 * 1000;
+
+// The hosted API in production; the local `inngest dev` server otherwise.
+const INNGEST_API_BASE_URL =
+  env.INNGEST_BASE_URL ??
+  (env.NODE_ENV === "production"
+    ? "https://api.inngest.com"
+    : "http://localhost:8288");
+
+let cache: { expiresAt: number; payload: InngestStatusResponse } | null = null;
+
+const apiFetch = async (path: string, params?: Record<string, string>) => {
+  const url = new URL(path, INNGEST_API_BASE_URL);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${env.INNGEST_SIGNING_KEY}` },
+    cache: "no-store",
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Inngest API responded with ${response.status}`);
+  }
+  return response.json() as Promise<unknown>;
+};
+
+const fetchEvents = async ({
+  name,
+  receivedAfter,
+  maxPages,
+}: {
+  name: string;
+  receivedAfter: string;
+  maxPages: number;
+}): Promise<InngestApiEvent[]> => {
+  const events: InngestApiEvent[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    const body = (await apiFetch("/v1/events", {
+      received_after: receivedAfter,
+      limit: String(PAGE_SIZE),
+      name,
+      ...(cursor ? { cursor } : {}),
+    })) as { data?: InngestApiEvent[] | null };
+
+    const items = body.data ?? [];
+    events.push(...items);
+
+    const last = items[items.length - 1];
+    if (items.length < PAGE_SIZE || !last?.internal_id) break;
+    cursor = last.internal_id;
+  }
+
+  return events;
+};
+
+const computeStatus = async (): Promise<InngestStatusResponse> => {
+  const fetchedAt = new Date();
+  const windowStart = new Date(
+    fetchedAt.getTime() - INNGEST_STATUS_WINDOW_HOURS * 60 * 60 * 1000,
+  ).toISOString();
+
+  try {
+    // The finished sweep is the backbone; the failed/cancelled sweeps only
+    // add error detail, so those degrade to empty on failure instead of
+    // failing the response.
+    const [finished, failed, cancelled] = await Promise.all([
+      fetchEvents({
+        name: "inngest/function.finished",
+        receivedAfter: windowStart,
+        maxPages: 5,
+      }),
+      fetchEvents({
+        name: "inngest/function.failed",
+        receivedAfter: windowStart,
+        maxPages: 2,
+      }).catch(() => []),
+      fetchEvents({
+        name: "inngest/function.cancelled",
+        receivedAfter: windowStart,
+        maxPages: 1,
+      }).catch(() => []),
+    ]);
+
+    const terminalRuns = collectTerminalRuns([
+      ...finished,
+      ...failed,
+      ...cancelled,
+    ]);
+
+    return buildInngestStatusResponse({ terminalRuns, fetchedAt });
+  } catch (error) {
+    return buildInngestStatusResponse({
+      terminalRuns: new Map(),
+      fetchedAt,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};
+
+export async function getInngestStatus(): Promise<InngestStatusResponse> {
+  if (!cache || Date.now() >= cache.expiresAt) {
+    const payload = await computeStatus();
+    cache = {
+      payload,
+      expiresAt:
+        Date.now() + (payload.error ? ERROR_CACHE_TTL_MS : CACHE_TTL_MS),
+    };
+  }
+  return cache.payload;
+}

--- a/apps/web/app/status/actions.ts
+++ b/apps/web/app/status/actions.ts
@@ -75,7 +75,7 @@ const fetchEvents = async ({
     const items = body.data ?? [];
     events.push(...items);
 
-    const last = items[items.length - 1];
+    const last = items.at(-1);
     if (items.length < PAGE_SIZE || !last?.internal_id) break;
     cursor = last.internal_id;
   }

--- a/apps/web/app/status/page.client.tsx
+++ b/apps/web/app/status/page.client.tsx
@@ -24,7 +24,11 @@ import {
   IconCircleX,
 } from "@tabler/icons-react";
 
-import { getRateLimitBuildDate, useGetMetaCompatibilityDates, useGetMetaStatus } from "@jitaspace/esi-client";
+import {
+  getRateLimitBuildDate,
+  useGetMetaCompatibilityDates,
+  useGetMetaStatus,
+} from "@jitaspace/esi-client";
 import { useServerStatus } from "@jitaspace/hooks";
 import { useGetVersion } from "@jitaspace/sde-client";
 import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
@@ -33,6 +37,7 @@ import type { SdeLastModifiedResponse, VercelStatusResponse } from "./types";
 import { env } from "~/env";
 import { EsiRateLimitDashboard } from "../../components/Status/EsiRateLimitDashboard";
 import { EsiStatusDashboard } from "../../components/Status/EsiStatusDashboard";
+import { InngestJobsDashboard } from "../../components/Status/InngestJobsDashboard";
 
 export interface PageProps {
   vercelStatusData: VercelStatusResponse | null;
@@ -136,17 +141,19 @@ export default function StatusPage({
                   </Text>
                   <Group gap="xs">
                     <Text size="sm">{buildDate || "-"}</Text>
-                    {buildDate && latestCompatibilityDate && (
-                      buildDate >= latestCompatibilityDate ? (
+                    {buildDate &&
+                      latestCompatibilityDate &&
+                      (buildDate >= latestCompatibilityDate ? (
                         <Tooltip label="ESI compatibility date is up to date!">
                           <IconCircleCheck color="green" size={14} />
                         </Tooltip>
                       ) : (
-                        <Tooltip label={`ESI compatibility date is outdated! Latest: ${latestCompatibilityDate}`}>
+                        <Tooltip
+                          label={`ESI compatibility date is outdated! Latest: ${latestCompatibilityDate}`}
+                        >
                           <IconCircleX color="red" size={14} />
                         </Tooltip>
-                      )
-                    )}
+                      ))}
                   </Group>
                 </Group>
                 <Group justify="space-between">
@@ -290,6 +297,8 @@ export default function StatusPage({
             </Stack>
           </Card>
         </SimpleGrid>
+
+        <InngestJobsDashboard />
 
         <EsiRateLimitDashboard />
       </Stack>

--- a/apps/web/components/Status/InngestJobsDashboard.tsx
+++ b/apps/web/components/Status/InngestJobsDashboard.tsx
@@ -1,0 +1,330 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Alert,
+  Badge,
+  ColorSwatch,
+  Group,
+  Loader,
+  Paper,
+  ScrollArea,
+  SimpleGrid,
+  Stack,
+  Table,
+  Text,
+  Title,
+  Tooltip,
+} from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { TimeAgoText } from "@jitaspace/ui";
+
+import type {
+  InngestJobStatus,
+  InngestRunStatus,
+  InngestRunSummary,
+} from "~/lib/inngestStatus";
+import { getInngestStatus } from "~/app/status/actions";
+
+const STATUS_COLORS: Record<InngestRunStatus, string> = {
+  Running: "blue",
+  Completed: "green",
+  Failed: "red",
+  Cancelled: "gray",
+};
+
+const formatDuration = (ms: number | null) => {
+  if (ms === null || ms < 0) return "-";
+  if (ms < 1000) return "<1s";
+
+  const totalSeconds = Math.round(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+};
+
+const runTimestamp = (run: InngestRunSummary) => run.endedAt ?? run.queuedAt;
+
+const runTooltip = (run: InngestRunSummary) => {
+  const timestamp = runTimestamp(run);
+  const parts: string[] = [run.status];
+  if (run.durationMs !== null)
+    parts.push(`in ${formatDuration(run.durationMs)}`);
+  if (timestamp) parts.push(`· ${new Date(timestamp).toLocaleString()}`);
+  if (run.errorMessage) parts.push(`— ${run.errorMessage}`);
+  return parts.join(" ");
+};
+
+/** Jobs whose latest run failed sort first, then by most recent activity. */
+const jobPriority = (job: InngestJobStatus) =>
+  job.lastRun?.status === "Failed" ? 0 : 1;
+
+export function InngestJobsDashboard() {
+  const { data, error, isLoading } = useQuery({
+    // Data comes from a server function (app/status/actions.ts), not a
+    // public route — React Query invokes it like any async function.
+    queryKey: ["inngest-status"],
+    queryFn: () => getInngestStatus(),
+    refetchInterval: 30 * 1000,
+  });
+
+  const sortedJobs = useMemo(() => {
+    if (!data) return [];
+    return [...data.jobs].sort((a, b) => {
+      const priorityDelta = jobPriority(a) - jobPriority(b);
+      if (priorityDelta !== 0) return priorityDelta;
+      const aTimestamp = a.lastRun ? (runTimestamp(a.lastRun) ?? 0) : 0;
+      const bTimestamp = b.lastRun ? (runTimestamp(b.lastRun) ?? 0) : 0;
+      if (aTimestamp !== bTimestamp) return bTimestamp - aTimestamp;
+      return a.name.localeCompare(b.name);
+    });
+  }, [data]);
+
+  const overallBadge = useMemo(() => {
+    if (!data || data.error) return null;
+    if (data.totals.failed > 0) {
+      return {
+        color: "red",
+        label: `${data.totals.failed} Failed Run${data.totals.failed === 1 ? "" : "s"}`,
+      };
+    }
+    if (data.totals.runs === 0) {
+      return { color: "gray", label: "No Recent Runs" };
+    }
+    return { color: "green", label: "All Jobs Healthy" };
+  }, [data]);
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="flex-end">
+        <Stack gap={0}>
+          <Title order={3}>Background Jobs</Title>
+          <Text size="xs" c="dimmed">
+            Inngest job runs over the last {data?.windowHours ?? 24} hours ·
+            jobs with no recent runs are not listed
+          </Text>
+        </Stack>
+        {overallBadge && (
+          <Badge color={overallBadge.color} variant="light">
+            {overallBadge.label}
+          </Badge>
+        )}
+      </Group>
+
+      {isLoading && (
+        <Group justify="center" py="xl">
+          <Loader size="sm" />
+        </Group>
+      )}
+
+      {error && (
+        <Alert
+          icon={<IconAlertCircle size="1rem" />}
+          color="red"
+          variant="light"
+        >
+          Failed to load background job status: {error.message}
+        </Alert>
+      )}
+
+      {data?.error && (
+        <Alert
+          icon={<IconAlertCircle size="1rem" />}
+          color="yellow"
+          variant="light"
+        >
+          Background job status is currently unavailable: {data.error}
+        </Alert>
+      )}
+
+      {data && !data.error && (
+        <>
+          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+            <Paper withBorder p="md" shadow="xs">
+              <Text size="xs" c="dimmed">
+                Active Jobs
+              </Text>
+              <Text size="xl" fw={700}>
+                {data.totals.jobs.toLocaleString()}
+              </Text>
+              <Text size="xs" c="dimmed">
+                with runs in the window
+              </Text>
+            </Paper>
+
+            <Paper withBorder p="md" shadow="xs">
+              <Text size="xs" c="dimmed">
+                Runs
+              </Text>
+              <Text size="xl" fw={700}>
+                {data.totals.runs.toLocaleString()}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {data.totals.completed.toLocaleString()} completed
+              </Text>
+            </Paper>
+
+            <Paper withBorder p="md" shadow="xs">
+              <Text size="xs" c="dimmed">
+                Failed Runs
+              </Text>
+              <Text
+                size="xl"
+                fw={700}
+                c={data.totals.failed > 0 ? "red" : "green"}
+              >
+                {data.totals.failed.toLocaleString()}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {data.totals.cancelled.toLocaleString()} cancelled
+              </Text>
+            </Paper>
+          </SimpleGrid>
+
+          {sortedJobs.length === 0 ? (
+            <Alert
+              icon={<IconAlertCircle size="1rem" />}
+              color="gray"
+              variant="light"
+            >
+              No job runs in the last {data.windowHours} hours.
+            </Alert>
+          ) : (
+            <ScrollArea>
+              <Table
+                withTableBorder
+                striped
+                highlightOnHover
+                verticalSpacing="xs"
+                fz="sm"
+              >
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Job</Table.Th>
+                    <Table.Th>Status</Table.Th>
+                    <Table.Th>Last Run</Table.Th>
+                    <Table.Th ta="right">Duration</Table.Th>
+                    <Table.Th ta="right">Runs</Table.Th>
+                    <Table.Th>History</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {sortedJobs.map((job) => {
+                    const lastRun = job.lastRun;
+                    const lastRunTimestamp = lastRun
+                      ? runTimestamp(lastRun)
+                      : null;
+                    const status = lastRun?.status ?? "Completed";
+                    const statusBadge = (
+                      <Badge color={STATUS_COLORS[status]} variant="light">
+                        {status}
+                      </Badge>
+                    );
+
+                    return (
+                      <Table.Tr key={job.id}>
+                        <Table.Td>
+                          <Text size="sm" fw={600}>
+                            {job.name}
+                          </Text>
+                          <Text size="xs" c="dimmed">
+                            {job.id}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          {lastRun?.status === "Failed" &&
+                          lastRun.errorMessage ? (
+                            <Tooltip
+                              multiline
+                              w={320}
+                              label={`${lastRun.errorName ?? "Error"}: ${lastRun.errorMessage}`}
+                              withArrow
+                            >
+                              {statusBadge}
+                            </Tooltip>
+                          ) : (
+                            statusBadge
+                          )}
+                        </Table.Td>
+                        <Table.Td>
+                          {lastRunTimestamp ? (
+                            <Tooltip
+                              label={new Date(
+                                lastRunTimestamp,
+                              ).toLocaleString()}
+                              withArrow
+                            >
+                              <TimeAgoText
+                                date={new Date(lastRunTimestamp)}
+                                addSuffix
+                                size="sm"
+                                span
+                              />
+                            </Tooltip>
+                          ) : (
+                            <Text size="sm" c="dimmed">
+                              -
+                            </Text>
+                          )}
+                        </Table.Td>
+                        <Table.Td ta="right">
+                          <Text size="sm" span>
+                            {formatDuration(lastRun?.durationMs ?? null)}
+                          </Text>
+                        </Table.Td>
+                        <Table.Td ta="right">
+                          <Text size="sm" span>
+                            {job.counts.total.toLocaleString()}
+                          </Text>
+                          {job.counts.failed > 0 && (
+                            <Text size="xs" c="red" span>
+                              {" "}
+                              ({job.counts.failed.toLocaleString()} failed)
+                            </Text>
+                          )}
+                        </Table.Td>
+                        <Table.Td>
+                          {job.recentRuns.length > 0 ? (
+                            <Group gap={4} wrap="nowrap">
+                              {[...job.recentRuns].reverse().map((run) => (
+                                <Tooltip
+                                  key={run.runId}
+                                  label={runTooltip(run)}
+                                  withArrow
+                                >
+                                  <ColorSwatch
+                                    size={10}
+                                    color={`var(--mantine-color-${STATUS_COLORS[run.status]}-6)`}
+                                  />
+                                </Tooltip>
+                              ))}
+                            </Group>
+                          ) : (
+                            <Text size="xs" c="dimmed">
+                              -
+                            </Text>
+                          )}
+                        </Table.Td>
+                      </Table.Tr>
+                    );
+                  })}
+                </Table.Tbody>
+              </Table>
+            </ScrollArea>
+          )}
+
+          <Text size="xs" c="dimmed">
+            Updated {new Date(data.fetchedAt).toLocaleTimeString()} · refreshes
+            every 30 seconds
+          </Text>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -16,6 +16,12 @@ const server = z.object({
   EVE_CLIENT_SECRET: z.string(),
 
   INNGEST_SIGNING_KEY: z.string().min(1),
+  /**
+   * Overrides the Inngest REST API base URL used by the status endpoint
+   * (defaults to https://api.inngest.com in production and the local
+   * `inngest dev` server otherwise).
+   */
+  INNGEST_BASE_URL: z.string().url().optional(),
   CRON_SECRET: z.string().min(16),
 
   SKIP_BUILD_STATIC_GENERATION: z.string(),
@@ -51,6 +57,7 @@ const processEnv = {
   EVE_CLIENT_ID: process.env.EVE_CLIENT_ID,
   EVE_CLIENT_SECRET: process.env.EVE_CLIENT_SECRET,
   INNGEST_SIGNING_KEY: process.env.INNGEST_SIGNING_KEY,
+  INNGEST_BASE_URL: process.env.INNGEST_BASE_URL,
   CRON_SECRET: process.env.CRON_SECRET,
   SKIP_BUILD_STATIC_GENERATION: process.env.SKIP_BUILD_STATIC_GENERATION,
   NEXT_PUBLIC_UMAMI_WEBSITE_ID: process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID,

--- a/apps/web/lib/inngestStatus.ts
+++ b/apps/web/lib/inngestStatus.ts
@@ -1,0 +1,315 @@
+/**
+ * Types and pure aggregation logic for the Inngest background-jobs status
+ * server function (`app/status/actions.ts`) and the status-page dashboard.
+ *
+ * The public Inngest REST API has no "list functions" or "list all runs"
+ * endpoint, so run state is reconstructed from the
+ * `inngest/function.finished|failed|cancelled` system events (queryable via
+ * `GET /v1/events?name=...`). This is deliberately data-driven: only jobs
+ * with at least one run inside the window appear, display names are derived
+ * from function slugs, and currently-running jobs are not detected (that
+ * would require a static event→function mapping; see git history /
+ * the eve-scrape registry if richer UX is ever wanted).
+ *
+ * Run IDs are ULIDs whose first 10 characters encode the time the run was
+ * queued; durations are derived from that, so they include time spent queued.
+ *
+ * Keep this module free of server-only imports — client components import
+ * types from it.
+ */
+
+export const INNGEST_STATUS_WINDOW_HOURS = 24;
+export const MAX_RECENT_RUNS_PER_JOB = 10;
+
+/** Run statuses as reported by the Inngest API. */
+export type InngestRunStatus = "Running" | "Completed" | "Failed" | "Cancelled";
+
+export interface InngestRunSummary {
+  runId: string;
+  status: InngestRunStatus;
+  /** When the run was queued, in ms since epoch (decoded from the run ULID). */
+  queuedAt: number | null;
+  /** When the run reached a terminal state, in ms since epoch. */
+  endedAt: number | null;
+  /** `endedAt - queuedAt`; includes time spent waiting in the queue. */
+  durationMs: number | null;
+  errorName?: string;
+  errorMessage?: string;
+}
+
+export interface InngestJobStatus {
+  /** Fully-qualified function slug as reported by the Inngest API. */
+  id: string;
+  /** Display name derived from the slug (e.g. "Scrape ESI Alliances"). */
+  name: string;
+  /** Most recent run within the window. */
+  lastRun: InngestRunSummary | null;
+  counts: {
+    completed: number;
+    failed: number;
+    cancelled: number;
+    total: number;
+  };
+  /** Newest-first, capped at MAX_RECENT_RUNS_PER_JOB. */
+  recentRuns: InngestRunSummary[];
+}
+
+export interface InngestStatusResponse {
+  fetchedAt: string;
+  windowHours: number;
+  /** Set when the Inngest API could not be reached; jobs will be empty. */
+  error?: string;
+  /** Only jobs with at least one run within the window. */
+  jobs: InngestJobStatus[];
+  totals: {
+    /** Jobs observed within the window. */
+    jobs: number;
+    runs: number;
+    completed: number;
+    failed: number;
+    cancelled: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Raw Inngest REST API shapes (the subset we consume)
+// ---------------------------------------------------------------------------
+
+export interface InngestApiEvent {
+  internal_id: string;
+  name: string;
+  ts?: number | null;
+  received_at?: string | null;
+  data?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/** Decode the millisecond timestamp encoded in a ULID's first 10 characters. */
+export const ulidTimestamp = (ulid: string): number | null => {
+  if (ulid.length < 10) return null;
+  let timestamp = 0;
+  for (const char of ulid.slice(0, 10).toUpperCase()) {
+    const index = ULID_ALPHABET.indexOf(char);
+    if (index === -1) return null;
+    timestamp = timestamp * 32 + index;
+  }
+  return timestamp;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+export const eventTimestamp = (event: InngestApiEvent): number | null => {
+  if (typeof event.ts === "number" && event.ts > 0) return event.ts;
+  if (event.received_at) {
+    const parsed = Date.parse(event.received_at);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return null;
+};
+
+/** Inngest prefixes function slugs with the app ID (see eve-scrape/client.ts). */
+const APP_SLUG_PREFIX = "jitaspace-";
+
+const ACRONYMS: Record<string, string> = {
+  esi: "ESI",
+  sde: "SDE",
+  npc: "NPC",
+  ids: "IDs",
+};
+
+/**
+ * Best-effort display name for a function slug, e.g.
+ * `jitaspace-scrape-esi-alliances` → "Scrape ESI Alliances". The API only
+ * exposes slugs; the human-readable names live in the function definitions,
+ * which this module must not import (see eve-scrape's import side effects).
+ */
+export const jobNameFromSlug = (slug: string): string => {
+  const id = slug.startsWith(APP_SLUG_PREFIX)
+    ? slug.slice(APP_SLUG_PREFIX.length)
+    : slug;
+  return id
+    .split("-")
+    .filter(Boolean)
+    .map(
+      (word) => ACRONYMS[word] ?? word.charAt(0).toUpperCase() + word.slice(1),
+    )
+    .join(" ");
+};
+
+// ---------------------------------------------------------------------------
+// Terminal runs from system events
+// ---------------------------------------------------------------------------
+
+export interface TerminalRunRecord {
+  runId: string;
+  functionSlug: string;
+  status: Exclude<InngestRunStatus, "Running">;
+  queuedAt: number | null;
+  endedAt: number | null;
+  errorName?: string;
+  errorMessage?: string;
+}
+
+const TERMINAL_STATUSES = new Set(["Completed", "Failed", "Cancelled"]);
+
+/**
+ * Build a map of terminal runs (keyed by run ID) from
+ * `inngest/function.finished|failed|cancelled` system events. Events for the
+ * same run are merged; Failed/Cancelled take precedence over Completed and
+ * error details are kept from whichever event carries them.
+ */
+export const collectTerminalRuns = (
+  events: InngestApiEvent[],
+): Map<string, TerminalRunRecord> => {
+  const runs = new Map<string, TerminalRunRecord>();
+
+  for (const event of events) {
+    const data = asRecord(event.data);
+    if (!data) continue;
+    const runId = asString(data.run_id);
+    const functionSlug = asString(data.function_id);
+    if (!runId || !functionSlug) continue;
+
+    const error = asRecord(data.error);
+    let status: TerminalRunRecord["status"];
+    switch (event.name) {
+      case "inngest/function.failed":
+        status = "Failed";
+        break;
+      case "inngest/function.cancelled":
+        status = "Cancelled";
+        break;
+      case "inngest/function.finished": {
+        const reported = asString(asRecord(data._inngest)?.status);
+        status =
+          reported && TERMINAL_STATUSES.has(reported)
+            ? (reported as TerminalRunRecord["status"])
+            : error
+              ? "Failed"
+              : "Completed";
+        break;
+      }
+      default:
+        continue;
+    }
+
+    const existing = runs.get(runId);
+    const record: TerminalRunRecord = existing ?? {
+      runId,
+      functionSlug,
+      status,
+      queuedAt: ulidTimestamp(runId),
+      endedAt: eventTimestamp(event),
+    };
+
+    if (existing) {
+      // Failed/Cancelled beats Completed; keep the latest end timestamp.
+      if (status !== "Completed") record.status = status;
+      const endedAt = eventTimestamp(event);
+      if (endedAt && (!record.endedAt || endedAt > record.endedAt)) {
+        record.endedAt = endedAt;
+      }
+    }
+
+    if (error) {
+      record.errorName ??= asString(error.name);
+      record.errorMessage ??= asString(error.message);
+    }
+
+    runs.set(runId, record);
+  }
+
+  return runs;
+};
+
+// ---------------------------------------------------------------------------
+// Response assembly
+// ---------------------------------------------------------------------------
+
+const runSortKey = (run: InngestRunSummary) => run.endedAt ?? run.queuedAt ?? 0;
+
+export const buildInngestStatusResponse = ({
+  terminalRuns,
+  fetchedAt,
+  windowHours = INNGEST_STATUS_WINDOW_HOURS,
+  error,
+}: {
+  terminalRuns: Map<string, TerminalRunRecord>;
+  fetchedAt: Date;
+  windowHours?: number;
+  error?: string;
+}): InngestStatusResponse => {
+  const runsBySlug = new Map<string, InngestRunSummary[]>();
+  for (const run of terminalRuns.values()) {
+    const summary: InngestRunSummary = {
+      runId: run.runId,
+      status: run.status,
+      queuedAt: run.queuedAt,
+      endedAt: run.endedAt,
+      durationMs:
+        run.endedAt !== null && run.queuedAt !== null
+          ? Math.max(0, run.endedAt - run.queuedAt)
+          : null,
+      ...(run.errorName ? { errorName: run.errorName } : {}),
+      ...(run.errorMessage ? { errorMessage: run.errorMessage } : {}),
+    };
+    runsBySlug.set(run.functionSlug, [
+      ...(runsBySlug.get(run.functionSlug) ?? []),
+      summary,
+    ]);
+  }
+
+  const jobs: InngestJobStatus[] = [...runsBySlug.entries()]
+    .map(([slug, runs]) => {
+      const sorted = [...runs].sort((a, b) => runSortKey(b) - runSortKey(a));
+
+      return {
+        id: slug,
+        name: jobNameFromSlug(slug),
+        lastRun: sorted[0] ?? null,
+        counts: {
+          completed: sorted.filter((run) => run.status === "Completed").length,
+          failed: sorted.filter((run) => run.status === "Failed").length,
+          cancelled: sorted.filter((run) => run.status === "Cancelled").length,
+          total: sorted.length,
+        },
+        recentRuns: sorted.slice(0, MAX_RECENT_RUNS_PER_JOB),
+      };
+    })
+    .sort((a, b) => {
+      const aKey = a.lastRun ? runSortKey(a.lastRun) : 0;
+      const bKey = b.lastRun ? runSortKey(b.lastRun) : 0;
+      if (aKey !== bKey) return bKey - aKey;
+      return a.id.localeCompare(b.id);
+    });
+
+  const totals = jobs.reduce(
+    (acc, job) => {
+      acc.runs += job.counts.total;
+      acc.completed += job.counts.completed;
+      acc.failed += job.counts.failed;
+      acc.cancelled += job.counts.cancelled;
+      return acc;
+    },
+    { jobs: jobs.length, runs: 0, completed: 0, failed: 0, cancelled: 0 },
+  );
+
+  return {
+    fetchedAt: fetchedAt.toISOString(),
+    windowHours,
+    ...(error ? { error } : {}),
+    jobs,
+    totals,
+  };
+};

--- a/apps/web/tests/inngestJobsDashboard.test.tsx
+++ b/apps/web/tests/inngestJobsDashboard.test.tsx
@@ -1,0 +1,172 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+// Type-only import: erased at compile time, so it does not defeat the
+// jest.mock below the way a value import of the component would.
+import type * as InngestJobsDashboardModule from "../components/Status/InngestJobsDashboard";
+import type { InngestStatusResponse } from "~/lib/inngestStatus";
+
+const mockGetInngestStatus = jest.fn<() => Promise<InngestStatusResponse>>();
+
+// The dashboard gets its data from a server function; stub it. The real
+// @jitaspace/ui pulls in ESM-only dependencies jest can't parse, and
+// TimeAgoText re-renders on a 1s interval; stub it too. Note jest.mock is not
+// hoisted above static imports in this setup, so the component under test is
+// require()d lazily inside renderDashboard, like statusPage.test.tsx does.
+jest.mock("~/app/status/actions", () => ({
+  getInngestStatus: () => mockGetInngestStatus(),
+}));
+
+jest.mock("@jitaspace/ui", () => ({
+  TimeAgoText: ({ date }: { date: Date }) => (
+    <span>{`ago:${date.toISOString()}`}</span>
+  ),
+}));
+
+const NOW = Date.UTC(2026, 5, 10, 12, 0, 0);
+
+const statusFixture: InngestStatusResponse = {
+  fetchedAt: new Date(NOW).toISOString(),
+  windowHours: 24,
+  jobs: [
+    {
+      id: "jitaspace-scrape-esi-alliances",
+      name: "Scrape ESI Alliances",
+      lastRun: {
+        runId: "RUN-COMPLETED",
+        status: "Completed",
+        queuedAt: NOW - 600_000,
+        endedAt: NOW - 300_000,
+        durationMs: 300_000,
+      },
+      counts: { completed: 3, failed: 0, cancelled: 0, total: 3 },
+      recentRuns: [
+        {
+          runId: "RUN-COMPLETED",
+          status: "Completed",
+          queuedAt: NOW - 600_000,
+          endedAt: NOW - 300_000,
+          durationMs: 300_000,
+        },
+      ],
+    },
+    {
+      id: "jitaspace-esi-update-wars",
+      name: "ESI Update Wars",
+      lastRun: {
+        runId: "RUN-FAILED",
+        status: "Failed",
+        queuedAt: NOW - 7_200_000,
+        endedAt: NOW - 7_100_000,
+        durationMs: 100_000,
+        errorName: "Error",
+        errorMessage: "ESI exploded",
+      },
+      counts: { completed: 22, failed: 2, cancelled: 0, total: 24 },
+      recentRuns: [
+        {
+          runId: "RUN-FAILED",
+          status: "Failed",
+          queuedAt: NOW - 7_200_000,
+          endedAt: NOW - 7_100_000,
+          durationMs: 100_000,
+          errorName: "Error",
+          errorMessage: "ESI exploded",
+        },
+      ],
+    },
+  ],
+  totals: {
+    jobs: 2,
+    runs: 27,
+    completed: 25,
+    failed: 2,
+    cancelled: 0,
+  },
+};
+
+function renderDashboard() {
+  const { InngestJobsDashboard } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../components/Status/InngestJobsDashboard") as typeof InngestJobsDashboardModule;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <InngestJobsDashboard />
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+describe("InngestJobsDashboard", () => {
+  beforeEach(() => {
+    mockGetInngestStatus.mockReset();
+  });
+
+  it("renders job rows, statuses and totals", async () => {
+    mockGetInngestStatus.mockResolvedValue(statusFixture);
+
+    renderDashboard();
+
+    expect(await screen.findByText("Scrape ESI Alliances")).toBeInTheDocument();
+    expect(screen.getByText("ESI Update Wars")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+
+    // 2 failed runs in window -> red overall badge + failed-run counter.
+    expect(screen.getByText("2 Failed Runs")).toBeInTheDocument();
+    expect(screen.getByText("(2 failed)")).toBeInTheDocument();
+
+    // Function slugs are shown under the derived job names.
+    expect(
+      screen.getByText("jitaspace-scrape-esi-alliances"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("jitaspace-esi-update-wars")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no runs in the window", async () => {
+    mockGetInngestStatus.mockResolvedValue({
+      ...statusFixture,
+      jobs: [],
+      totals: { jobs: 0, runs: 0, completed: 0, failed: 0, cancelled: 0 },
+    });
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText(/No job runs in the last 24 hours/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No Recent Runs")).toBeInTheDocument();
+  });
+
+  it("shows a warning when the server function reports an upstream error", async () => {
+    mockGetInngestStatus.mockResolvedValue({
+      ...statusFixture,
+      error: "Inngest API responded with 500",
+    });
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText(/Background job status is currently unavailable/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error when the server function itself fails", async () => {
+    mockGetInngestStatus.mockRejectedValue(new Error("connection lost"));
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText(/Failed to load background job status/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/connection lost/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/inngestStatus.test.ts
+++ b/apps/web/tests/inngestStatus.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment node
+ */
+import { describe, expect, it } from "@jest/globals";
+
+import type { InngestApiEvent } from "~/lib/inngestStatus";
+import {
+  buildInngestStatusResponse,
+  collectTerminalRuns,
+  jobNameFromSlug,
+  ulidTimestamp,
+} from "~/lib/inngestStatus";
+
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+/** Build a syntactically valid ULID whose time component is `ms`. */
+const ulidAt = (ms: number, suffix = "AAAAAAAAAAAAAAAA") => {
+  let value = ms;
+  let prefix = "";
+  for (let i = 0; i < 10; i++) {
+    prefix = ULID_ALPHABET[value % 32] + prefix;
+    value = Math.floor(value / 32);
+  }
+  return prefix + suffix;
+};
+
+const T0 = Date.UTC(2026, 5, 10, 6, 0, 0); // queued
+const T1 = Date.UTC(2026, 5, 10, 6, 5, 0); // ended
+const T2 = Date.UTC(2026, 5, 10, 7, 0, 0); // a later run
+
+const ALLIANCES_SLUG = "jitaspace-scrape-esi-alliances";
+const WARS_SLUG = "jitaspace-esi-update-wars";
+
+const finishedEvent = (overrides?: {
+  runId?: string;
+  status?: string;
+  ts?: number;
+  functionId?: string;
+  error?: { name?: string; message?: string };
+}): InngestApiEvent => ({
+  internal_id: `EVT${overrides?.ts ?? T1}`,
+  name: "inngest/function.finished",
+  ts: overrides?.ts ?? T1,
+  data: {
+    function_id: overrides?.functionId ?? ALLIANCES_SLUG,
+    run_id: overrides?.runId ?? ulidAt(T0),
+    _inngest: { status: overrides?.status ?? "Completed" },
+    ...(overrides?.error ? { error: overrides.error } : {}),
+  },
+});
+
+describe("ulidTimestamp", () => {
+  it("decodes the timestamp of a real Inngest run ID", () => {
+    // Run created by the hourly cron at 2026-06-10T07:30:00Z.
+    expect(ulidTimestamp("01KTR70960HQBXCQ2SVK2KH1EN")).toBe(
+      Date.UTC(2026, 5, 10, 7, 30, 0),
+    );
+  });
+
+  it("round-trips with the fixture encoder and rejects invalid input", () => {
+    expect(ulidTimestamp(ulidAt(T0))).toBe(T0);
+    expect(ulidTimestamp("not-a-ulid!")).toBeNull();
+    expect(ulidTimestamp("short")).toBeNull();
+  });
+});
+
+describe("jobNameFromSlug", () => {
+  it("strips the app prefix, title-cases and uppercases known acronyms", () => {
+    expect(jobNameFromSlug("jitaspace-scrape-esi-alliances")).toBe(
+      "Scrape ESI Alliances",
+    );
+    expect(jobNameFromSlug("jitaspace-esi-update-wars")).toBe(
+      "ESI Update Wars",
+    );
+    expect(jobNameFromSlug("jitaspace-process-redis-alliance-ids")).toBe(
+      "Process Redis Alliance IDs",
+    );
+  });
+
+  it("handles slugs without the app prefix", () => {
+    expect(jobNameFromSlug("scrape-sde-agents")).toBe("Scrape SDE Agents");
+  });
+});
+
+describe("collectTerminalRuns", () => {
+  it("collects completed runs from finished events", () => {
+    const runs = collectTerminalRuns([finishedEvent()]);
+    const run = runs.get(ulidAt(T0));
+
+    expect(runs.size).toBe(1);
+    expect(run).toMatchObject({
+      functionSlug: ALLIANCES_SLUG,
+      status: "Completed",
+      queuedAt: T0,
+      endedAt: T1,
+    });
+  });
+
+  it("merges failed events over finished events and keeps error details", () => {
+    const runId = ulidAt(T0);
+    const runs = collectTerminalRuns([
+      finishedEvent({ runId, status: "Failed" }),
+      {
+        internal_id: "EVT-FAILED",
+        name: "inngest/function.failed",
+        ts: T1,
+        data: {
+          function_id: ALLIANCES_SLUG,
+          run_id: runId,
+          error: { name: "Error", message: "boom" },
+        },
+      },
+    ]);
+
+    expect(runs.get(runId)).toMatchObject({
+      status: "Failed",
+      errorName: "Error",
+      errorMessage: "boom",
+    });
+  });
+
+  it("ignores events without run metadata", () => {
+    const runs = collectTerminalRuns([
+      { internal_id: "EVT-EMPTY", name: "inngest/function.finished", ts: T1 },
+      { internal_id: "EVT-OTHER", name: "scrape/esi/alliances", ts: T1 },
+    ]);
+    expect(runs.size).toBe(0);
+  });
+});
+
+describe("buildInngestStatusResponse", () => {
+  it("derives jobs from observed runs and computes totals", () => {
+    const failedRunId = ulidAt(T1);
+    const terminalRuns = collectTerminalRuns([
+      finishedEvent(),
+      finishedEvent({
+        runId: failedRunId,
+        status: "Failed",
+        ts: T2,
+        error: { name: "Error", message: "boom" },
+      }),
+      finishedEvent({
+        runId: ulidAt(T2),
+        ts: T2 + 60_000,
+        functionId: WARS_SLUG,
+      }),
+    ]);
+
+    const response = buildInngestStatusResponse({
+      terminalRuns,
+      fetchedAt: new Date(T2),
+    });
+
+    expect(response.totals).toEqual({
+      jobs: 2,
+      runs: 3,
+      completed: 2,
+      failed: 1,
+      cancelled: 0,
+    });
+
+    // Jobs are sorted by most recent activity; names derive from slugs.
+    expect(response.jobs.map((job) => job.id)).toEqual([
+      WARS_SLUG,
+      ALLIANCES_SLUG,
+    ]);
+
+    const alliances = response.jobs.find((job) => job.id === ALLIANCES_SLUG);
+    expect(alliances?.name).toBe("Scrape ESI Alliances");
+    expect(alliances?.counts).toEqual({
+      completed: 1,
+      failed: 1,
+      cancelled: 0,
+      total: 2,
+    });
+    // Newest run (the failure) is the last run.
+    expect(alliances?.lastRun).toMatchObject({
+      runId: failedRunId,
+      status: "Failed",
+      durationMs: T2 - T1,
+      errorMessage: "boom",
+    });
+    expect(alliances?.recentRuns.map((run) => run.status)).toEqual([
+      "Failed",
+      "Completed",
+    ]);
+  });
+
+  it("omits jobs without observed runs entirely", () => {
+    const response = buildInngestStatusResponse({
+      terminalRuns: collectTerminalRuns([finishedEvent()]),
+      fetchedAt: new Date(T2),
+    });
+
+    expect(response.jobs).toHaveLength(1);
+    expect(response.totals.jobs).toBe(1);
+  });
+
+  it("carries an error message with no jobs", () => {
+    const response = buildInngestStatusResponse({
+      terminalRuns: new Map(),
+      fetchedAt: new Date(T2),
+      error: "Inngest API responded with 500",
+    });
+
+    expect(response.error).toBe("Inngest API responded with 500");
+    expect(response.jobs).toEqual([]);
+    expect(response.totals).toEqual({
+      jobs: 0,
+      runs: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+    });
+  });
+});

--- a/apps/web/tests/statusPage.test.tsx
+++ b/apps/web/tests/statusPage.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/jest-globals";
 
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { MantineProvider } from "@mantine/core";
 import { render, screen } from "@testing-library/react";
 
@@ -55,6 +55,10 @@ jest.mock("../components/Status/EsiRateLimitDashboard", () => ({
 
 jest.mock("../components/Status/EsiStatusDashboard", () => ({
   EsiStatusDashboard: () => <div>ESI Status Dashboard</div>,
+}));
+
+jest.mock("../components/Status/InngestJobsDashboard", () => ({
+  InngestJobsDashboard: () => <div>Inngest Jobs Dashboard</div>,
 }));
 
 jest.mock("next/link", () => ({
@@ -157,6 +161,7 @@ describe("Status Page", () => {
 
     // Dashboards render
     expect(screen.getByText("Rate Limit Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Inngest Jobs Dashboard")).toBeInTheDocument();
   });
 
   it("renders outdated branches and partial ESI degradation", () => {


### PR DESCRIPTION
## What

Adds a **Background Jobs** section to `/status` showing the state of Inngest background jobs, similar to the Inngest dashboard:

- Summary cards (active jobs, runs, failed runs over the last 24h) and an overall health badge (`All Jobs Healthy` / `N Failed Runs` / `No Recent Runs`)
- Per-job table: derived display name + function slug, last-run status badge (with error tooltip on failures), relative last-run time, duration, 24h run count, and a colored dot strip of the last 10 runs with per-run tooltips
- Jobs whose latest run failed sort to the top; auto-refreshes every 30s

## How

The public Inngest REST API has **no list-runs or list-functions endpoint** (the Inngest dashboard uses a private GraphQL API), so run state is reconstructed from queryable system events:

- `GET /v1/events?name=inngest/function.finished|failed|cancelled` over a 24h window (cursor-paginated, capped) — each event carries the function slug, run ID, status and error details
- Run IDs are ULIDs whose first 10 chars encode the queued-at timestamp, so durations need no per-run API calls
- Deliberately data-driven: only jobs with runs in the window appear, and names are title-cased from slugs (`jobNameFromSlug`). A richer variant (static function manifest + running-job detection) was considered and dropped to avoid duplicating the registry — recoverable later if wanted.

Data is exposed **only via a server function** (`app/status/actions.ts`, `"use server"`) that React Query polls directly — no public API route. The `INNGEST_SIGNING_KEY` stays server-side; results are cached in-memory for 30s; upstream failures degrade to a warning alert instead of breaking the status page.

## Notes for review

- `lib/inngestStatus.ts` is pure logic (types, ULID decode, event aggregation) shared by the server function, the client component (types only) and unit tests
- New optional env var `INNGEST_BASE_URL` overrides the API base (defaults: `api.inngest.com` in production, the local `inngest dev` server otherwise); set it to `https://api.inngest.com` locally to demo with real data
- Tests: 10 unit tests for the aggregation logic, 4 component tests (server function mocked), status-page test extended. The component test lazy-`require`s the component because `jest.mock` isn't hoisted above static imports in this jest setup (same pattern as `statusPage.test.tsx`)
- Verified against the live Inngest account: correctly showed 24 hourly `esi-update-wars` runs, including two real ESI-500 failures while they were inside the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)