### PR TITLE
chore(web): remove SDE API dev tools from homepage and spotlight

### DIFF
--- a/.changeset/remove-development-tools-homepage.md
+++ b/.changeset/remove-development-tools-homepage.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Removed the SDE API tool from the homepage (the "Development Tools" section) and from the Spotlight search.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import type { ImageProps } from "next/image";
-import type { LinkProps } from "next/link";
-import type React from "react";
-import Image from "next/image";
 import Link from "next/link";
 import {
   Anchor,
@@ -31,29 +27,6 @@ import { DevelopmentModeAlert } from "~/components/debug";
 import { AllianceMenu, CorporationMenu } from "~/components/Menu";
 import { NewsCarousel } from "~/components/News";
 import { characterApps, universeApps } from "~/config/apps";
-
-const devApps: {
-  name: string;
-  description: string;
-  icon: (props: Partial<Omit<ImageProps, "src">>) => React.ReactElement;
-  url: LinkProps["href"];
-  onClick?: () => void;
-  tags?: string[];
-}[] = [
-  {
-    name: "An OpenAPI for the SDE",
-    description:
-      "An OpenAPI specification for the EVE Online Static Data Export, making it easy to integrate into your web applications without the need for a database.",
-    icon: ({ alt, ...otherProps }) => (
-      <Image
-        src="https://images.evetech.net/types/60753/icon?size=64"
-        alt={alt ?? "SDE OpenAPI"}
-        {...otherProps}
-      />
-    ),
-    url: "https://sde.jita.space",
-  },
-];
 
 export default function Page() {
   const theme = useMantineTheme();
@@ -240,65 +213,6 @@ export default function Page() {
                   color={theme.primaryColor}
                 />
               </Container>
-              <Group>
-                <Text
-                  fz="lg"
-                  fw={500}
-                  style={{
-                    "&::after": {
-                      content: '""',
-                      display: "block",
-                      backgroundColor: theme.primaryColor,
-                      width: rem(45),
-                      height: rem(2),
-                      marginTop: theme.spacing.sm,
-                    },
-                  }}
-                  mt="md"
-                >
-                  {feature.name}
-                </Text>
-                {feature.tags?.map((tag) => (
-                  <Badge key={tag}>{tag}</Badge>
-                ))}
-              </Group>
-              <Text fz="sm" c="dimmed" mt="sm">
-                {feature.description}
-              </Text>
-            </Card>
-          </UnstyledButton>
-        ))}
-      </SimpleGrid>
-      <Title order={3}>Development Tools</Title>
-      <SimpleGrid spacing="xl" my="xl" cols={{ base: 1, xs: 2 }}>
-        {devApps.map((feature) => (
-          <UnstyledButton
-            component={Link}
-            href={feature.url ?? ""}
-            onClick={feature.onClick}
-            key={feature.name}
-          >
-            <Card
-              shadow="md"
-              radius="md"
-              styles={{
-                root: {
-                  height: "100%",
-                  transition: "transform 0.2s",
-                  border: `${rem(1)} solid ${
-                    colorScheme === "dark"
-                      ? theme.colors.dark[5]
-                      : theme.colors.gray[1]
-                  }`,
-                  /* // FIXME Mantine v7 migration
-                  "&:hover": {
-                    transform: "scale(1.05)",
-                  },*/
-                },
-              }}
-              padding="xl"
-            >
-              <feature.icon height={64} width={64} color={theme.primaryColor} />
               <Group>
                 <Text
                   fz="lg"

--- a/apps/web/config/apps.tsx
+++ b/apps/web/config/apps.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Image from "next/image";
 
 import type { ESIScope } from "@jitaspace/esi-metadata";
 import type { EveIconProps } from "@jitaspace/eve-icons";
@@ -410,23 +409,6 @@ export const universeApps: Record<string, JitaApp> = {
                                 },*/
 };
 
-export const devApps: Record<string, JitaApp> = {
-  sde: {
-    name: "SDE REST API",
-    description:
-      "A REST API with an OpenAPI specification for EVE Online's Static Data Export.",
-    url: "https://sde.jita.space",
-    Icon: (props) =>
-      React.createElement(Image, {
-        src: "https://images.evetech.net/types/60753/icon?size=64",
-        alt: "SDE OpenAPI",
-        ...props,
-      }),
-    hotKey: ["⌘", "P"],
-    scopes: {},
-  },
-};
-
 export const extraJitaFeatures: AppScopeSet[] = [
   {
     reason: "Set in-game autopilot",
@@ -517,15 +499,5 @@ export const jitaApps: Record<
     apps: universeApps,
     name: "Universe",
     Icon: (props) => <MapIcon {...props} />,
-  },
-  developer: {
-    apps: devApps,
-    name: "Developer",
-    Icon: (props) =>
-      React.createElement(Image, {
-        src: "https://images.evetech.net/types/60753/icon?size=64",
-        alt: "SDE OpenAPI",
-        ...props,
-      }),
   },
 };


### PR DESCRIPTION
## What

The SDE API ([sde.jita.space](https://sde.jita.space)) is being sunset, so this removes its entry points from the web app:

- **Homepage** — removed the "Development Tools" section and its SDE OpenAPI card (`apps/web/app/page.tsx`), along with the local `devApps` array.
- **Spotlight search** — removed the `devApps` export and the "Developer" group from `jitaApps` (`apps/web/config/apps.tsx`); since Spotlight iterates `jitaApps`, the SDE entry no longer appears in search.
- Dropped now-unused imports (`next/image` and related types) from both files.

## Why

The SDE API is scheduled to be sunset, so we're removing the links that point users to it.

## Kept intentionally

- The status page's **"SDE API Updated On"** row (`apps/web/app/status/page.client.tsx`) is left in place — it's monitoring tied to the API lifecycle, not a homepage entry point.

## Notes for reviewers

- Net change is a deletion (114 lines removed, 5 added — the changeset).
- The Spotlight unit test (`apps/web/tests/mainSpotlight.test.tsx`) mocks `~/config/apps` with its own inline data (no developer group), so no test changes were needed.
- Includes a `@jitaspace/web` patch changeset with an end-user-readable note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)