### PR TITLE
fix(sde-client): fetch OpenAPI spec over HTTPS in kubb codegen

### DIFF
--- a/packages/sde-client/kubb.config.ts
+++ b/packages/sde-client/kubb.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(async () => {
     name: "sde-client",
     root: ".",
     input: {
-      path: "http://sde.jita.space/20260527/swagger.json",
+      path: "https://sde.jita.space/20260527/swagger.json",
     },
     output: {
       path: "./src/generated",


### PR DESCRIPTION
## What

Switched the Kubb codegen input for `@jitaspace/sde-client` from `http://` to `https://`:

```diff
-      path: "http://sde.jita.space/20260527/swagger.json",
+      path: "https://sde.jita.space/20260527/swagger.json",
```

## Why

Resolves SonarCloud security hotspot **S5332** (cleartext HTTP). This came out of a review of all 9 open SonarCloud security hotspots on the project.

- The generated client's `baseURL` (lines 22 & 29 of the same file) already used `https://` — only the spec-fetch input was still `http://`.
- `sde.jita.space` serves the spec over TLS (`200`), and the old HTTP URL already `301`-redirected to HTTPS.
- So this is a **zero-behavior-change** hardening fix; regenerated output is identical.

## Reviewer notes

- `@jitaspace/sde-client` is `private`, so no changeset is required.
- Build-time codegen config only — not runtime or browser-observable.

### Other hotspots reviewed (no code change — false positives / legitimate use)

The remaining 8 hotspots are safe and should be dismissed via **Mark as Safe** in the SonarCloud UI:

- **S5852** regex DoS in `CorporationCard.tsx:38` — `/<[^>]+>/g` is linear-time (single quantifier over a `>`-excluding class, no nested quantifier/overlapping alternation); not exploitable. Input is a bounded ESI corporation description.
- **S2245** weak PRNG (`Math.random`) ×7 in `packages/utils/src/math.ts` & `objects.ts` — used only for statistical helpers and picking a **default mail-label color**. Nothing security-sensitive (no tokens/secrets/salts/session state). The only other `Math.random` callsites (`apps/cli/utils/collections.ts`) are commented-out dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)