### PR TITLE
fix(web): reduce CLS by reserving layout space in route loading states

### DIFF
--- a/.changeset/reduce-loading-layout-shift.md
+++ b/.changeset/reduce-loading-layout-shift.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Reduced page jumping while content loads. Item, character, market, travel, LP store and other detail pages now show a placeholder that reserves room for the incoming content instead of a small spinner, so the page no longer shifts down as it finishes loading.

--- a/apps/web/app/active-wars/page.tsx
+++ b/apps/web/app/active-wars/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import { cacheLife } from "next/cache";
 import { notFound } from "next/navigation";
-import { Container, Group, Loader, Stack, Title } from "@mantine/core";
+import { Container, Group, Stack, Title } from "@mantine/core";
 
 export const metadata = {
   title: "Active Wars",
@@ -9,6 +9,7 @@ export const metadata = {
     "Live list of active wars in EVE Online — track ongoing conflicts between corporations and alliances.",
 };
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 import { WarsIcon } from "@jitaspace/eve-icons";
 
@@ -131,7 +132,7 @@ async function ActiveWarsContent() {
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <ActiveWarsContent />
     </Suspense>
   );

--- a/apps/web/app/alliance/[allianceId]/page.tsx
+++ b/apps/web/app/alliance/[allianceId]/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
 import { getAlliancesAllianceId } from "@jitaspace/esi-client";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export async function generateMetadata({
@@ -37,7 +37,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/bloodline/[bloodlineId]/page.tsx
+++ b/apps/web/app/bloodline/[bloodlineId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/calendar/[eventId]/page.tsx
+++ b/apps/web/app/calendar/[eventId]/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export default function Page({
@@ -9,7 +9,7 @@ export default function Page({
   params: Promise<{ eventId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient params={params} />
     </Suspense>
   );

--- a/apps/web/app/category/[categoryId]/page.tsx
+++ b/apps/web/app/category/[categoryId]/page.tsx
@@ -2,8 +2,9 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
-import { Container, Group, Loader, SimpleGrid, Stack, Text, Title } from "@mantine/core";
+import { Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 import { CategoryBreadcrumbs, GroupAnchor } from "@jitaspace/ui";
 
@@ -114,7 +115,7 @@ export default function Page({
   params: Promise<{ categoryId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/character/[characterId]/page.tsx
+++ b/apps/web/app/character/[characterId]/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
 import { getCharactersCharacterId } from "@jitaspace/esi-client";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export async function generateMetadata({
@@ -37,7 +37,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/constellation/[constellationId]/page.tsx
+++ b/apps/web/app/constellation/[constellationId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/contract/[contractId]/page.tsx
+++ b/apps/web/app/contract/[contractId]/page.tsx
@@ -1,11 +1,11 @@
 import { Suspense } from "react";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/corporation/[corporationId]/page.tsx
+++ b/apps/web/app/corporation/[corporationId]/page.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
 import { getCorporationsCorporationId } from "@jitaspace/esi-client";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 function stripHtml(s: string): string {
@@ -55,7 +55,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/dogma/attribute/[attributeId]/page.tsx
+++ b/apps/web/app/dogma/attribute/[attributeId]/page.tsx
@@ -2,8 +2,8 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import type { PageProps } from "./page.client";
@@ -137,7 +137,7 @@ export default function Page({
   params: Promise<{ attributeId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/dogma/effect/[effectId]/page.tsx
+++ b/apps/web/app/dogma/effect/[effectId]/page.tsx
@@ -2,8 +2,8 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import DogmaEffectPage from "./page.client";
@@ -135,7 +135,7 @@ export default function Page({
   params: Promise<{ effectId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/faction/[factionId]/page.tsx
+++ b/apps/web/app/faction/[factionId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/group/[groupId]/page.tsx
+++ b/apps/web/app/group/[groupId]/page.tsx
@@ -2,8 +2,9 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
-import { Container, Group, Loader, SimpleGrid, Stack, Text, Title } from "@mantine/core";
+import { Container, Group, SimpleGrid, Stack, Text, Title } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 import { TypeAnchor, TypeAvatar } from "@jitaspace/ui";
 
@@ -113,7 +114,7 @@ export default function Page({
   params: Promise<{ groupId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/kill/[killId]/page.tsx
+++ b/apps/web/app/kill/[killId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export async function generateMetadata({
@@ -20,7 +20,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/lp-store/[corporationId]/page.tsx
+++ b/apps/web/app/lp-store/[corporationId]/page.tsx
@@ -2,8 +2,8 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import LPStoreCorporationPage from "./page.client";
@@ -136,7 +136,7 @@ export default function Page({
   params: Promise<{ corporationId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/mail/page.tsx
+++ b/apps/web/app/mail/page.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from "react";
-import { Loader } from "@mantine/core";
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/market/page.tsx
+++ b/apps/web/app/market/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export const metadata = {
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/planet/[planetId]/page.tsx
+++ b/apps/web/app/planet/[planetId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/race/[raceId]/page.tsx
+++ b/apps/web/app/race/[raceId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/region/[regionId]/page.tsx
+++ b/apps/web/app/region/[regionId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/star/[starId]/page.tsx
+++ b/apps/web/app/star/[starId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/station/[stationId]/page.tsx
+++ b/apps/web/app/station/[stationId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/status/page.tsx
+++ b/apps/web/app/status/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import type { SdeLastModifiedResponse, VercelStatusResponse } from "./types";
 import StatusPageClient from "./page.client";
 
@@ -42,7 +42,7 @@ async function StatusPageContent() {
 
 export default function StatusPage() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <StatusPageContent />
     </Suspense>
   );

--- a/apps/web/app/structure/[structureId]/page.tsx
+++ b/apps/web/app/structure/[structureId]/page.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from "react";
-import { Loader } from "@mantine/core";
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/system/[systemId]/page.tsx
+++ b/apps/web/app/system/[systemId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import PageClient from "./page.client";
@@ -31,7 +31,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/app/travel/[[...waypoints]]/page.tsx
+++ b/apps/web/app/travel/[[...waypoints]]/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 import { toArrayIfNot } from "@jitaspace/utils";
 
@@ -88,7 +88,7 @@ export default function Page({
   params: Promise<{ waypoints?: string[] }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/type/[typeId]/page.tsx
+++ b/apps/web/app/type/[typeId]/page.tsx
@@ -3,8 +3,8 @@ import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
 import type { Metadata } from "next";
 import { HttpStatusCode } from "axios";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 
 import TypePage from "./page.client";
@@ -115,7 +115,7 @@ export default function Page({
   params: Promise<{ typeId: string }>;
 }) {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageContent params={params} />
     </Suspense>
   );

--- a/apps/web/app/war/[warId]/page.tsx
+++ b/apps/web/app/war/[warId]/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { Loader } from "@mantine/core";
 
+import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
 
 export async function generateMetadata({
@@ -20,7 +20,7 @@ export async function generateMetadata({
 
 export default function Page() {
   return (
-    <Suspense fallback={<Loader />}>
+    <Suspense fallback={<PageSkeleton />}>
       <PageClient />
     </Suspense>
   );

--- a/apps/web/components/PageSkeleton/PageSkeleton.tsx
+++ b/apps/web/components/PageSkeleton/PageSkeleton.tsx
@@ -19,7 +19,10 @@ export interface PageSkeletonProps {
  * already-reserved layout instead of pushing the page down — keeping Cumulative
  * Layout Shift low both on first paint and on client-side navigation.
  */
-export function PageSkeleton({ size = "xl", rows = 8 }: PageSkeletonProps) {
+export function PageSkeleton({
+  size = "xl",
+  rows = 8,
+}: Readonly<PageSkeletonProps>) {
   const rowKeys = Array.from({ length: rows }, (_, i) => `page-skeleton-${i}`);
   return (
     <Container size={size} role="status" aria-label="Loading">

--- a/apps/web/components/PageSkeleton/PageSkeleton.tsx
+++ b/apps/web/components/PageSkeleton/PageSkeleton.tsx
@@ -1,0 +1,39 @@
+import type { ContainerProps } from "@mantine/core";
+import { Container, Group, Skeleton, Stack } from "@mantine/core";
+
+export interface PageSkeletonProps {
+  /**
+   * Container width, matched to the page's own `Container` so the swap to real
+   * content doesn't shift horizontally. Defaults to `"xl"` — the wide table
+   * pages (market, travel, wallet, LP store) where layout shift hurts most.
+   */
+  size?: ContainerProps["size"];
+  /** Number of placeholder content rows to render. */
+  rows?: number;
+}
+
+/**
+ * Height-reserving loading placeholder used as the `Suspense` fallback for route
+ * content. Replaces a bare `<Loader />` (a small spinner that reserves no
+ * vertical space) so that when the streamed page content arrives it drops into
+ * already-reserved layout instead of pushing the page down — keeping Cumulative
+ * Layout Shift low both on first paint and on client-side navigation.
+ */
+export function PageSkeleton({ size = "xl", rows = 8 }: PageSkeletonProps) {
+  const rowKeys = Array.from({ length: rows }, (_, i) => `page-skeleton-${i}`);
+  return (
+    <Container size={size} role="status" aria-label="Loading">
+      <Stack gap="xl" mih="70vh">
+        <Group>
+          <Skeleton height={48} width={48} radius="md" />
+          <Skeleton height={32} width={240} radius="sm" />
+        </Group>
+        <Stack gap="sm">
+          {rowKeys.map((key) => (
+            <Skeleton key={key} height={40} radius="sm" />
+          ))}
+        </Stack>
+      </Stack>
+    </Container>
+  );
+}

--- a/apps/web/components/PageSkeleton/index.ts
+++ b/apps/web/components/PageSkeleton/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageSkeleton";

--- a/apps/web/tests/pageSkeleton.test.tsx
+++ b/apps/web/tests/pageSkeleton.test.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import type { ReactElement } from "react";
+import { describe, expect, it } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+import { PageSkeleton } from "~/components/PageSkeleton";
+
+function renderWithMantine(ui: ReactElement) {
+  return render(<MantineProvider>{ui}</MantineProvider>);
+}
+
+function skeletonCount(container: HTMLElement) {
+  return container.querySelectorAll(".mantine-Skeleton-root").length;
+}
+
+describe("PageSkeleton", () => {
+  it("exposes a labelled status region for assistive tech", () => {
+    renderWithMantine(<PageSkeleton />);
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("renders the header placeholders plus eight content rows by default", () => {
+    const { container } = renderWithMantine(<PageSkeleton />);
+    // 2 header skeletons (icon + title) + 8 default content rows
+    expect(skeletonCount(container)).toBe(10);
+  });
+
+  it("renders the requested number of content rows", () => {
+    const { container } = renderWithMantine(<PageSkeleton rows={3} />);
+    // 2 header skeletons + 3 content rows
+    expect(skeletonCount(container)).toBe(5);
+  });
+
+  it("renders only the header when asked for zero rows", () => {
+    const { container } = renderWithMantine(<PageSkeleton rows={0} />);
+    expect(skeletonCount(container)).toBe(2);
+  });
+
+  it("accepts a custom container size without throwing", () => {
+    const { container } = renderWithMantine(
+      <PageSkeleton size="sm" rows={1} />,
+    );
+    expect(skeletonCount(container)).toBe(3);
+  });
+});

--- a/apps/web/tests/routeLoadingFallback.test.tsx
+++ b/apps/web/tests/routeLoadingFallback.test.tsx
@@ -1,0 +1,119 @@
+import { Suspense } from "react";
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { PageSkeleton } from "~/components/PageSkeleton";
+
+/* Loading each route's server component requires a dynamic `require` whose
+   result is `any`; the unsafe-* rules below are inherent to that pattern (the
+   same one existing page tests use). */
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call */
+
+// Every server page wraps its content in <Suspense fallback={<PageSkeleton />}>,
+// so the route reserves layout space while content streams in (replacing the old
+// bare <Loader /> spinner that caused layout shift). Invoking a page's default
+// export runs that wrapper without awaiting the async content, letting us assert
+// — across every route — that the shared loading skeleton is used.
+
+// Some route content components pull in ESM-only table libraries that Jest does
+// not transform. We only assert the Suspense fallback (not the content), so stub
+// them out to let the page modules load.
+jest.mock("mantine-react-table", () => ({
+  MantineReactTable: () => null,
+  useMantineReactTable: () => ({}),
+}));
+jest.mock("mantine-datatable", () => ({
+  DataTable: () => null,
+}));
+
+jest.mock("next/cache", () => ({
+  cacheLife: () => undefined,
+  unstable_cacheLife: () => undefined,
+}));
+jest.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NEXT_NOT_FOUND");
+  },
+  redirect: () => undefined,
+  useParams: () => ({}),
+  useRouter: () => ({}),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const ROUTES = [
+  { name: "active-wars", Page: require("~/app/active-wars/page").default },
+  {
+    name: "alliance",
+    Page: require("~/app/alliance/[allianceId]/page").default,
+  },
+  {
+    name: "bloodline",
+    Page: require("~/app/bloodline/[bloodlineId]/page").default,
+  },
+  { name: "calendar", Page: require("~/app/calendar/[eventId]/page").default },
+  {
+    name: "category",
+    Page: require("~/app/category/[categoryId]/page").default,
+  },
+  {
+    name: "character",
+    Page: require("~/app/character/[characterId]/page").default,
+  },
+  {
+    name: "constellation",
+    Page: require("~/app/constellation/[constellationId]/page").default,
+  },
+  {
+    name: "contract",
+    Page: require("~/app/contract/[contractId]/page").default,
+  },
+  {
+    name: "corporation",
+    Page: require("~/app/corporation/[corporationId]/page").default,
+  },
+  {
+    name: "dogma/attribute",
+    Page: require("~/app/dogma/attribute/[attributeId]/page").default,
+  },
+  {
+    name: "dogma/effect",
+    Page: require("~/app/dogma/effect/[effectId]/page").default,
+  },
+  { name: "faction", Page: require("~/app/faction/[factionId]/page").default },
+  { name: "group", Page: require("~/app/group/[groupId]/page").default },
+  { name: "kill", Page: require("~/app/kill/[killId]/page").default },
+  {
+    name: "lp-store",
+    Page: require("~/app/lp-store/[corporationId]/page").default,
+  },
+  { name: "mail", Page: require("~/app/mail/page").default },
+  { name: "market", Page: require("~/app/market/page").default },
+  { name: "planet", Page: require("~/app/planet/[planetId]/page").default },
+  { name: "race", Page: require("~/app/race/[raceId]/page").default },
+  { name: "region", Page: require("~/app/region/[regionId]/page").default },
+  { name: "star", Page: require("~/app/star/[starId]/page").default },
+  { name: "station", Page: require("~/app/station/[stationId]/page").default },
+  { name: "status", Page: require("~/app/status/page").default },
+  {
+    name: "structure",
+    Page: require("~/app/structure/[structureId]/page").default,
+  },
+  { name: "system", Page: require("~/app/system/[systemId]/page").default },
+  {
+    name: "travel",
+    Page: require("~/app/travel/[[...waypoints]]/page").default,
+  },
+  { name: "type", Page: require("~/app/type/[typeId]/page").default },
+  { name: "war", Page: require("~/app/war/[warId]/page").default },
+];
+
+describe("route loading fallback", () => {
+  it.each(ROUTES)(
+    "$name route wraps its content in a PageSkeleton fallback",
+    ({ Page }) => {
+      const element = Page({ params: Promise.resolve({}) });
+      expect(element.type).toBe(Suspense);
+      expect(element.props.fallback?.type).toBe(PageSkeleton);
+    },
+  );
+});

--- a/apps/web/tests/routeLoadingFallback.test.tsx
+++ b/apps/web/tests/routeLoadingFallback.test.tsx
@@ -14,16 +14,31 @@ import { PageSkeleton } from "~/components/PageSkeleton";
 // export runs that wrapper without awaiting the async content, letting us assert
 // — across every route — that the shared loading skeleton is used.
 
-// Some route content components pull in ESM-only table libraries that Jest does
-// not transform. We only assert the Suspense fallback (not the content), so stub
-// them out to let the page modules load.
-jest.mock("mantine-react-table", () => ({
-  MantineReactTable: () => null,
-  useMantineReactTable: () => ({}),
-}));
-jest.mock("mantine-datatable", () => ({
-  DataTable: () => null,
-}));
+// We only assert the Suspense fallback element — never render the page content —
+// so we stub out everything the page modules pull in that isn't available in the
+// coverage CI job (which runs install + test only, no `kubb:generate` and no
+// Prisma client). Existing page tests mock these same modules. Catch-all proxies
+// return a no-op for any named export, which is enough to let the modules load.
+jest.mock("@jitaspace/hooks", () => new Proxy({}, { get: () => () => null }));
+jest.mock("@jitaspace/ui", () => new Proxy({}, { get: () => () => null }));
+jest.mock(
+  "@jitaspace/esi-client",
+  () => new Proxy({}, { get: () => () => null }),
+);
+jest.mock(
+  "@jitaspace/sde-client",
+  () => new Proxy({}, { get: () => () => null }),
+);
+jest.mock(
+  "@jitaspace/tiptap-eve",
+  () => new Proxy({}, { get: () => () => null }),
+);
+jest.mock(
+  "mantine-react-table",
+  () => new Proxy({}, { get: () => () => null }),
+);
+jest.mock("mantine-datatable", () => new Proxy({}, { get: () => () => null }));
+jest.mock("~/lib/db", () => ({ prisma: {} }));
 
 jest.mock("next/cache", () => ({
   cacheLife: () => undefined,


### PR DESCRIPTION
## Problem

Vercel Speed Insights flagged a poor **Cumulative Layout Shift** (P75 = 0.13, "Needs Improvement"). Index pages score ~0 (`/market` = 0, `/lp-store` = 0.02) while detail pages score badly — the tell is that index pages render synchronously, whereas detail pages render a small placeholder that's then replaced by full-height content, with nothing reserving the space in between.

This PR is **fix #1 of a series**: the systemic one. Every route that wraps its content in `<Suspense fallback={<Loader />}>` shows a tiny centered spinner that reserves **no vertical space**. When the streamed (or client-navigated) content arrives, it drops in and pushes the page down — layout shift proportional to content size.

## Change

- **New `PageSkeleton` component** (`apps/web/components/PageSkeleton/`): a height-reserving loading placeholder — header (icon + title) plus content-row skeletons inside a `Container` with `mih="70vh"`, so content lands in already-reserved layout. Theme-aware (Mantine `Skeleton`), `role="status"` for a11y, optional `size`/`rows` props.
- **Swapped the fallback on 28 routes** (`apps/web/app/**/page.tsx`): `<Loader />` → `<PageSkeleton />`. Each diff is minimal (≤5 lines): drop the `Loader` import, add the `PageSkeleton` import, swap the fallback.

## Impact

Directly addresses the **streamed / client-navigation** shifts — the LP-store detail pages and other server-streamed detail routes in the "Needs Improvement" column — and stabilizes scrollbar/footer reflow app-wide. The worst "Poor"-column pages (`/market/[typeId]`, `/wallet/character`, `/travel`) have *additional* client-fetch-then-inject shifts that follow-up fixes (#2–#4) will target.

## Reviewer notes

- **No unrelated reformatting.** 25 of these 28 page files were already Prettier-dirty at `HEAD` (this repo doesn't enforce Prettier on them / it isn't CI-gated), so edits were kept minimal rather than running whole-file `prettier --write`. The 3 files that *were* clean stay clean.
- `pnpm type-check` for `@jitaspace/web` reports **zero errors in the changed files** (the only failures are pre-existing baseline issues in `packages/eve-icons` and `packages/ui`, unrelated to this change).
- Verified the skeleton renders correctly in the real app (dark theme) before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)