### PR TITLE
feat(web): add Support page

### DIFF
--- a/.changeset/support-page.md
+++ b/.changeset/support-page.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+feat(web): add Support page — ways to contribute (Discord, GitHub feedback/stars, EVE creator code "JITA", Markee Dragon affiliate link, GitHub Sponsors, Buy Me a Coffee, and in-game ISK), with FTC/EU-style affiliate disclosures and RMT-safe framing. Linked from the footer.

--- a/apps/web/app/support/SupportContent.tsx
+++ b/apps/web/app/support/SupportContent.tsx
@@ -52,7 +52,8 @@ const DONATION_CORPORATION_ID = 98832245;
 const MY_CHARACTER_ID = 401563624;
 
 /**
- * External destinations. TODO: enable GitHub Sponsors before relying on that link.
+ * External destinations. Note: GitHub Sponsors must be enabled on the account
+ * before that link resolves.
  */
 const links = {
   // The creator code is entered at the payment step on the EVE Online Store.
@@ -62,7 +63,7 @@ const links = {
   github: "https://github.com/joaomlneto/jitaspace",
   // Pre-filled "new issue" picker (bug / feature templates).
   feedback: "https://github.com/joaomlneto/jitaspace/issues/new/choose",
-  githubSponsors: "https://github.com/sponsors/joaomlneto", // TODO: enable GitHub Sponsors
+  githubSponsors: "https://github.com/sponsors/joaomlneto", // needs GitHub Sponsors enabled on the account
   buyMeACoffee: "https://buymeacoffee.com/joaomlneto",
 };
 

--- a/apps/web/app/support/SupportContent.tsx
+++ b/apps/web/app/support/SupportContent.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Anchor,
+  Button,
+  Card,
+  Code,
+  Container,
+  Divider,
+  Group,
+  List,
+  SimpleGrid,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from "@mantine/core";
+import {
+  IconBrandDiscordFilled,
+  IconBrandGithub,
+  IconBuildingStore,
+  IconCoffee,
+  IconCoins,
+  IconGift,
+  IconHeartHandshake,
+  IconMessageReport,
+  IconShoppingBag,
+} from "@tabler/icons-react";
+
+import {
+  CharacterAnchor,
+  CharacterAvatar,
+  CharacterName,
+  CorporationAnchor,
+  CorporationAvatar,
+  CorporationName,
+} from "@jitaspace/ui";
+
+import { env } from "~/env";
+
+/**
+ * The EVE Online creator code used to support the project. Entering it at the EVE
+ * Store checkout earns JitaSpace a revenue share at no extra cost to the buyer.
+ */
+const CREATOR_CODE = "JITA";
+
+/** In-game corporation that receives community ISK donations (giveaways/events). */
+const DONATION_CORPORATION_ID = 98832245;
+
+/** My in-game character, for personal ISK donations. */
+const MY_CHARACTER_ID = 401563624;
+
+/**
+ * External destinations. TODO: enable GitHub Sponsors before relying on that link.
+ */
+const links = {
+  // The creator code is entered at the payment step on the EVE Online Store.
+  eveStore: "https://store.eveonline.com/",
+  // Markee Dragon affiliate link — auto-attributes the sale (CCP-authorized reseller).
+  markeeDragon: "https://store.markeedragon.com/affiliate.php?id=1213",
+  github: "https://github.com/joaomlneto/jitaspace",
+  // Pre-filled "new issue" picker (bug / feature templates).
+  feedback: "https://github.com/joaomlneto/jitaspace/issues/new/choose",
+  githubSponsors: "https://github.com/sponsors/joaomlneto", // TODO: enable GitHub Sponsors
+  buyMeACoffee: "https://buymeacoffee.com/joaomlneto",
+};
+
+export function SupportContent() {
+  return (
+    <Container size="sm">
+      <Stack gap="xl">
+        <Stack gap="xs">
+          <Title>Support JitaSpace</Title>
+          <Text size="sm">
+            JitaSpace is a collection of EVE Online tools I build in my spare
+            time, for the love of the game. If you&apos;ve found it useful and
+            would like to give something back, here are a few ways to help —
+            there&apos;s no obligation at all, and the free options below help
+            just as much.
+          </Text>
+        </Stack>
+
+        {/* ---- Free ways to help ---- */}
+        <Stack gap="xs">
+          <Title order={3}>Free ways to help</Title>
+          <Text size="sm">The most valuable support costs nothing at all:</Text>
+          <Group>
+            <Button
+              component="a"
+              href={env.NEXT_PUBLIC_DISCORD_INVITE_LINK}
+              target="_blank"
+              variant="light"
+              leftSection={<IconBrandDiscordFilled size={18} />}
+            >
+              Join the Discord
+            </Button>
+            <Button
+              component="a"
+              href={links.feedback}
+              target="_blank"
+              variant="light"
+              leftSection={<IconMessageReport size={18} />}
+            >
+              Give feedback
+            </Button>
+            <Button
+              component="a"
+              href={links.github}
+              target="_blank"
+              variant="light"
+              leftSection={<IconBrandGithub size={18} />}
+            >
+              Star on GitHub
+            </Button>
+          </Group>
+          <Text size="sm" c="dimmed">
+            Spreading the word helps just as much — tell your corp, alliance, or
+            friends. Word of mouth is everything for a small project.
+          </Text>
+        </Stack>
+
+        {/* ---- Shop with creator code ---- */}
+        <Stack gap="xs">
+          <Title order={3}>Buy PLEX, Omega &amp; game time</Title>
+          <Text size="sm">
+            Topping up anyway? Use my EVE creator code{" "}
+            <Code>{CREATOR_CODE}</Code> or my Markee Dragon link below, and a
+            share of your purchase comes back to JitaSpace — at no extra cost to
+            you.
+          </Text>
+          <SimpleGrid cols={{ base: 1, xs: 2 }} spacing="md">
+            <Card withBorder padding="md">
+              <Stack gap="xs" h="100%" justify="space-between">
+                <Stack gap="xs">
+                  <Group gap="xs">
+                    <ThemeIcon variant="light" size="lg">
+                      <IconBuildingStore size={20} />
+                    </ThemeIcon>
+                    <Text fw={600}>EVE Online Store</Text>
+                  </Group>
+                  <Text size="sm" c="dimmed">
+                    Enter creator code <Code>{CREATOR_CODE}</Code> at the
+                    payment step. It doesn&apos;t change your price — it just
+                    sends a 5% revenue share my way.
+                  </Text>
+                </Stack>
+                <Button
+                  component="a"
+                  href={links.eveStore}
+                  target="_blank"
+                  rel="sponsored noopener noreferrer"
+                  variant="light"
+                  fullWidth
+                >
+                  Open the EVE Store
+                </Button>
+              </Stack>
+            </Card>
+            <Card withBorder padding="md">
+              <Stack gap="xs" h="100%" justify="space-between">
+                <Stack gap="xs">
+                  <Group gap="xs">
+                    <ThemeIcon variant="light" size="lg">
+                      <IconShoppingBag size={20} />
+                    </ThemeIcon>
+                    <Text fw={600}>Markee Dragon</Text>
+                  </Group>
+                  <Text size="sm" c="dimmed">
+                    An official, CCP-authorized reseller of PLEX, Omega, and
+                    game time — often cheaper than buying direct. Shopping
+                    through my affiliate link sends a commission my way.
+                  </Text>
+                </Stack>
+                <Button
+                  component="a"
+                  href={links.markeeDragon}
+                  target="_blank"
+                  rel="sponsored noopener noreferrer"
+                  variant="light"
+                  fullWidth
+                >
+                  Open Markee Dragon
+                </Button>
+              </Stack>
+            </Card>
+          </SimpleGrid>
+          <Text size="xs" c="dimmed">
+            Affiliate disclosure: the code and link above are affiliate
+            referrals — when you use them I receive a commission or revenue
+            share, at no extra cost to you. See the fine print below.
+          </Text>
+        </Stack>
+
+        {/* ---- Sponsor development ---- */}
+        <Stack gap="xs">
+          <Title order={3}>Sponsor development</Title>
+          <Text size="sm">
+            Prefer to chip in directly? This helps cover hosting, server, and
+            API costs. One-off or recurring — whatever suits you.
+          </Text>
+          <SimpleGrid cols={{ base: 1, xs: 2 }} spacing="md">
+            <Card withBorder padding="md">
+              <Stack gap="xs" h="100%" justify="space-between">
+                <Stack gap="xs">
+                  <Group gap="xs">
+                    <ThemeIcon variant="light" size="lg">
+                      <IconHeartHandshake size={20} />
+                    </ThemeIcon>
+                    <Text fw={600}>GitHub Sponsors</Text>
+                  </Group>
+                  <Text size="sm" c="dimmed">
+                    Sponsor the open-source project monthly or one-time. 100%
+                    reaches the project — GitHub takes no platform fee.
+                  </Text>
+                </Stack>
+                <Button
+                  component="a"
+                  href={links.githubSponsors}
+                  target="_blank"
+                  variant="light"
+                  fullWidth
+                  leftSection={<IconBrandGithub size={18} />}
+                >
+                  Become a sponsor
+                </Button>
+              </Stack>
+            </Card>
+            <Card withBorder padding="md">
+              <Stack gap="xs" h="100%" justify="space-between">
+                <Stack gap="xs">
+                  <Group gap="xs">
+                    <ThemeIcon variant="light" size="lg">
+                      <IconCoffee size={20} />
+                    </ThemeIcon>
+                    <Text fw={600}>Buy Me a Coffee</Text>
+                  </Group>
+                  <Text size="sm" c="dimmed">
+                    A quick one-off tip — no account or subscription needed.
+                  </Text>
+                </Stack>
+                <Button
+                  component="a"
+                  href={links.buyMeACoffee}
+                  target="_blank"
+                  variant="light"
+                  fullWidth
+                  leftSection={<IconCoffee size={18} />}
+                >
+                  Buy me a coffee
+                </Button>
+              </Stack>
+            </Card>
+          </SimpleGrid>
+        </Stack>
+
+        {/* ---- ISK ---- */}
+        <Stack gap="xs">
+          <Title order={3}>Send ISK in-game</Title>
+          <Card withBorder padding="md">
+            <Group wrap="nowrap" align="flex-start" gap="md">
+              <ThemeIcon variant="light" size="xl">
+                <IconCoins size={24} />
+              </ThemeIcon>
+              <Stack gap="xs">
+                <Text size="sm">
+                  Rich in ISK but not in spare euros? You can support the
+                  project directly in-game. For community donations, send ISK to
+                  the corporation:
+                </Text>
+                <Group gap="xs" wrap="nowrap" align="center">
+                  <CorporationAvatar
+                    corporationId={DONATION_CORPORATION_ID}
+                    size="sm"
+                  />
+                  <CorporationAnchor
+                    corporationId={DONATION_CORPORATION_ID}
+                    size="sm"
+                    fw={600}
+                  >
+                    <CorporationName corporationId={DONATION_CORPORATION_ID} />
+                  </CorporationAnchor>
+                </Group>
+                <Text size="sm">
+                  …or to my character, for a personal donation:
+                </Text>
+                <Group gap="xs" wrap="nowrap" align="center">
+                  <CharacterAvatar characterId={MY_CHARACTER_ID} size="sm" />
+                  <CharacterAnchor
+                    characterId={MY_CHARACTER_ID}
+                    size="sm"
+                    fw={600}
+                  >
+                    <CharacterName characterId={MY_CHARACTER_ID} />
+                  </CharacterAnchor>
+                </Group>
+                <Group gap="xs" wrap="nowrap" align="flex-start">
+                  <ThemeIcon variant="transparent" color="gray" size="sm">
+                    <IconGift size={16} />
+                  </ThemeIcon>
+                  <Text size="sm" c="dimmed">
+                    ISK sent to the corporation goes straight back to the
+                    community — mostly giveaways and events. It&apos;s a
+                    voluntary in-game gift, never exchanged for real money or
+                    site features.
+                  </Text>
+                </Group>
+              </Stack>
+            </Group>
+          </Card>
+        </Stack>
+
+        <Divider />
+
+        {/* ---- Disclosures ---- */}
+        <Stack gap="xs">
+          <Title order={3}>Disclosures &amp; the fine print</Title>
+          <List size="sm" spacing="xs">
+            <List.Item>
+              JitaSpace is an independent, third-party project. It is not
+              affiliated with, sponsored by, or endorsed by{" "}
+              <Anchor
+                inherit
+                href="https://fenriscreations.com"
+                target="_blank"
+              >
+                Fenris Creations
+              </Anchor>
+              . My affiliate relationships with the EVE Store and Markee Dragon
+              are disclosed below.
+            </List.Item>
+            <List.Item>
+              The EVE Online creator code and the Markee Dragon link are
+              affiliate referrals. If you use them, I receive a commission or
+              revenue share from the respective store — this never costs you any
+              more than the normal price.
+            </List.Item>
+            <List.Item>
+              ISK you choose to send is treated as a voluntary in-game gift and
+              is used for community activities such as giveaways. ISK is never
+              bought, sold, or exchanged for real money — doing so would violate
+              the EVE Online EULA.
+            </List.Item>
+            <List.Item>
+              Payments are handled entirely by the respective platforms (the EVE
+              Store, Markee Dragon, GitHub, Buy Me a Coffee, …). JitaSpace does
+              not process or store any of your payment information. See the{" "}
+              <Anchor inherit component={Link} href="/about">
+                About page
+              </Anchor>{" "}
+              for the full privacy policy.
+            </List.Item>
+          </List>
+        </Stack>
+      </Stack>
+    </Container>
+  );
+}

--- a/apps/web/app/support/page.tsx
+++ b/apps/web/app/support/page.tsx
@@ -1,0 +1,11 @@
+import { SupportContent } from "./SupportContent";
+
+export const metadata = {
+  title: "Support",
+  description:
+    "Ways to support JitaSpace — join the community, shop with creator code JITA, sponsor development, or send ISK in-game.",
+};
+
+export default function SupportPage() {
+  return <SupportContent />;
+}

--- a/apps/web/layouts/MainLayout/FooterWithLinks.tsx
+++ b/apps/web/layouts/MainLayout/FooterWithLinks.tsx
@@ -22,6 +22,10 @@ const links: { link: LinkProps["href"]; label: string }[] = [
     label: "About",
   },
   {
+    link: "/support",
+    label: "Support",
+  },
+  {
     link: "/status",
     label: "Status",
   },

--- a/apps/web/tests/supportPage.test.tsx
+++ b/apps/web/tests/supportPage.test.tsx
@@ -1,0 +1,163 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import type { ReactNode } from "react";
+import { describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// The Support page renders Mantine UI plus a few data-fetching @jitaspace/ui
+// entity wrappers, and reads the Discord invite from ~/env. Stub the wrappers
+// as passthroughs and mock env / next/link so the page renders fully without a
+// QueryClient or ESI. (jest.mock is not hoisted under this SWC transform, so
+// the modules under test are lazy-required after the mocks are registered.)
+// ---------------------------------------------------------------------------
+
+jest.mock("~/env", () => ({
+  env: { NEXT_PUBLIC_DISCORD_INVITE_LINK: "https://discord.gg/jitaspace-test" },
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+  }: {
+    href?: string | object;
+    children?: ReactNode;
+  }) => <a href={typeof href === "string" ? href : ""}>{children}</a>,
+}));
+
+jest.mock("@jitaspace/ui", () => ({
+  CharacterAvatar: ({ characterId }: { characterId?: number }) => (
+    <span>{`char-avatar-${characterId ?? ""}`}</span>
+  ),
+  CharacterName: ({ characterId }: { characterId?: number }) => (
+    <span>{`Character ${characterId ?? ""}`}</span>
+  ),
+  CharacterAnchor: ({
+    characterId,
+    children,
+  }: {
+    characterId?: number;
+    children?: ReactNode;
+  }) => <a href={`/character/${characterId}`}>{children}</a>,
+  CorporationAvatar: ({ corporationId }: { corporationId?: number }) => (
+    <span>{`corp-avatar-${corporationId ?? ""}`}</span>
+  ),
+  CorporationName: ({ corporationId }: { corporationId?: number }) => (
+    <span>{`Corporation ${corporationId ?? ""}`}</span>
+  ),
+  CorporationAnchor: ({
+    corporationId,
+    children,
+  }: {
+    corporationId?: number;
+    children?: ReactNode;
+  }) => <a href={`/corporation/${corporationId}`}>{children}</a>,
+}));
+
+jest.mock("~/components/Badge", () => ({
+  PartnerBadge: () => <div>PartnerBadge</div>,
+}));
+
+function renderSupportPage() {
+  const SupportPage = require("~/app/support/page").default;
+  return render(
+    <MantineProvider>
+      <SupportPage />
+    </MantineProvider>,
+  );
+}
+
+function renderFooter() {
+  const { FooterWithLinks } = require("~/layouts/MainLayout/FooterWithLinks");
+  return render(
+    <MantineProvider>
+      <FooterWithLinks />
+    </MantineProvider>,
+  );
+}
+
+describe("Support page", () => {
+  it("exports a Support title in its metadata", () => {
+    const { metadata } = require("~/app/support/page");
+    expect(metadata.title).toBe("Support");
+  });
+
+  it("renders every section heading", () => {
+    renderSupportPage();
+    expect(
+      screen.getByRole("heading", { name: "Support JitaSpace" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Free ways to help")).toBeInTheDocument();
+    expect(screen.getByText("Buy PLEX, Omega & game time")).toBeInTheDocument();
+    expect(screen.getByText("Sponsor development")).toBeInTheDocument();
+    expect(screen.getByText("Send ISK in-game")).toBeInTheDocument();
+    expect(
+      screen.getByText("Disclosures & the fine print"),
+    ).toBeInTheDocument();
+  });
+
+  it("wires up the free-to-help actions", () => {
+    renderSupportPage();
+    expect(
+      screen.getByRole("link", { name: /Join the Discord/ }),
+    ).toHaveAttribute("href", "https://discord.gg/jitaspace-test");
+    expect(screen.getByRole("link", { name: /Give feedback/ })).toHaveAttribute(
+      "href",
+      "https://github.com/joaomlneto/jitaspace/issues/new/choose",
+    );
+    expect(
+      screen.getByRole("link", { name: /Star on GitHub/ }),
+    ).toHaveAttribute("href", "https://github.com/joaomlneto/jitaspace");
+  });
+
+  it("marks the affiliate shop links as sponsored", () => {
+    renderSupportPage();
+    const eve = screen.getByRole("link", { name: "Open the EVE Store" });
+    expect(eve).toHaveAttribute("href", "https://store.eveonline.com/");
+    expect(eve).toHaveAttribute("rel", "sponsored noopener noreferrer");
+
+    const markee = screen.getByRole("link", { name: "Open Markee Dragon" });
+    expect(markee).toHaveAttribute(
+      "href",
+      "https://store.markeedragon.com/affiliate.php?id=1213",
+    );
+    expect(markee).toHaveAttribute("rel", "sponsored noopener noreferrer");
+
+    // creator code is shown, and the disclosure is present
+    expect(screen.getAllByText("JITA").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Affiliate disclosure:/)).toBeInTheDocument();
+  });
+
+  it("wires up the sponsorship and tip links", () => {
+    renderSupportPage();
+    expect(
+      screen.getByRole("link", { name: /Become a sponsor/ }),
+    ).toHaveAttribute("href", "https://github.com/sponsors/joaomlneto");
+    expect(
+      screen.getByRole("link", { name: /Buy me a coffee/ }),
+    ).toHaveAttribute("href", "https://buymeacoffee.com/joaomlneto");
+  });
+
+  it("points ISK donations at the corporation and character pages", () => {
+    renderSupportPage();
+    expect(
+      screen.getByRole("link", { name: /Corporation 98832245/ }),
+    ).toHaveAttribute("href", "/corporation/98832245");
+    expect(
+      screen.getByRole("link", { name: /Character 401563624/ }),
+    ).toHaveAttribute("href", "/character/401563624");
+  });
+});
+
+describe("Footer", () => {
+  it("links to the Support page", () => {
+    renderFooter();
+    expect(screen.getByRole("link", { name: "Support" })).toHaveAttribute(
+      "href",
+      "/support",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a new **`/support`** page (linked from the footer, between *About* and *Status*) explaining how people can support the project — financially and otherwise.

**Sections**
- **Free ways to help** — Join the Discord, Give feedback (opens the GitHub new-issue picker), Star on GitHub, plus a spread-the-word nudge.
- **Buy PLEX, Omega & game time** — EVE Online Store using creator code `JITA` (5% revenue share, no change to the buyer's price) and a Markee Dragon affiliate link.
- **Sponsor development** — GitHub Sponsors and Buy Me a Coffee.
- **Send ISK in-game** — the corporation (*JitaSpace Technologies*) for community/giveaway funds, or my character for personal donations. Both render with the shared `Corporation*`/`Character*` UI components and link to their entity pages.
- **Disclosures & the fine print** — affiliate/referral disclosure, independence from Fenris Creations, RMT-safe ISK framing, and a "we don't process payments" note.

## Why

Folks have asked how to support the project; this puts the options in one place and tries to do it compliantly:

- Affiliate links carry a clear, conspicuous disclosure (FTC + EU/Omnibus) and `rel="sponsored noopener noreferrer"`.
- The independence disclaimer is scoped to the game's publisher (Fenris Creations); the Markee Dragon affiliate relationship is **acknowledged and disclosed** rather than denied.
- Real-money support and in-game ISK are kept strictly separate — ISK is framed as a voluntary in-game gift for community giveaways, never bought/sold for real money — to stay clear of EVE's RMT rules.
- Intro copy is intentionally non-committal (no "always free / ad-free / no paywall" promises) so future monetization options aren't foreclosed.

## Implementation notes

- `page.tsx` is a thin server component (sets the page title via `metadata`) rendering a `"use client"` `SupportContent` — same component family as the existing About page.
- External links/codes live in clearly-commented constants at the top of `SupportContent.tsx`.
- Includes a changeset (`@jitaspace/web` patch).

## Verification

- Rendered locally on Next dev: `/support` returns `200`, no console errors; corp/character names + portraits resolve via ESI; all link targets confirmed (Markee affiliate link, Buy Me a Coffee, `/character/401563624`, `/corporation/98832245`, EVE Store, Sponsors).
- `tsc --noEmit` clean for the changed files; Prettier applied. (ESLint couldn't load its flat config in my local runner — an `import.meta.dirname`/jiti quirk — so leaving the lint gate to CI; the code is unused-var/type-import clean and follows existing patterns.)

## Follow-up before it's fully live

- ⚠️ **GitHub Sponsors isn't enabled yet** — `github.com/sponsors/joaomlneto` will 404 until you turn it on. Everything else (EVE code, Markee link, Buy Me a Coffee, corp/character) is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
