### PR TITLE
fix(web): darken PWA title bar to match the app header

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -88,7 +88,10 @@ export const metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: "#9bb4d0",
+  // Matches the manifest theme_color and the dark app header so the installed
+  // PWA title bar (and mobile status bar) blend with the UI. The runtime
+  // theme-color meta tag takes precedence over the manifest, so keep them in sync.
+  themeColor: "#04070c",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Problem

When the PWA is installed on desktop (Chrome/Edge), the window title bar renders **light blue** instead of matching the dark app header:

The PWA manifest's `theme_color` was already set to the dark header background (`#04070c`) in #558, but `viewport.themeColor` in the root layout was still the old light blue `#9bb4d0`. The runtime `<meta name="theme-color">` (emitted from `viewport.themeColor`) **takes precedence over the manifest** for the rendered window/title bar, so the title bar stayed light blue.

## Fix

Align `viewport.themeColor` with the manifest (`#04070c`). The installed PWA title bar — and the mobile browser status bar — now match the dark header even in standalone mode (i.e. before window-controls-overlay activates).

## Notes

- This does **not** affect window-controls-overlay activation. The separate title-bar strip only disappears once the updated manifest is installed (uninstall + reinstall the PWA after this deploys).
- No auth, API-client, or DB changes.

https://claude.ai/code/session_013DB1BwzUejgZrCnhmyDLdr

---
_Generated by [Claude Code](https://claude.ai/code/session_013DB1BwzUejgZrCnhmyDLdr)_