### PR TITLE
fix(web): remove dead debug blocks in ship-scanner page

### DIFF
--- a/apps/web/app/ship-scanner/page.client.tsx
+++ b/apps/web/app/ship-scanner/page.client.tsx
@@ -9,7 +9,6 @@ import {
   FocusTrap,
   Group,
   HoverCard,
-  JsonInput,
   SimpleGrid,
   Stack,
   Text,
@@ -23,7 +22,7 @@ import { IconX } from "@tabler/icons-react";
 
 import type { FittingItemFlag } from "@jitaspace/hooks";
 import { itemsFlagEnum } from "@jitaspace/esi-client";
-import { useEsiTypeIdsFromNames, useType } from "@jitaspace/hooks";
+import { useEsiTypeIdsFromNames } from "@jitaspace/hooks";
 import { EveEntitySelect, TypeAnchor, TypeAvatar } from "@jitaspace/ui";
 
 import { ShipFittingCard } from "~/components/Fitting";
@@ -182,11 +181,6 @@ function mergeAndConvertScans(scans: ScanResult[]) {
 export default function Page({ ships }: PageProps) {
   const [shipTypeId, setShipTypeId] = useState<number | undefined>();
   const [scans, setScans] = useState<ScanResult[]>([]);
-  const { data: shipData } = useType(
-    shipTypeId ?? 0,
-    {},
-    { query: { enabled: shipTypeId !== undefined } },
-  );
   const inputRef = React.useRef<HTMLTextAreaElement>(null);
 
   const _mergedScans = useMemo(() => mergeScans(scans), [scans]);
@@ -335,33 +329,6 @@ export default function Page({ ships }: PageProps) {
           </Stack>
         </SimpleGrid>
       </Stack>
-      {false && (
-        <JsonInput
-          label="IDs from Names"
-          value={JSON.stringify(xx, null, 2)}
-          readOnly
-          autosize
-          maxRows={40}
-        />
-      )}
-      {false && (
-        <JsonInput
-          label="Scans"
-          value={JSON.stringify(scans, null, 2)}
-          readOnly
-          autosize
-          maxRows={40}
-        />
-      )}
-      {false && (
-        <JsonInput
-          label="Selected Ship Data"
-          value={JSON.stringify(shipData, null, 2)}
-          readOnly
-          autosize
-          maxRows={10}
-        />
-      )}
     </Container>
   );
 }


### PR DESCRIPTION
## What

Removes three disabled debug blocks from the ship-scanner page and cleans up the code they orphaned.

## Why

SonarQube flagged three reliability bugs (`no-constant-binary-expression` — "Unexpected constant truthiness on the left-hand side of a `&&` expression") in `apps/web/app/ship-scanner/page.client.tsx` at L338, L347, and L356. Each was a `{false && (<JsonInput ... />)}` debug JSON dump that never rendered.

## Changes

- Deleted the three dead `{false && (...)}` `JsonInput` debug panels.
- Removed the now-unused `JsonInput` import.
- Removed the `useType(...)` / `shipData` hook call (its result fed only the deleted "Selected Ship Data" dump) and dropped `useType` from the `@jitaspace/hooks` import.

## Notes for reviewers

- Net effect is purely dead-code removal — the blocks were gated behind a constant `false`, so nothing user-facing changes.
- Verified `apps/web` type-check produces **no errors** in `page.client.tsx` and no unused-symbol leftovers. (The two pre-existing `implicit any` errors in the sibling `page.tsx` are baseline and untouched by this change.)
- No changeset added: `@jitaspace/web` is a private package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)