### PR TITLE
fix(web): refresh "Website Updated On" date on every code change

### DIFF
--- a/.changeset/website-updated-on-git-date.md
+++ b/.changeset/website-updated-on-git-date.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the "Website Updated On" date on the status page showing a stale timestamp. It now reflects the date of the deployed code change instead of being frozen by build caching.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { withSentryConfig } from "@sentry/nextjs";
 import { createJiti } from "jiti";
 
@@ -72,9 +73,33 @@ const config = {
   ],
 
   env: {
-    NEXT_PUBLIC_MODIFIED_DATE: new Date().toISOString(),
+    NEXT_PUBLIC_MODIFIED_DATE: getModifiedDate(),
   },
 };
+
+/**
+ * Timestamp surfaced as "Website Updated On" on the status page.
+ *
+ * Derived from the deployed commit's git committer date rather than
+ * `new Date()`. A wall-clock timestamp is non-deterministic, so Turborepo /
+ * Vercel build caching would restore a previously-built `.next` artifact — with
+ * its stale inlined date — on every cache hit, and `next build` (hence this
+ * file) never re-runs to refresh it. The commit date is stable per revision, so
+ * it only moves when the site's code actually changed. Falls back to wall-clock
+ * time when git isn't available (e.g. some local shells).
+ */
+function getModifiedDate() {
+  try {
+    const iso = execSync("git show -s --format=%cI HEAD", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (iso) return new Date(iso).toISOString();
+  } catch {
+    // git unavailable or not a checkout — fall back below.
+  }
+  return new Date().toISOString();
+}
 
 export default withSentryConfig(config, {
   // For all available options, see:


### PR DESCRIPTION
## Problem

The status page's **"Website Updated On"** timestamp was frozen — it no longer refreshed with deploys.

`NEXT_PUBLIC_MODIFIED_DATE` was set to `new Date().toISOString()` at build time in `apps/web/next.config.mjs`. That string is inlined into the bundle, but `new Date()` is **not part of Turborepo's build cache key** (the `build` task is keyed only on `*.ts/*.tsx/package.json/tsconfig.json`, and Vercel uses Turborepo remote cache). So any build with unchanged inputs is a **cache hit**: Vercel restores the previous `.next` artifact — including its stale inlined date — and `next build` (hence `next.config.mjs`) never re-runs to refresh it.

## Fix

Derive the value from the **deployed commit's git committer date** (`git show -s --format=%cI HEAD`) instead of wall-clock time:

- **Cache-correct** — stable per revision, so it only moves when the site's code actually changed (which busts the build cache and re-runs `next build`). A content-identical redeploy correctly keeps the same date.
- **Matches the label** — "Website Updated On" links to `/changelog`, i.e. when the site last shipped a change.
- **Safe fallback** — falls back to `new Date()` when git isn't available (e.g. some local shells).

Output stays ISO-8601 `Z`, so consumers (`status/page.client.tsx`, `sitemap.ts`) need no changes.

## Verification

Evaluating the real `next.config.mjs` confirms the value Next inlines now equals the HEAD commit date:

```
inlined NEXT_PUBLIC_MODIFIED_DATE = 2026-06-14T06:30:40.000Z
git HEAD committer date           = 2026-06-14T06:30:40.000Z
match                             = true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)