### PR TITLE
fix(web): avoid ERR_PNPM_EXDEV on Vercel install (kubb v4 deploy fix)

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "name": "JitaSpace WebApp",
   "buildCommand": "(cd ../.. && pnpm db:generate && pnpm db:push) && pnpm dlx turbo run build --filter=@jitaspace/web",
-  "installCommand": "pnpm --filter !mobile install --store=node_modules/.pnpm-store",
+  "installCommand": "pnpm --filter !mobile install --package-import-method=copy",
   "env": {
     "ENABLE_EXPERIMENTAL_COREPACK": "1"
   }


### PR DESCRIPTION
## Problem

The production Vercel deploy started failing on `pnpm install` right after the kubb v4 upgrade ([#557](https://github.com/joaomlneto/jitaspace/pull/557)) merged:

```
[ERR_PNPM_EXDEV] [importPackage …/node_modules/@kubb/plugin-ts] EXDEV: cross-device link not permitted,
copyfile '…/node_modules/.pnpm-store/v11/files/…' -> '…/node_modules/@kubb/plugin-ts_tmp_90_1/src/index.ts'
Error: Command "pnpm --filter !mobile install --store=node_modules/.pnpm-store" exited with 1
```

## Root cause

Not a kubb bug — a Vercel + pnpm filesystem issue the upgrade happened to expose:

- Vercel restores the cached pnpm store on a **different device** than the fresh `node_modules`.
- The **new** v4 `@kubb/*` packages aren't in that cached store, so pnpm imports them fresh.
- pnpm's default `auto` import tries a cross-device **clone/hardlink**, which throws `EXDEV` instead of falling back to a copy — aborting the install.

CI's plain `pnpm install` didn't hit this (no separately-cached cross-device store), which is why Cypress was green.

## Fix — one flag, not two

The existing `--store=node_modules/.pnpm-store` was itself an earlier EXDEV workaround (force the store onto the same device so hardlinks work), but Vercel's cache restore puts it cross-device anyway and defeats it. Rather than **stack** another workaround on top, this **replaces** it:

```diff
- "installCommand": "pnpm --filter !mobile install --store=node_modules/.pnpm-store",
+ "installCommand": "pnpm --filter !mobile install --package-import-method=copy",
```

`--package-import-method=copy` makes pnpm copy from the store, which works across devices regardless of where the store lives — so the `--store=…` flag is no longer needed. Net result is a shorter install command with a single, correct EXDEV fix. Vercel-only; local dev and CI keep the fast default hardlink path.

## Verifying

I can't reproduce Vercel's sandbox locally, so this is research-backed, not locally-tested. The production deploy after merge is the real test. As an immediate alternative, a **Redeploy with "Clear build cache"** on the failed deploy may unblock production on its own. If `copy` alone ever proves insufficient, the fallback is to also pin the store location — but the redundant `--store` flag isn't pulling its weight today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
