### PR TITLE
docs(triggerdev): document the Trigger.dev console build settings

### DIFF
--- a/packages/background-jobs-triggerdev/README.md
+++ b/packages/background-jobs-triggerdev/README.md
@@ -39,9 +39,22 @@ Deployment runs through the official **Trigger.dev GitHub + Vercel integrations*
 Action or `TRIGGER_ACCESS_TOKEN` secret in this repo. For a manual/local deploy:
 `pnpm deploy` (runs `trigger.dev deploy`).
 
-**Prisma 7:** modern-mode `prismaExtension` does **not** run `prisma generate`,
-so the generated client must exist before deploy. The repo's `pnpm install`
-postinstall generates it, so the integration's install step covers this.
+Because this is a monorepo, set these in the Trigger.dev project's **build
+settings** (Console → Project → Settings):
+
+| Setting             | Value                                                   |
+| ------------------- | ------------------------------------------------------- |
+| Trigger config file | `packages/background-jobs-triggerdev/trigger.config.ts` |
+| Install command     | `pnpm install`                                          |
+| Pre-build command   | `pnpm db:generate`                                      |
+
+The **pre-build command** is load-bearing: modern-mode `prismaExtension` does
+**not** run `prisma generate`, and the native build server only runs
+`pnpm install` + the bundle (never `turbo build`), so the Prisma client
+(`packages/db/prisma/generated`) would be missing when esbuild bundles
+`db/index.ts`. `pnpm db:generate` runs after install and before the build, and is
+offline (no `DATABASE_URL` needed). The kubb-generated `*-client` packages already
+self-generate via their own `postinstall`, so they're present after install.
 
 ## Status dashboard
 

--- a/packages/background-jobs-triggerdev/trigger.config.ts
+++ b/packages/background-jobs-triggerdev/trigger.config.ts
@@ -7,9 +7,9 @@ import { defineConfig } from "@trigger.dev/sdk";
  * the placeholder) before `trigger.dev dev`/`deploy`.
  *
  * Prisma 7 uses the `prisma-client` generator, so the build uses modern mode.
- * Modern mode does NOT run `prisma generate` — it must run before the build.
- * The deploy installs from the repo root and `@jitaspace/db`'s postinstall
- * runs `prisma generate`, so the install step covers it.
+ * Modern mode does NOT run `prisma generate` — it must run before the build, so
+ * the Trigger.dev project sets a pre-build command `pnpm db:generate` (Console →
+ * build settings; documented in this package's README).
  *
  * runtime "node-22" → Node 22.16.0: the repo pins `pnpm@11.3.0`, which needs
  * Node >=22.13, but Trigger's default build runtime is older. node-22 is the


### PR DESCRIPTION
The Trigger.dev deploy depends on monorepo-specific build settings that live only in the Trigger.dev Console — invisible to anyone reading the repo. This documents them so they're discoverable, and supersedes the `@jitaspace/db` postinstall in #568.

## Build settings (Console → Project → Settings)

| Setting | Value |
| --- | --- |
| Trigger config file | `packages/background-jobs-triggerdev/trigger.config.ts` |
| Install command | `pnpm install` |
| Pre-build command | `pnpm db:generate` |

## Why the pre-build command

Modern-mode `prismaExtension` does **not** run `prisma generate`, and the native build server only runs `pnpm install` + the bundle (never `turbo build`) — so the Prisma client would be missing when esbuild bundles `db/index.ts`. `pnpm db:generate` runs after install / before the build and is offline (no `DATABASE_URL`). This is the scoped alternative to a global db `postinstall` (#568): no every-install cost, no `--prod`/published-consumer footgun.

## Changes

- README: add the build-settings table + an accurate explanation of the pre-build command.
- `trigger.config.ts`: fix the stale comment that claimed a db `postinstall` generated the client.

Docs only; `background-jobs-triggerdev` is private, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)