### PR TITLE
fix(db): generate Prisma client on postinstall (unblocks Trigger.dev build)

### DIFF
--- a/.changeset/db-postinstall-prisma-generate.md
+++ b/.changeset/db-postinstall-prisma-generate.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/db": patch
+---
+
+Generate the Prisma client on `postinstall` so a bare `pnpm install` produces `prisma/generated/client` (previously only the `build` / `db:generate` scripts did). This unblocks build environments that install without running the repo build — e.g. the Trigger.dev native build server. `prisma generate` is offline, so no `DATABASE_URL` is required.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -41,6 +41,7 @@
     "dev": "pnpm with-env concurrently -c \"auto\" --names \"Studio,Watch\" \"pnpm:db:studio\" \"pnpm:db:generate:watch\"",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
+    "postinstall": "prisma generate",
     "prepublishOnly": "pnpm build",
     "type-check": "tsc --jsx react-jsx --noEmit",
     "with-env": "dotenv -e ../../.env --"


### PR DESCRIPTION
Follow-up to #565 / #567. With node-22 in place, the Trigger.dev deploy now installs deps, generates the kubb clients, and starts the native build — then fails:

> Building trigger code
> X Error: Build failed with 1 error:
> ../db/index.ts:3:29: ERROR: Could not resolve "./prisma/generated/client"

## Why

The native build server runs `pnpm install` and then bundles with esbuild — it never runs turbo `build` / `db:generate`. The five generated `*-client` packages self-generate via a **`postinstall`** hook (visible in the deploy log), but `packages/db` only generates its Prisma client inside its **`build`** script. So the client is missing when esbuild bundles `db/index.ts`.

## What

Add `"postinstall": "prisma generate"` to `packages/db` — mirroring the `*-client` pattern — so every `pnpm install` produces the client.

`prisma generate` is **offline** (reads the schema, no DB connection), so it needs no `DATABASE_URL` — verified by running it with the var unset. Safe in CI, fresh clones, and the Trigger build alike. (This also makes the `copilot-instructions.md` claim that "db runs prisma generate on postinstall" actually true.)

## Verification

- `env -u DATABASE_URL prisma generate` → ✅ generated the client (no DB needed)
- `pnpm --filter @jitaspace/db run postinstall` → ✅ runs `prisma generate`, generates to `./prisma/generated`
- No lockfile change (scripts don't affect the lockfile)

Merging re-fires the deploy; the bundle should now resolve `./prisma/generated/client` and index all 46 tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)