### PR TITLE
perf(web): keep Travel Planner responsive while recalculating routes

### DIFF
--- a/.changeset/travel-route-slider-inp.md
+++ b/.changeset/travel-route-slider-inp.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Improve the Travel Planner's responsiveness. Adjusting the security-penalty sliders in "Custom" route preference no longer freezes the page while the route recalculates, and the waypoint system pickers now open instantly instead of stalling on the full list of solar systems.

--- a/apps/web/app/travel/[[...waypoints]]/page.client.tsx
+++ b/apps/web/app/travel/[[...waypoints]]/page.client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Container,
@@ -53,19 +53,35 @@ export default function TravelPage({
   const [lowSecPenalty, setLowSecPenalty] = useState<number>(0);
   const [highSecPenalty, setHighSecPenalty] = useState<number>(0);
 
+  // The penalty sliders fire `onChange` continuously while dragging. Running the
+  // NBA* pathfinder over the full New Eden graph (thousands of systems) on every
+  // tick blocks the main thread and wrecks Interaction to Next Paint. Deferring
+  // the values the route depends on keeps the slider thumb and live labels
+  // responsive (urgent update), while React recomputes the route as a
+  // lower-priority, interruptible transition that coalesces rapid changes.
+  const deferredNullSecPenalty = useDeferredValue(nullSecPenalty);
+  const deferredLowSecPenalty = useDeferredValue(lowSecPenalty);
+  const deferredHighSecPenalty = useDeferredValue(highSecPenalty);
+
   const route = useMemo(() => {
     if (!graph || waypoints.length < 2) return [];
     const pathFinder = path.nba(graph, {
       distance(fromNode, toNode, _link) {
         const destinationSecurityStatus = toNode.data.securityStatus;
-        if (destinationSecurityStatus < 0) return 1 + nullSecPenalty;
-        if (destinationSecurityStatus < 0.5) return 1 + lowSecPenalty;
-        if (destinationSecurityStatus >= 0.5) return 1 + highSecPenalty;
+        if (destinationSecurityStatus < 0) return 1 + deferredNullSecPenalty;
+        if (destinationSecurityStatus < 0.5) return 1 + deferredLowSecPenalty;
+        if (destinationSecurityStatus >= 0.5) return 1 + deferredHighSecPenalty;
         return 1;
       },
     });
     return pathFinder.find(waypoints[1]!, waypoints[0]!);
-  }, [graph, waypoints, nullSecPenalty, lowSecPenalty, highSecPenalty]);
+  }, [
+    graph,
+    waypoints,
+    deferredNullSecPenalty,
+    deferredLowSecPenalty,
+    deferredHighSecPenalty,
+  ]);
 
   const solarSystemSelectData = useMemo(() => {
     return Object.entries(solarSystems ?? {})
@@ -89,6 +105,7 @@ export default function TravelPage({
               label="Waypoint"
               data={solarSystemSelectData}
               searchable
+              limit={100}
               value={waypoints[index]}
               onChange={(value) => {
                 if (value === null) {

--- a/apps/web/tests/travelPage.test.tsx
+++ b/apps/web/tests/travelPage.test.tsx
@@ -1,0 +1,76 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// The Travel page uses next/navigation (useRouter), @jitaspace/eve-icons
+// (MapIcon) and the local RouteTable — which fetches kill data per system, so
+// it is stubbed here to render the page in isolation. ngraph (graph + NBA*
+// pathfinding) and the Mantine controls run for real.
+// ---------------------------------------------------------------------------
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@jitaspace/eve-icons", () => ({
+  MapIcon: () => <span>MapIcon</span>,
+}));
+
+jest.mock("~/components/Travel", () => ({
+  RouteTable: ({ route }: { route: { id: string }[] }) => (
+    <div data-testid="route-table">{route.length} systems</div>
+  ),
+}));
+
+// A tiny slice of New Eden spanning all three security bands (high/low/null),
+// so the pathfinder's per-band distance branches are all exercised:
+// Alpha(0.9) — Beta(0.3) — Gamma(-0.5) — Delta(0.9)
+const solarSystems = {
+  "30000001": { name: "Alpha", securityStatus: 0.9, neighbors: [30000002] },
+  "30000002": {
+    name: "Beta",
+    securityStatus: 0.3,
+    neighbors: [30000001, 30000003],
+  },
+  "30000003": {
+    name: "Gamma",
+    securityStatus: -0.5,
+    neighbors: [30000002, 30000004],
+  },
+  "30000004": { name: "Delta", securityStatus: 0.9, neighbors: [30000003] },
+};
+
+function renderPage(initialWaypoints: string[]) {
+  const Page =
+    require("~/app/travel/[[...waypoints]]/page.client").default;
+  return render(
+    <MantineProvider>
+      <Page solarSystems={solarSystems} initialWaypoints={initialWaypoints} />
+    </MantineProvider>,
+  );
+}
+
+describe("Travel Page", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
+  it("computes a route across security bands between two waypoints", () => {
+    renderPage(["30000001", "30000004"]);
+
+    expect(screen.getByText("Travel Planner")).toBeInTheDocument();
+    // Alpha → Beta → Gamma → Delta = 4 systems in the path.
+    expect(screen.getByTestId("route-table")).toHaveTextContent("4 systems");
+  });
+
+  it("produces an empty route when given fewer than two waypoints", () => {
+    renderPage(["30000001"]);
+
+    expect(screen.getByTestId("route-table")).toHaveTextContent("0 systems");
+  });
+});


### PR DESCRIPTION
## Problem

Vercel Speed Insights flags **Interaction to Next Paint** as "Needs Improvement" (256ms P75 desktop), dragged up by a cluster of data-heavy routes. `/travel/*` is the single worst offender at **~1312ms**.

Root cause on this route: the "Custom" route-preference sliders call `setNullSecPenalty`/`setLowSecPenalty`/`setHighSecPenalty` on **every `onChange` tick**, and the `route` `useMemo` depends on those values. So each pixel of slider drag re-runs `ngraph.path` NBA\* pathfinding across the **entire New Eden solar-system graph (~5.4k nodes)** synchronously on the main thread — blocking the browser from painting the interaction. The waypoint `<Select>` also feeds its dropdown ~5.4k options with no cap.

## What changed

`apps/web/app/travel/[[...waypoints]]/page.client.tsx`:

- Wrap the three penalty values feeding the pathfinder in **`useDeferredValue`**. The slider thumb and live `(123)` labels still update urgently (cheap → instant paint, which is what INP measures per interaction), while React recomputes the route as a **low-priority, interruptible transition that coalesces** rapid drags — so the expensive pathfind no longer runs per-tick or blocks the response.
- Add **`limit={100}`** to the waypoint `<Select>` so opening the dropdown doesn't push all ~5.4k systems through layout.

Plus a user-facing changeset (`@jitaspace/web` patch).

## Reviewer notes

- **No behavior change.** Same route output and same live label feedback; only the *scheduling* of the recompute changes. `useDeferredValue` is stable React (repo is on 19.2.6); `Select.limit` is valid Mantine (v9.3). The `SegmentedControl` presets still set penalties as urgent updates — deferred values catch up one render later.
- **Verification:** type-safe by inspection. I deliberately did **not** measure this on a local dev server — INP is a *field* metric aggregated over days, and `useDeferredValue`'s benefit only manifests under production React's concurrent scheduler (a StrictMode dev build can't produce a representative number). It should improve on the same Speed Insights chart a few days post-deploy.
- **Scope:** this PR fixes `/travel` only. `/lp-store/*` (MRT `enableFacetedValues` over thousands of rows) and `/mail` (non-memoized, non-virtualized table with per-row fetch hooks) share the same root-cause pattern and are good follow-ups, but are larger and left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)