### PR TITLE
fix(triggerdev): build on Node 22 so pnpm 11.3.0 can run

### DIFF
--- a/packages/background-jobs-triggerdev/trigger.config.ts
+++ b/packages/background-jobs-triggerdev/trigger.config.ts
@@ -7,13 +7,18 @@ import { defineConfig } from "@trigger.dev/sdk";
  * the placeholder) before `trigger.dev dev`/`deploy`.
  *
  * Prisma 7 uses the `prisma-client` generator, so the build uses modern mode.
- * Modern mode does NOT run `prisma generate` — CI/deploy must run it first
- * (the GitHub Action runs `pnpm db:generate` before deploying).
+ * Modern mode does NOT run `prisma generate` — it must run before the build.
+ * The deploy installs from the repo root and `@jitaspace/db`'s postinstall
+ * runs `prisma generate`, so the install step covers it.
+ *
+ * runtime "node-22" → Node 22.16.0: the repo pins `pnpm@11.3.0`, which needs
+ * Node >=22.13, but Trigger's default build runtime is older. node-22 is the
+ * newest Trigger offers (no node-24 yet), and it clears the pnpm floor.
  */
 export default defineConfig({
   project: process.env.TRIGGER_PROJECT_REF ?? "proj_REPLACE_ME",
   dirs: ["./src/trigger"],
-  runtime: "node",
+  runtime: "node-22",
   // Generous default; long jobs (solar systems, killmail backfill) set their own.
   maxDuration: 600,
   retries: {


### PR DESCRIPTION
Follow-up to #565. With the CLI bumped to 4.4.6, the Trigger.dev deploy got past the version check and reached dependency installation, where it **failed**:

> warn: This version of pnpm requires at least Node.js v22.13
> warn: The current version of Node.js is v20.20.2
> Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite

## Why

The native build server's default runtime is **Node 20.20.2**. Corepack honours the repo's `packageManager: pnpm@11.3.0`, but pnpm 11 requires **Node ≥22.13** (it imports `node:sqlite`), so it crashes during install.

## What

Set `runtime: "node-22"` (Node 22.16.0) in `trigger.config.ts` — the newest runtime Trigger offers and above pnpm's floor.

- No root `.npmrc` (so no `engine-strict`) and no pnpm `use-node-version` pin, so the repo's `engines` (Node 24) only **warns** on Node 22 — it won't fail the install — and the tasks use no Node-24-only APIs.
- Trigger has no `node-24` option yet, so 22.16.0 is the closest to our Node 24 target.

Also refreshed a stale comment that referenced the removed GitHub Action (Prisma generate now runs via `@jitaspace/db`'s install postinstall).

## Verification

`pnpm --filter @jitaspace/background-jobs-triggerdev type-check` — clean (`"node-22"` is a valid runtime literal).

Merging this re-fires the deploy on Node 22.16.0, which should clear the install step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)