### PR TITLE
fix(db): shim import.meta in CJS build; exclude dist from type-check

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "prisma generate && tsup index.ts --format cjs,esm --dts",
+    "build": "prisma generate && tsup index.ts --format cjs,esm --dts --shims",
     "clean": "rm -rf .turbo node_modules dist",
     "db:studio": "prisma studio --browser none",
     "db:generate": "pnpm with-env prisma generate",

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -7,6 +7,7 @@
     "."
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist"
   ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -57,7 +57,7 @@
       "cache": false
     },
     "build": {
-      "dependsOn": ["^build", "^db:generate", "kubb:generate"],
+      "dependsOn": ["^build", "db:generate", "^db:generate", "kubb:generate"],
       "inputs": ["**/*.ts", "**/*.tsx", "package.json", "tsconfig.json"],
       "outputs": [
         ".next/**",


### PR DESCRIPTION
## What changed

- Added `--shims` to the tsup build in `packages/db/package.json`
- Added `dist` to the `exclude` list in `packages/db/tsconfig.json`

## Why

`pnpm build` in `packages/db` emitted this on every run:

```
[warn] ▲ [WARNING] "import.meta" is not available with the "cjs" output format and will be empty [empty-import-meta]
```

The Prisma 7 `prisma-client` generator sees `"type": "module"` and emits ESM-flavored code — the generated `client.ts` sets `globalThis.__dirname` from `fileURLToPath(import.meta.url)`. Since `index.ts` imports the generated client by relative path, tsup bundles it into both output formats, and in the CJS bundle `import.meta` is empty.

This was not just noise: `require('./dist/index.cjs')` crashed at load time with `ERR_INVALID_ARG_TYPE` because `fileURLToPath(undefined)` throws. The published CJS artifact was dead on arrival. tsup's `--shims` substitutes a `__filename`-based `import.meta.url` in the CJS output (and the inverse `__dirname` shim for ESM), which fixes the runtime behavior and silences the warning.

The tsconfig change fixes an adjacent local-only footgun found while verifying: the package tsconfig overrides `exclude` with `["node_modules"]`, which drops the base config's `dist` exclusion (`exclude` replaces rather than merges when extending). After any local build, `pnpm type-check` failed by type-checking the bundled JS output. CI never hit this because turbo's `type-check` task doesn't depend on `build`. This matches what `packages/hooks` already does.

## Verification

- `pnpm build` — clean, zero warnings
- `require('./dist/index.cjs')` and `import('./dist/index.js')` both load; `globalThis.__dirname` resolves to the real `dist/` directory in both
- `createPrismaClient(...)` constructs a `PrismaClient` from the CJS bundle
- `pnpm type-check` and `pnpm lint` pass with `dist/` present

## Reviewer notes

Fourteen other packages share the same `exclude: ["node_modules"]` tsconfig pattern; this PR deliberately fixes only `db` (the package being touched) rather than widening scope. A follow-up can sweep the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum: CI race fix (second commit)

The first CI run exposed a latent race in the turbo task graph: `build.dependsOn` lists `^db:generate` (upstream packages only), so `@jitaspace/db#build` was never ordered against `@jitaspace/db#db:generate` — yet both enter the same graph (the latter via dependent packages' `^db:generate` edges) and both run `prisma generate` into `prisma/generated/`. Running concurrently, one regeneration can tear down files mid-bundle:

```
ERROR: Could not resolve "./internal/class.ts"
```

This never fired on `main` because `db#build` is always a turbo cache hit there; any PR touching `packages/db` re-executes the task and rolls the dice — on this PR, cypress shard 1 passed and shard 2 failed at the Build step on the identical commit. The second commit adds a caret-less `"db:generate"` to `build.dependsOn`, serializing the two tasks. It adds no new task executions (both already ran in every CI build), only an ordering edge. Verified locally via `turbo run build --filter=@jitaspace/db --dry=json` (edge present) and a forced real run (both tasks green, serialized).
