### PR TITLE
feat(ui): add DogmaAttributeValue for unit-aware dogma value formatting

### DIFF
--- a/.changeset/dogma-attribute-value.md
+++ b/.changeset/dogma-attribute-value.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/ui": patch
+"@jitaspace/web": patch
+---
+
+Add `DogmaAttributeValue`, a component that formats EVE dogma attribute values for their unit. Item Type and Dogma Attribute pages now render resistances and percentages as "25%", multipliers as "+10%", volumes as "100 m³", and boolean flags as "Yes"/"No" instead of raw numbers.

--- a/apps/web/app/dogma/attribute/[attributeId]/page.client.tsx
+++ b/apps/web/app/dogma/attribute/[attributeId]/page.client.tsx
@@ -15,7 +15,7 @@ import {
 } from "@mantine/core";
 
 import { sanitizeFormattedEveString } from "@jitaspace/tiptap-eve";
-import { TypeAnchor, TypeAvatar } from "@jitaspace/ui";
+import { DogmaAttributeValue, TypeAnchor, TypeAvatar } from "@jitaspace/ui";
 
 import { MailMessageViewer } from "~/components/EveMail";
 
@@ -30,6 +30,7 @@ export interface PageProps {
   published: boolean | null;
   stackable: boolean | null;
   unit: string | null;
+  unitId: number | null;
   iconId: number | null;
   types: { typeId: number; name: string; value: number; groupId: number }[];
   groups: { groupId: number; name: string }[];
@@ -46,6 +47,7 @@ export default function DogmaAttributePage({
   published,
   stackable,
   unit,
+  unitId,
   iconId,
   types,
   groups,
@@ -75,7 +77,18 @@ export default function DogmaAttributePage({
     ...(name ? [{ label: "Name", value: name }] : []),
     ...(displayName ? [{ label: "Display Name", value: displayName }] : []),
     ...(defaultValue !== null
-      ? [{ label: "Default Value", value: defaultValue }]
+      ? [
+          {
+            label: "Default Value",
+            value: (
+              <DogmaAttributeValue
+                value={defaultValue}
+                unitId={unitId ?? undefined}
+                unitSymbol={unit ?? undefined}
+              />
+            ),
+          },
+        ]
       : []),
     { label: "High is Good", value: booleanBadge(highIsGood) },
     { label: "Published", value: booleanBadge(published) },
@@ -143,7 +156,13 @@ export default function DogmaAttributePage({
                           </TypeAnchor>
                         </Group>
                       </Table.Td>
-                      <Table.Td align="right">{type.value}</Table.Td>
+                      <Table.Td align="right">
+                        <DogmaAttributeValue
+                          value={type.value}
+                          unitId={unitId ?? undefined}
+                          unitSymbol={unit ?? undefined}
+                        />
+                      </Table.Td>
                     </Table.Tr>
                   ))}
                 </Table.Tbody>

--- a/apps/web/app/dogma/attribute/[attributeId]/page.tsx
+++ b/apps/web/app/dogma/attribute/[attributeId]/page.tsx
@@ -83,6 +83,7 @@ async function getAttributeData(attributeId: number): Promise<PageProps> {
     published: attribute.published ?? null,
     stackable: attribute.stackable ?? null,
     unit: attribute.DogmaUnit?.displayName ?? attribute.DogmaUnit?.name ?? null,
+    unitId: attribute.unitId ?? null,
     iconId: attribute.iconId ?? null,
     types: attribute.TypeAttributes.map((entry) => ({
       ...entry.type,

--- a/apps/web/app/type/[typeId]/page.client.tsx
+++ b/apps/web/app/type/[typeId]/page.client.tsx
@@ -46,6 +46,7 @@ import { sanitizeFormattedEveString } from "@jitaspace/tiptap-eve";
 import {
   CategoryAnchor,
   DogmaAttributeAnchor,
+  DogmaAttributeValue,
   DogmaEffectAnchor,
   EveIconAvatar,
   GroupAnchor,
@@ -111,15 +112,6 @@ const booleanBadge = (value: boolean | null | undefined) => (
   </Badge>
 );
 
-/** Turn ASCII unit shorthand from the SDE into nicer typography (m3 -> m³). */
-const prettifyUnitSymbol = (symbol?: string): string | undefined =>
-  symbol
-    ? symbol
-        .replaceAll(/m3/gi, "m³")
-        .replaceAll("^3", "³")
-        .replaceAll("^2", "²")
-    : undefined;
-
 /** Locale-format a number, keeping useful precision for small fractions. */
 const formatNumber = (value: number): string => {
   if (value === 0) return "0";
@@ -129,37 +121,6 @@ const formatNumber = (value: number): string => {
   if (abs < 1) maximumFractionDigits = 4;
   if (abs < 0.001) maximumFractionDigits = 6;
   return value.toLocaleString(undefined, { maximumFractionDigits });
-};
-
-/**
- * Format a dogma attribute value the way the EVE client does, applying the
- * well-known unit transforms (resistances, percentages, multipliers) and
- * otherwise appending the unit symbol. Transforms are documented in the SDE
- * unit descriptions and verified against in-game values.
- */
-const formatAttributeValue = (value: number, unit?: UnitInfo): string => {
-  switch (unit?.unitId) {
-    // Inverse Absolute Percent — resistances. 0.0 => 100%, 1.0 => 0%.
-    case 108:
-      return `${formatNumber((1 - value) * 100)}%`;
-    // Absolute Percent. 0.0 => 0%, 1.0 => 100%.
-    case 127:
-      return `${formatNumber(value * 100)}%`;
-    // Modifier Percent — multiplier shown as a signed %. 1.1 => +10%, 0.9 => -10%.
-    case 109: {
-      const percent = (value - 1) * 100;
-      return `${percent > 0 ? "+" : ""}${formatNumber(percent)}%`;
-    }
-    // Boolean flag.
-    case 137:
-      return value >= 1 ? "Yes" : "No";
-    default: {
-      const symbol = prettifyUnitSymbol(unit?.symbol);
-      if (!symbol) return formatNumber(value);
-      if (symbol === "%") return `${formatNumber(value)}%`;
-      return `${formatNumber(value)} ${symbol}`;
-    }
-  }
 };
 
 function SectionHeading({
@@ -266,9 +227,14 @@ function AttributeValue({
       );
     default:
       return (
-        <Text ff="monospace" fw={600} c="eve.2">
-          {formatAttributeValue(value, unit)}
-        </Text>
+        <DogmaAttributeValue
+          value={value}
+          unitId={unit?.unitId}
+          unitSymbol={unit?.symbol}
+          ff="monospace"
+          fw={600}
+          c="eve.2"
+        />
       );
   }
 }

--- a/apps/web/components/Compare/CompareTable.tsx
+++ b/apps/web/components/Compare/CompareTable.tsx
@@ -4,16 +4,13 @@ import { Group, JsonInput, Table } from "@mantine/core";
 import { useDogmaAttributes, useTypes } from "@jitaspace/hooks";
 import {
   DogmaAttributeAnchor,
+  formatDogmaAttributeValue,
   TypeAnchor,
   TypeAvatar,
   TypeName,
 } from "@jitaspace/ui";
 
 import { DogmaAttributeName } from "~/components/Text";
-
-
-
-
 
 export interface CompareTableProps {
   typeIds: number[];
@@ -103,15 +100,20 @@ export const CompareTable = memo(({ typeIds }: CompareTableProps) => {
                   <DogmaAttributeName attributeId={attribute.attribute_id} />
                 </DogmaAttributeAnchor>
               </Table.Td>
-              {sortedTypes.map((type) => (
-                <Table.Td key={type.type_id}>
-                  {(type.dogma_attributes ?? [])
-                    .find(
-                      (entry) => entry.attribute_id === attribute.attribute_id,
-                    )
-                    ?.value.toLocaleString()}
-                </Table.Td>
-              ))}
+              {sortedTypes.map((type) => {
+                const value = (type.dogma_attributes ?? []).find(
+                  (entry) => entry.attribute_id === attribute.attribute_id,
+                )?.value;
+                return (
+                  <Table.Td key={type.type_id}>
+                    {value === undefined
+                      ? null
+                      : formatDogmaAttributeValue(value, {
+                          unitId: attribute.unit_id,
+                        })}
+                  </Table.Td>
+                );
+              })}
             </Table.Tr>
           ))}
         </Table.Tbody>

--- a/apps/web/tests/dataTables.test.tsx
+++ b/apps/web/tests/dataTables.test.tsx
@@ -58,6 +58,7 @@ jest.mock("@jitaspace/ui", () => ({
   DogmaAttributeAnchor: ({ children }: { children?: ReactNode }) => (
     <span data-testid="attr-anchor">{children}</span>
   ),
+  formatDogmaAttributeValue: (value: number) => value.toLocaleString(),
   TypeAnchor: ({ children }: { children?: ReactNode }) => (
     <span data-testid="type-anchor">{children}</span>
   ),

--- a/packages/ui/Text/DogmaAttributeValue.tsx
+++ b/packages/ui/Text/DogmaAttributeValue.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { TextProps } from "@mantine/core";
+import React, { memo } from "react";
+import { Skeleton, Text } from "@mantine/core";
+
+export type DogmaAttributeValueProps = TextProps & {
+  /** The raw numeric attribute value. */
+  value?: number;
+  /** The dogma unit's id (SDE `dogmaUnits`) — drives the transforms below. */
+  unitId?: number;
+  /** The unit's display symbol (e.g. "m", "m3", "%"); used for plain units. */
+  unitSymbol?: string;
+};
+
+/** Locale-format a number, keeping useful precision for small fractions. */
+function formatNumber(value: number): string {
+  if (value === 0) return "0";
+  if (Number.isInteger(value)) return value.toLocaleString();
+  const abs = Math.abs(value);
+  let maximumFractionDigits = 2;
+  if (abs < 1) maximumFractionDigits = 4;
+  if (abs < 0.001) maximumFractionDigits = 6;
+  return value.toLocaleString(undefined, { maximumFractionDigits });
+}
+
+/** Turn ASCII unit shorthand from the SDE into nicer typography (m3 -> m³). */
+function prettifyUnitSymbol(symbol?: string): string | undefined {
+  return symbol
+    ? symbol
+        .replaceAll(/m3/gi, "m³")
+        .replaceAll("^3", "³")
+        .replaceAll("^2", "²")
+    : undefined;
+}
+
+/**
+ * Format a dogma attribute value the way the EVE client does: applying the
+ * well-known unit transforms (resistances, percentages, multipliers, booleans)
+ * and otherwise appending the unit's display symbol. The numeric ids are the
+ * SDE `dogmaUnits` ids; the transforms are verified against in-game values.
+ */
+export function formatDogmaAttributeValue(
+  value: number,
+  unit?: { unitId?: number; symbol?: string },
+): string {
+  switch (unit?.unitId) {
+    // Inverse Absolute Percent — resistances. 0.0 => 100%, 1.0 => 0%.
+    case 108:
+      return `${formatNumber((1 - value) * 100)}%`;
+    // Absolute Percent. 0.0 => 0%, 1.0 => 100%.
+    case 127:
+      return `${formatNumber(value * 100)}%`;
+    // Modifier Percent — multiplier shown as a signed %. 1.1 => +10%, 0.9 => -10%.
+    case 109: {
+      const percent = (value - 1) * 100;
+      return `${percent > 0 ? "+" : ""}${formatNumber(percent)}%`;
+    }
+    // Boolean flag.
+    case 137:
+      return value >= 1 ? "Yes" : "No";
+    default: {
+      const symbol = prettifyUnitSymbol(unit?.symbol);
+      if (!symbol) return formatNumber(value);
+      if (symbol === "%") return `${formatNumber(value)}%`;
+      return `${formatNumber(value)} ${symbol}`;
+    }
+  }
+}
+
+/**
+ * Renders a single dogma attribute value formatted for its unit. Pass the
+ * attribute's `unitId` (and, for plain units, the unit's `unitSymbol`) so the
+ * value reads the way it does in the EVE client — resistances as "25%",
+ * multipliers as "+10%", volumes as "100 m³", booleans as "Yes"/"No". Renders
+ * a skeleton while `value` is undefined.
+ */
+export const DogmaAttributeValue = memo(
+  ({ value, unitId, unitSymbol, ...otherProps }: DogmaAttributeValueProps) => {
+    if (value === undefined) {
+      return (
+        <Text {...otherProps}>
+          <Skeleton
+            component="span"
+            style={{ display: "inline-block" }}
+            height="1em"
+            width="4ch"
+          />
+        </Text>
+      );
+    }
+    return (
+      <Text {...otherProps}>
+        {formatDogmaAttributeValue(value, { unitId, symbol: unitSymbol })}
+      </Text>
+    );
+  },
+);
+DogmaAttributeValue.displayName = "DogmaAttributeValue";

--- a/packages/ui/Text/index.ts
+++ b/packages/ui/Text/index.ts
@@ -9,6 +9,7 @@ export * from "./ConstellationName";
 export * from "./CorporationName";
 export * from "./CSPACostText";
 export * from "./DogmaAttributeName";
+export * from "./DogmaAttributeValue";
 export * from "./DogmaEffectName";
 export * from "./EveEntityName";
 export * from "./EveMailSenderName";

--- a/packages/ui/tests/Text/DogmaAttributeValue.test.tsx
+++ b/packages/ui/tests/Text/DogmaAttributeValue.test.tsx
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import type { ReactElement } from "react";
+import { describe, expect, it } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+import {
+  DogmaAttributeValue,
+  formatDogmaAttributeValue,
+} from "../../Text/DogmaAttributeValue";
+
+const renderWithMantine = (ui: ReactElement) =>
+  render(<MantineProvider>{ui}</MantineProvider>);
+
+describe("formatDogmaAttributeValue", () => {
+  // The unit-id transforms mirror the EVE client. Values are kept free of
+  // thousands separators so the assertions stay locale-independent.
+  it.each<
+    [string, number, { unitId?: number; symbol?: string } | undefined, string]
+  >([
+    ["resistance (inverse percent, unit 108)", 0.25, { unitId: 108 }, "75%"],
+    ["absolute percent (unit 127)", 0.5, { unitId: 127 }, "50%"],
+    ["positive modifier percent (unit 109)", 1.1, { unitId: 109 }, "+10%"],
+    ["negative modifier percent (unit 109)", 0.9, { unitId: 109 }, "-10%"],
+    ["boolean true (unit 137)", 1, { unitId: 137 }, "Yes"],
+    ["boolean false (unit 137)", 0, { unitId: 137 }, "No"],
+    ["plain unit with m3 prettified to m³", 100, { symbol: "m3" }, "100 m³"],
+    ["percent symbol unit", 5, { symbol: "%" }, "5%"],
+    ["bare value with no unit", 42, undefined, "42"],
+  ])("formats %s", (_label, value, unit, expected) => {
+    expect(formatDogmaAttributeValue(value, unit)).toBe(expected);
+  });
+});
+
+describe("DogmaAttributeValue", () => {
+  it("renders the value transformed for its unit id", () => {
+    renderWithMantine(<DogmaAttributeValue value={0.25} unitId={108} />);
+    expect(screen.getByText("75%")).toBeInTheDocument();
+  });
+
+  it("appends the prettified unit symbol for plain units", () => {
+    renderWithMantine(<DogmaAttributeValue value={100} unitSymbol="m3" />);
+    expect(screen.getByText("100 m³")).toBeInTheDocument();
+  });
+
+  it("renders a skeleton placeholder when the value is missing", () => {
+    renderWithMantine(<DogmaAttributeValue data-testid="dav" />);
+    const text = screen.getByTestId("dav");
+    expect(text).toBeInTheDocument();
+    expect(text.querySelector("span")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a reusable `DogmaAttributeValue` component (and a pure `formatDogmaAttributeValue` helper) to `@jitaspace/ui` that formats EVE dogma attribute values the way the in-game client does, then uses it everywhere dogma attribute values are displayed.

The Type page already had this exact formatting logic inline — this extracts it into one shared place and reuses it, so values render consistently across the app.

## What changed

- **New component** — `packages/ui/Text/DogmaAttributeValue.tsx`, exported from the `Text` barrel. Applies the well-known unit-id transforms (resistances → `25%`, absolute percent → `50%`, modifier multipliers → `+10%`/`-10%`, booleans → `Yes`/`No`) and otherwise appends the prettified unit symbol (`m3` → `m³`). Renders a skeleton while the value is `undefined`.
- **Type page** (`apps/web/app/type/[typeId]/page.client.tsx`) — replaced the duplicated inline `formatAttributeValue`/`prettifyUnitSymbol` with the shared component (≈40 fewer lines). The id-reference link cases for type/group/attribute units are preserved, and `formatNumber` stays for physical properties (volume, mass, …).
- **Dogma Attribute page** (`apps/web/app/dogma/attribute/[attributeId]/page.{tsx,client.tsx}`) — threaded the attribute's `unitId` through the server component and formatted the **Default Value** and **per-type values**, which were previously raw numbers (e.g. a resistance now shows `75%` instead of `0.25`).
- **Compare table** (`apps/web/components/Compare/CompareTable.tsx`) — formats values via the shared helper instead of a bare `toLocaleString()`.
- **Tests** — `packages/ui/tests/Text/DogmaAttributeValue.test.tsx` covers every unit transform plus the value/symbol/skeleton render states (100% line coverage of the new component).
- **Changeset** — `@jitaspace/ui` + `@jitaspace/web` (patch), with a user-facing note.

## Verification

- `pnpm test` (ui Text suites): **77 passing**, including 12 new cases asserting exact formatted output.
- `pnpm type-check`: the touched files report **0 errors** (the package-wide `tsc` red is entirely pre-existing — classic-JSX `React` globals in untouched files and generated-type drift).
- Prettier: clean on all touched files.

## Notes for reviewers

- The component imports `React` to satisfy `@jitaspace/ui`'s classic `"jsx": "react"` tsconfig, matching its siblings `DogmaAttributeName`/`DogmaEffectName`.
- Live in-browser verification wasn't possible from the worktree (no local `.env`, and both routes query Prisma at request time against the production DB), so behavior was verified via the unit tests instead.
- One pre-existing import-ordering quirk in the dogma `page.tsx` was intentionally left untouched to keep the diff focused on the one-line `unitId` addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)