### PR TITLE
docs: expand and consolidate developer guidance across CLAUDE.md, AGENTS.md, and copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,9 +2,9 @@
 
 ## What This Repo Is
 
-Turborepo monorepo for an EVE Online companion web application. Three apps (`apps/web`, `apps/cli`, `apps/worker`) and 15+ shared packages under `packages/`. The main product is `apps/web`, a Next.js 16 app deployed to Vercel.
+Turborepo monorepo for an EVE Online companion web application. Two apps (`apps/web`, `apps/cli`) and 20+ shared packages under `packages/`. The main product is `apps/web`, a Next.js 16 app deployed to Vercel. Background jobs run inside `apps/web` via Inngest — there is no `apps/worker`.
 
-**Tech stack:** Node.js >=24.16.0 · TypeScript 5.9 · Next.js 16 · React 19 · Mantine 8 · TanStack Query 5 · Prisma 7 + PostgreSQL · NextAuth 4 · Inngest · Turborepo 2 · pnpm 10.33.4
+**Tech stack:** Node.js >=24.16.0 · TypeScript 5.9 · Next.js 16 · React 19 · Mantine 8 · TanStack Query 5 · Prisma 7 + PostgreSQL · NextAuth 4 · Inngest · Turborepo 2 · pnpm 11.3.0
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file is a concise, actionable guide for automated coding agents (or humans) to understand the JitaSpace monorepo quickly and make safe, useful changes.
 
 Big picture
-- Monorepo (Turborepo) containing three apps (apps/web, apps/cli, apps/worker) and many internal packages under `packages/` (db, auth, esi-client, esi-metadata, ui, utils, etc.). See `CLAUDE.md` for a short overview.
+- Monorepo (Turborepo) containing two apps (apps/web, apps/cli) and many internal packages under `packages/` (db, auth, esi-client, esi-metadata, ui, utils, etc.). Background jobs run inside `apps/web` via Inngest — there is no `apps/worker`. See `CLAUDE.md` for a short overview.
 - The web app (`apps/web`) is a Next.js 16 app that imports many local packages via `@jitaspace/*`. Local packages are consumed directly in source (see `apps/web/next.config.mjs` → `transpilePackages`).
 - Data layer: Prisma (packages/db) with a large schema at `packages/db/prisma/schema.prisma`. Database client is generated into the package (run `pnpm db:generate`).
 - API clients: generated with Kubb from OpenAPI specs (see `packages/esi-client/kubb.config.ts` and `packages/*-client/*/swagger.json`). Generated code lives under each client package (e.g. `packages/esi-client/src/generated`). Do NOT edit generated files.
@@ -39,7 +39,7 @@ pnpm kubb:generate
 - Run all dev servers (parallel):
 ```zsh
 pnpm dev
-# This runs `turbo dev --parallel` and starts web/cli/worker
+# This runs `turbo dev --parallel` and starts the web and cli dev servers
 ```
 - Build / CI:
 ```zsh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,85 +1,156 @@
-# JitaSpace - Claude Code Instructions
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
 
-JitaSpace is a Turborepo monorepo for an EVE Online companion web application. It consists of web, CLI, and worker apps plus 15+ shared packages.
+JitaSpace is a Turborepo + pnpm monorepo for an EVE Online companion web app (mail, assets, market orders, wallet, killmails, rich-text rendering of EVE's HTML, and scheduled background data sync). The main product is `apps/web`, a Next.js 16 app deployed to Vercel and live at [jita.space](https://www.jita.space).
+
+> Two sibling docs cover the same ground for other tools: `AGENTS.md` (concise agent guide with per-area file map) and `.github/copilot-instructions.md` (detailed build/CI guide). Keep this file consistent with them when making changes.
 
 ## Package Manager
 
-Use **pnpm** exclusively. npm and yarn are blocked via preinstall hook.
+Use **pnpm exclusively** — the root `preinstall` hook runs `only-allow pnpm`, so `npm install`/`yarn` fail. Pinned to `pnpm@11.3.0`; Node `>=24.16.0` (see `.nvmrc`).
 
-```
-pnpm install
+```bash
+pnpm install                    # install all workspace dependencies
+pnpm install --frozen-lockfile  # CI-safe install (does not alter lockfile)
 ```
 
 ## Key Commands
 
 ```bash
-pnpm build          # Build all packages/apps
-pnpm dev            # Start all dev servers
-pnpm test           # Run tests
-pnpm lint           # ESLint + manypkg checks
-pnpm lint:fix       # Fix linting issues
-pnpm type-check     # TypeScript type checking
-pnpm format         # Prettier formatting
-pnpm db:generate    # Generate Prisma client
-pnpm db:push        # Push Prisma schema to DB (also runs db:generate)
-pnpm kubb:generate  # Generate API clients from OpenAPI specs
-pnpm clean            # Remove root node_modules only
-pnpm clean:workspaces # Clean all workspace packages via turbo
+pnpm dev            # all dev servers (turbo dev --parallel)
+pnpm build          # build all packages/apps
+pnpm test           # Jest unit tests across workspaces (writes coverage/)
+pnpm test:watch     # Jest watch mode
+pnpm lint           # ESLint (flat config) + manypkg workspace checks
+pnpm lint:fix       # auto-fix lint issues
+pnpm type-check     # tsc --noEmit across all workspaces
+pnpm format         # Prettier (also sorts imports)
+pnpm db:generate    # generate Prisma client from packages/db/prisma/schema.prisma
+pnpm db:push        # push Prisma schema to DB (also runs db:generate)
+pnpm kubb:generate  # generate API clients from OpenAPI specs
+pnpm cypress:run    # run web E2E tests headlessly
+pnpm cypress:open   # open Cypress runner
+pnpm clean          # remove all node_modules
+pnpm clean:workspaces # clean workspace build output via turbo
 ```
+
+### Running a single test
+
+Tests live in `apps/web` and run via Jest behind `pnpm with-env` (loads root `.env`). From `apps/web`:
+
+```bash
+pnpm test path/to/file.test.ts          # a single file
+pnpm test -- -t "test name substring"   # by test name
+pnpm test:watch                          # interactive watch
+```
+
+## Critical: code generation before build
+
+Two generated artifacts are prerequisites and the Turbo `build`/`type-check` tasks depend on them. After a fresh clone, a schema change, or a `swagger.json`/`kubb.config.ts` change, run them explicitly:
+
+```bash
+pnpm db:generate     # Prisma client → packages/db
+pnpm kubb:generate   # OpenAPI → TypeScript clients in packages/*-client/src/generated/
+```
+
+If you see import errors for `@jitaspace/db` or `@jitaspace/esi-client`, these haven't run yet.
+
+**Never edit generated files directly.** Instead edit the source and regenerate:
+- Prisma client → edit `packages/db/prisma/schema.prisma`, then `pnpm db:generate`
+- API clients → edit the package's `swagger.json` / `kubb.config.ts`, then `pnpm kubb:generate`
+
+## Environment variables & `SKIP_ENV_VALIDATION`
+
+Copy `.env.example` to `.env` at the repo root. `apps/web/env.ts` validates env vars with Zod (server schema, plus `NEXT_PUBLIC_`-prefixed client schema) and `next.config.mjs` imports it unless `SKIP_ENV_VALIDATION` is set.
+
+**For CI, lint, builds, or any environment without real secrets, set `SKIP_ENV_VALIDATION=1`** or the build/dev server aborts with env errors. Required vars for a real run include `DATABASE_URL`, `REDIS_URL`, `NEXTAUTH_SECRET`, `EVE_CLIENT_ID`, `EVE_CLIENT_SECRET` (full list in `.env.example` / `turbo.json` `globalEnv`).
 
 ## Repository Structure
 
 ```
 apps/
-  web/      # Next.js 16 web app (main product, deployed to Vercel)
-  cli/      # CLI utilities
-  worker/   # Background worker (Vercel-hosted)
+  web/   # Next.js 16 (App Router) — the main product, deployed to Vercel.
+         # Inngest background jobs and cron routes are co-hosted here.
+  cli/   # Developer CLI utilities
 packages/
-  auth/             # Custom EVE Online SSO OAuth2 flow (PKCE + state), token sealing & refresh
-  db/               # Prisma ORM client and schema
-  esi-client/       # Generated EVE Online ESI API client
-  esi-metadata/     # ESI metadata, scopes, ID ranges
-  eve-icons/        # EVE Online icons as React components
-  eve-scrape/       # Inngest background jobs for EVE data scraping
-  hooks/            # React hooks for ESI interactions
-  ui/               # Mantine-based UI component library
-  utils/            # Shared utilities
-  ...               # Other generated API clients
+  auth/ auth-utils/          # NextAuth EVE SSO (OAuth2 PKCE + state), token seal/refresh
+  db/                        # Prisma 7 client + PostgreSQL schema
+  kv/                        # Redis client + Bull job queues
+  esi-client/ sde-client/    # Kubb-generated EVE API clients (ESI, self-hosted SDE)
+  evekill-client/ evetycoon-client/ fuzzworks-market-client/  # more generated clients
+  esi-metadata/ eve-data/    # ESI scopes/ID ranges; static EVE datasets
+  hooks/                     # React Query hooks over ESI / third-party APIs
+  ui/ eve-icons/ tiptap-eve/ # Mantine component lib; icons; EVE-HTML Tiptap extension
+  datatable/ datatable-mantine/ datatable-tanstack/  # engine-agnostic table contract + adapters
+  chat/                      # Discord-backed in-app chat
+  eve-scrape/                # Inngest jobs for scheduled EVE data scraping / SDE imports
+  utils/ sde-utils/          # shared utilities
 tooling/
-  eslint/           # Shared ESLint presets
-  prettier/         # Shared Prettier config
-  scripts/          # Shared build/tooling scripts
-  tsconfig/         # Shared TypeScript configs
+  eslint/ prettier/ tsconfig/  # shared presets (extend these, don't redefine)
 ```
+
+> Note: there is no `apps/worker` — background jobs run inside `apps/web` via Inngest.
 
 ## Tech Stack
 
-- **Runtime:** Node.js >=24.5.0
-- **Language:** TypeScript 5.8.3
-- **Monorepo:** Turborepo 2.5.4
-- **Frontend:** Next.js 16, React 19, Mantine 8
-- **Data Fetching:** TanStack React Query 5
-- **Database:** Prisma 7 + PostgreSQL
-- **Auth:** NextAuth 4 with EVE Online OAuth2
-- **Background Jobs:** Inngest
-- **API Client Generation:** Kubb 3 (generates from OpenAPI specs)
-- **Testing:** Jest 30, Cypress 15
+- **Runtime/Lang:** Node.js ≥24.16.0, TypeScript ~5.9
+- **Monorepo:** Turborepo ~2.9 + pnpm 11
+- **Frontend:** Next.js 16 (App Router), React 19, Mantine 8, Zustand
+- **Data fetching:** TanStack React Query 5
+- **DB / cache:** PostgreSQL + Prisma 7; Redis + Bull
+- **Auth:** NextAuth 4 with EVE Online SSO
+- **Background jobs:** Inngest
+- **API codegen:** Kubb 3 (OpenAPI → TypeScript)
+- **Rich text:** Tiptap + EVE HTML extensions
+- **Testing:** Jest 30 (unit), Cypress 15 (E2E)
+- **Monitoring:** Sentry + Umami
 
 ## Key Conventions
 
-- All internal packages are imported as `@jitaspace/*` with `workspace:*` version specifier
-- Build task depends on `db:generate` and `kubb:generate` — run these first if generated files are missing
-- ESLint uses flat config format (`eslint.config.*`)
-- Prettier uses `@ianvs/prettier-plugin-sort-imports` for import sorting
-- API clients under `packages/*-client/` are auto-generated — do not edit generated files directly
+- **Internal imports:** `@jitaspace/<name>` with `workspace:*` version specifiers in `package.json`.
+- **Adding a new `@jitaspace/*` package to the web app:** if it ships TypeScript source, add it to `transpilePackages` in `apps/web/next.config.mjs`; server-only/Node-only deps go in `serverExternalPackages` instead (e.g. `bull`).
+- **New dependencies** go in the consuming package's `package.json`, not root.
+- **ESLint:** flat config only (`eslint.config.ts`); never `.eslintrc.*`. `apps/web` lints with `--flag unstable_native_nodejs_ts_config`.
+- **TypeScript:** `moduleResolution: Bundler`, `strict`, `noUncheckedIndexedAccess`; all packages extend `tooling/tsconfig/base.json`.
+- **Prettier import order** (via `@ianvs/prettier-plugin-sort-imports`): React/Next → third-party → `@jitaspace/*` types → `@jitaspace/*` values → relative.
+- **Build note:** `apps/web` sets `typescript.ignoreBuildErrors: true` in CI, so TS errors don't fail the Next build — but they still fail `pnpm type-check`. Always run `pnpm type-check` to validate types.
 
-## Environment Variables
+## Changesets
 
-Copy `.env.example` to `.env` at the repo root. Required variables include:
-- `NEXTAUTH_SECRET`, `EVE_CLIENT_ID`, `EVE_CLIENT_SECRET` — Auth
-- `DATABASE_URL` — PostgreSQL connection string
-- `REDIS_URL` — Redis connection
-- `INNGEST_SIGNING_KEY`, `INNGEST_EVENT_KEY` — Background jobs
-- `CRON_SECRET` — Cron endpoint protection
+Non-trivial changes need a changeset in `.changeset/` (skip private packages, i.e. `"private": true`):
+
+```markdown
+---
+"@jitaspace/package-name": patch | minor | major
+---
+
+Description of the change.
+```
+
+- patch = bug fix/internal; minor = new feature/export; major = breaking.
+- **`@jitaspace/web` changesets must be end-user-readable** ("Fixed mail search not returning results"), not implementation detail. All other packages use developer-facing descriptions.
+- If a dependency change produces a visible web-app effect, also add `"@jitaspace/web": patch` with a user-facing note.
+
+## CI
+
+Two GitHub Actions run on push/PR (both set `SKIP_ENV_VALIDATION=1`):
+- **`cypress.yml`:** spins up CockroachDB + Redis → push DB schema → `pnpm build` → start web → Cypress E2E (parallel).
+- **`sonarcloud.yml`:** `pnpm install --frozen-lockfile` → `pnpm test` (coverage) → SonarQube scan. New code must keep coverage above the quality gate.
+
+Local equivalent before pushing: `pnpm db:generate` → `SKIP_ENV_VALIDATION=1 pnpm build` → `pnpm lint` → `pnpm type-check` → `pnpm test`.
+
+## Where to look first
+
+| Area | Path |
+|---|---|
+| Turbo pipeline | `turbo.json` |
+| Web config / env | `apps/web/next.config.mjs`, `apps/web/env.ts` |
+| Web routes | `apps/web/app/` |
+| DB schema | `packages/db/prisma/schema.prisma` |
+| ESI client gen | `packages/esi-client/kubb.config.ts`, `packages/esi-client/swagger.json` |
+| Auth | `packages/auth/src/auth-options.ts` |
+| Shared tooling | `tooling/eslint/src/base.ts`, `tooling/prettier/index.mjs`, `tooling/tsconfig/base.json` |
+| Test config (web) | `apps/web/jest.config.ts`, `apps/web/cypress.config.ts` |


### PR DESCRIPTION
## Summary

Significantly expanded and reorganized the developer documentation to provide clearer, more actionable guidance for both humans and AI agents working with the JitaSpace monorepo. Updated all three guidance files to reflect current project structure and best practices.

## Key Changes

- **CLAUDE.md** (major expansion):
  - Added introductory note linking to sibling docs (AGENTS.md, copilot-instructions.md)
  - Expanded package manager section with specific version pins and frozen-lockfile guidance
  - Reorganized and annotated key commands with descriptions
  - Added new "Running a single test" section with Jest examples
  - Added critical "code generation before build" section explaining Prisma and Kubb prerequisites
  - Added "Environment variables & `SKIP_ENV_VALIDATION`" section with CI guidance
  - Expanded repository structure with detailed package descriptions and clarification that `apps/worker` no longer exists
  - Updated tech stack with more specific versions and additional tools (Zustand, Bull, Sentry, Umami, Tiptap)
  - Expanded "Key Conventions" with guidance on `transpilePackages`, `serverExternalPackages`, ESLint flat config, TypeScript settings, Prettier import order, and build error handling
  - Added new "Changesets" section documenting the process and requirements
  - Added new "CI" section describing GitHub Actions workflows
  - Added "Where to look first" reference table for common tasks

- **AGENTS.md**:
  - Updated app count from three to two (removed `apps/worker`)
  - Added clarification that background jobs run inside `apps/web` via Inngest

- **.github/copilot-instructions.md**:
  - Updated app count and architecture description
  - Updated pnpm version from 10.33.4 to 11.3.0
  - Clarified that background jobs run via Inngest, not a separate worker app

## Notable Details

- All three files now consistently reflect that `apps/worker` has been removed and Inngest jobs are co-hosted in `apps/web`
- CLAUDE.md now serves as the comprehensive reference with cross-references to the other two docs
- Added practical guidance on environment validation, code generation prerequisites, and CI workflows
- Expanded package descriptions to help developers understand the purpose of each internal package

https://claude.ai/code/session_01QouqVWYzG1b8hF4HJbK4XR