### PR TITLE
feat(web): link to EVE Workbench ship fittings on type pages

### DIFF
--- a/.changeset/eveworkbench-fits-link.md
+++ b/.changeset/eveworkbench-fits-link.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Added a link to EVE Workbench ship fittings on ship type pages, next to the EVE Ref and EVE Tycoon links.

--- a/apps/web/app/type/[typeId]/page.client.tsx
+++ b/apps/web/app/type/[typeId]/page.client.tsx
@@ -82,6 +82,9 @@ const notAvailableText = "Not available";
 /** The Forge — the region containing Jita, EVE's main trade hub. */
 const THE_FORGE_REGION_ID = 10000002;
 
+/** Inventory category for ship hulls — used to gate ship-only external links. */
+const SHIP_CATEGORY_ID = 6;
+
 /** Image variations that look good rendered large (vs. small square icons). */
 const LARGE_IMAGE_VARIATIONS = new Set(["render", "bp", "bpc"]);
 
@@ -580,6 +583,18 @@ export default function TypePage({
                 >
                   EVE Tycoon
                 </Button>
+                {categoryId === SHIP_CATEGORY_ID && (
+                  <Button
+                    component={Link}
+                    href={`https://eveworkbench.com/fits?ship=${typeId}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    size="xs"
+                    leftSection={<IconExternalLink size={14} />}
+                  >
+                    EVE Workbench
+                  </Button>
+                )}
               </Group>
             </Stack>
           </Group>

--- a/apps/web/tests/typePage.test.tsx
+++ b/apps/web/tests/typePage.test.tsx
@@ -248,6 +248,23 @@ describe("Type page (client)", () => {
       "href",
       "https://evetycoon.com/market/30",
     );
+
+    // The EVE Workbench fits link is ship-only; this type is category 4.
+    expect(
+      screen.queryByRole("link", { name: /EVE Workbench/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the EVE Workbench fits link only for ships (category 6)", () => {
+    mockUseGetUniverseGroupsGroupId.mockReturnValue({
+      data: { data: { category_id: 6 } },
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByRole("link", { name: /EVE Workbench/i }),
+    ).toHaveAttribute("href", "https://eveworkbench.com/fits?ship=30");
   });
 
   it("exposes Overview, Attributes, Market and Description tabs for full data", () => {


### PR DESCRIPTION
## What

Adds an **EVE Workbench** link to the type page hero, alongside the existing **EVE Ref** and **EVE Tycoon** links. It deep-links into EVE Workbench's fitting search for the current ship:

`https://eveworkbench.com/fits?ship=<typeId>`

## Why

Lionear, who runs [EVE Workbench](https://eveworkbench.com), asked us to cross-link. JitaSpace already links out to EVE Ref and EVE Tycoon from the type page; this adds EVE Workbench's fittings next to them.

## Details

- **Ship-only.** The button only renders for ship hulls (inventory category `6`, via a new `SHIP_CATEGORY_ID` constant). EVE Workbench's `?ship=` search only returns results for ships, so showing it on a mineral/module page would just link to an empty search. EVE Ref and EVE Tycoon stay unconditional.
- Reuses the exact `Button` + `IconExternalLink` pattern of the adjacent links, so placement and styling are consistent by construction.
- The button appears once the group/category ESI lookup resolves (same progressive-load behaviour as the rest of the hero).

## Testing

- `apps/web` Jest (`typePage.test.tsx`): new coverage for the link's **presence for ships** (category 6 → exact href `https://eveworkbench.com/fits?ship=30`) and **absence for non-ships** (category 4). Full suite: 10/10 pass.
- `type-check`: no errors introduced in the changed file (pre-existing baseline noise elsewhere is unrelated).
- Prettier: clean.

## Not included

Lionear also offered a market link next to EVE Tycoon, but didn't provide a URL and their market URL structure is inconsistent (`/market/buy/<id>` vs longer region/station forms). Deferred pending a canonical per-type market deeplink — not in this PR.

## Try it

On a ship page (e.g. `/type/641`, the Megathron) the new **EVE Workbench** button shows in the hero; on a non-ship page (e.g. `/type/34`, Tritanium) it's absent.
