### PR TITLE
fix(web): correct LP Store "All offers" ISK/LP pricing and sorting

### DIFF
--- a/.changeset/chunk-fuzzwork-aggregate-requests.md
+++ b/.changeset/chunk-fuzzwork-aggregate-requests.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/hooks": patch
+---
+
+`useFuzzworkRegionalMarketAggregates` now splits the type IDs across multiple requests (chunks of 500) and merges the results. Fuzzwork serves aggregates via a GET with the type IDs in the query string and returns HTTP 414 (URI Too Long) once the list grows past ~1000 IDs, which previously caused large requests (e.g. the "all LP offers" page) to return no market data at all.

--- a/.changeset/fix-lp-store-all-isk-per-lp.md
+++ b/.changeset/fix-lp-store-all-isk-per-lp.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the LP Store "All offers" page (`/lp-store/all`) showing incorrect ISK/LP values and ranking. Market prices for each offer's reward item were not being loaded on that page, so sorting by "Jita 5% Buy/Sell ISK/LP" produced wrong results that didn't match the individual corporation pages — the highest ISK/LP offers were no longer at the top. Offers that cost no loyalty points no longer display "Infinity ISK/LP".

--- a/apps/web/app/lp-store/all/collectTypeIds.ts
+++ b/apps/web/app/lp-store/all/collectTypeIds.ts
@@ -1,0 +1,19 @@
+/**
+ * Collect the distinct type IDs that need market prices for a set of LP store
+ * offers: both the reward items (`offer.typeId`) and the required items.
+ *
+ * The reward items were previously omitted on the "all offers" page, so the
+ * table couldn't price them and its ISK/LP ranking didn't match the
+ * per-corporation pages (issue #455).
+ */
+export function collectLpStoreOfferTypeIds(
+  offers: { typeId: number }[],
+  requiredItems: { typeId: number }[],
+): number[] {
+  return [
+    ...new Set([
+      ...offers.map((offer) => offer.typeId),
+      ...requiredItems.map((item) => item.typeId),
+    ]),
+  ];
+}

--- a/apps/web/app/lp-store/all/page.tsx
+++ b/apps/web/app/lp-store/all/page.tsx
@@ -1,15 +1,15 @@
-import { notFound } from "next/navigation";
 import { cacheLife } from "next/cache";
+import { notFound } from "next/navigation";
 
+import type { LPStoreAllPageProps } from "./page.client";
 import { prisma } from "~/lib/db";
+import LPStoreAllPage from "./page.client";
 
 export const metadata = {
   title: "All LP Store Offers",
-  description: "Browse all Loyalty Point store offers from every NPC corporation in EVE Online.",
+  description:
+    "Browse all Loyalty Point store offers from every NPC corporation in EVE Online.",
 };
-
-import LPStoreAllPage from "./page.client";
-import type { LPStoreAllPageProps } from "./page.client";
 
 export default async function Page() {
   "use cache";
@@ -66,7 +66,12 @@ export default async function Page() {
       lpCost: Number(offer.lpCost),
     }));
 
-    const typeIds = [...new Set(requiredItems.map((item) => item.typeId))];
+    const typeIds = [
+      ...new Set([
+        ...offersWithoutRequiredItems.map((offer) => offer.typeId),
+        ...requiredItems.map((item) => item.typeId),
+      ]),
+    ];
 
     types = await prisma.type.findMany({
       select: {

--- a/apps/web/app/lp-store/all/page.tsx
+++ b/apps/web/app/lp-store/all/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 
 import type { LPStoreAllPageProps } from "./page.client";
 import { prisma } from "~/lib/db";
+import { collectLpStoreOfferTypeIds } from "./collectTypeIds";
 import LPStoreAllPage from "./page.client";
 
 export const metadata = {
@@ -66,12 +67,10 @@ export default async function Page() {
       lpCost: Number(offer.lpCost),
     }));
 
-    const typeIds = [
-      ...new Set([
-        ...offersWithoutRequiredItems.map((offer) => offer.typeId),
-        ...requiredItems.map((item) => item.typeId),
-      ]),
-    ];
+    const typeIds = collectLpStoreOfferTypeIds(
+      offersWithoutRequiredItems,
+      requiredItems,
+    );
 
     types = await prisma.type.findMany({
       select: {

--- a/apps/web/components/LPStore/LoyaltyPointsTable.tsx
+++ b/apps/web/components/LPStore/LoyaltyPointsTable.tsx
@@ -3,6 +3,7 @@
 import { memo, useMemo } from "react";
 import { Group, Stack, Text, Tooltip } from "@mantine/core";
 
+import type { DataTableColumn } from "@jitaspace/datatable";
 import type { FuzzworkTypeMarketAggregate } from "@jitaspace/hooks";
 import { useFuzzworkRegionalMarketAggregates } from "@jitaspace/hooks";
 import {
@@ -14,7 +15,6 @@ import {
   TypeAvatar,
   TypeName,
 } from "@jitaspace/ui";
-import type { DataTableColumn } from "@jitaspace/datatable";
 
 import { DataTable } from "~/components/DataTable";
 import { usePreferencesStore } from "~/lib/preferences";
@@ -395,10 +395,12 @@ const LoyaltyPointsTableExperimental = memo(
           id: "jita5psellisklp",
           header: "Jita 5% Sell ISK/LP",
           accessor: (row) =>
-            ((row.marketStats?.sell.percentile ?? 0) -
-              (row.iskCost ?? 0) -
-              requiredItemsSellCost(row)) /
-            row.lpCost,
+            row.lpCost > 0
+              ? ((row.marketStats?.sell.percentile ?? 0) -
+                  (row.iskCost ?? 0) -
+                  requiredItemsSellCost(row)) /
+                row.lpCost
+              : undefined,
           sortable: true,
           align: "right",
           cell: iskPerLpCell,
@@ -443,10 +445,12 @@ const LoyaltyPointsTableExperimental = memo(
           id: "jita5pbuyisklp",
           header: "Jita 5% Buy ISK/LP",
           accessor: (row) =>
-            ((row.marketStats?.buy.percentile ?? 0) -
-              (row.iskCost ?? 0) -
-              requiredItemsBuyCost(row)) /
-            row.lpCost,
+            row.lpCost > 0
+              ? ((row.marketStats?.buy.percentile ?? 0) -
+                  (row.iskCost ?? 0) -
+                  requiredItemsBuyCost(row)) /
+                row.lpCost
+              : undefined,
           sortable: true,
           align: "right",
           cell: iskPerLpCell,

--- a/apps/web/components/LPStore/LoyaltyPointsTableClassic.tsx
+++ b/apps/web/components/LPStore/LoyaltyPointsTableClassic.tsx
@@ -505,16 +505,18 @@ export const LoyaltyPointsTableClassic = memo(
           header: "Jita 5% Sell ISK/LP",
           size: 10,
           accessorFn: (row) =>
-            ((row.marketStats?.sell.percentile ?? 0) -
-              (row.iskCost ?? 0) -
-              row.requiredItems
-                .map(
-                  (item) =>
-                    (item.marketStats?.sell.percentile ?? 0) *
-                    (item.quantity ?? 1),
-                )
-                .reduce((a, b) => a + b, 0)) /
-            row.lpCost,
+            row.lpCost > 0
+              ? ((row.marketStats?.sell.percentile ?? 0) -
+                  (row.iskCost ?? 0) -
+                  row.requiredItems
+                    .map(
+                      (item) =>
+                        (item.marketStats?.sell.percentile ?? 0) *
+                        (item.quantity ?? 1),
+                    )
+                    .reduce((a, b) => a + b, 0)) /
+                row.lpCost
+              : undefined,
           Cell: iskPerLpValueCell,
         },
         {
@@ -566,16 +568,18 @@ export const LoyaltyPointsTableClassic = memo(
           header: "Jita 5% Buy ISK/LP",
           size: 10,
           accessorFn: (row) =>
-            ((row.marketStats?.buy.percentile ?? 0) -
-              (row.iskCost ?? 0) -
-              row.requiredItems
-                .map(
-                  (item) =>
-                    (item.marketStats?.buy.percentile ?? 0) *
-                    (item.quantity ?? 1),
-                )
-                .reduce((a, b) => a + b, 0)) /
-            row.lpCost,
+            row.lpCost > 0
+              ? ((row.marketStats?.buy.percentile ?? 0) -
+                  (row.iskCost ?? 0) -
+                  row.requiredItems
+                    .map(
+                      (item) =>
+                        (item.marketStats?.buy.percentile ?? 0) *
+                        (item.quantity ?? 1),
+                    )
+                    .reduce((a, b) => a + b, 0)) /
+                row.lpCost
+              : undefined,
           Cell: iskPerLpValueCell,
         },
         {

--- a/apps/web/tests/LoyaltyPointsTable.test.tsx
+++ b/apps/web/tests/LoyaltyPointsTable.test.tsx
@@ -5,14 +5,10 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { MantineProvider } from "@mantine/core";
 import { render, screen } from "@testing-library/react";
 
-// @jitaspace/hooks is redirected to __mocks__/@jitaspace/hooks.ts via
-// moduleNameMapper — import the stub's jest.fn() directly so tests can
-// configure return values without needing their own jest.mock() calls.
-import {
-  useFuzzworkRegionalMarketAggregates,
-  type FuzzworkTypeMarketAggregate,
-} from "@jitaspace/hooks";
+import type { FuzzworkTypeMarketAggregate } from "@jitaspace/hooks";
+import { useFuzzworkRegionalMarketAggregates } from "@jitaspace/hooks";
 
+import { usePreferencesStore } from "~/lib/preferences";
 // @jitaspace/ui is redirected to __mocks__/@jitaspace/ui.tsx via moduleNameMapper
 // (same reason as hooks — real source pulls in @tabler/icons-react ESM bundles).
 
@@ -21,7 +17,10 @@ import {
 // @jitaspace/datatable is loaded via moduleNameMapper → real source → SWC
 // ---------------------------------------------------------------------------
 import { LoyaltyPointsTable } from "../components/LPStore/LoyaltyPointsTable";
-import { usePreferencesStore } from "~/lib/preferences";
+
+// @jitaspace/hooks is redirected to __mocks__/@jitaspace/hooks.ts via
+// moduleNameMapper — import the stub's jest.fn() directly so tests can
+// configure return values without needing their own jest.mock() calls.
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -369,4 +368,48 @@ describe("LoyaltyPointsTable — classic engine (experimental off)", () => {
     // The per-table engine selector only appears in the experimental version.
     expect(screen.queryByText("Table engine")).not.toBeInTheDocument();
   });
+});
+
+describe("LoyaltyPointsTable — zero-LP offers (divide-by-zero guard)", () => {
+  const zeroLpOffer = {
+    offerId: 9001,
+    corporationId: 1,
+    typeId: 100,
+    quantity: 1,
+    akCost: null,
+    lpCost: 0,
+    iskCost: 0,
+    requiredItems: [],
+  };
+
+  beforeEach(() => {
+    (useFuzzworkRegionalMarketAggregates as jest.Mock).mockReturnValue({
+      data: { 100: MARKET_STATS, 200: MARKET_STATS },
+    });
+  });
+
+  it.each([
+    ["experimental", true],
+    ["classic", false],
+  ])(
+    "renders a blank ISK/LP (never Infinity) for a 0 LP cost offer — %s engine",
+    (_label, experimental) => {
+      usePreferencesStore.setState({
+        experimentalDataTables: experimental as boolean,
+      });
+      wrap(
+        React.createElement(LoyaltyPointsTable, {
+          corporations: singleCorp,
+          types,
+          offers: [zeroLpOffer],
+        }),
+      );
+      // The row rendered (LP Cost cell shows "0 LP") ...
+      expect(screen.getByText("0 LP")).toBeInTheDocument();
+      // ... but the lpCost > 0 guard yields a blank ISK/LP cell, never the
+      // Infinity / NaN that an unguarded divide-by-zero would produce.
+      expect(screen.queryByText(/Infinity/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+    },
+  );
 });

--- a/apps/web/tests/collectTypeIds.test.ts
+++ b/apps/web/tests/collectTypeIds.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { collectLpStoreOfferTypeIds } from "~/app/lp-store/all/collectTypeIds";
+
+describe("collectLpStoreOfferTypeIds", () => {
+  it("includes both reward item and required item type ids", () => {
+    const result = collectLpStoreOfferTypeIds(
+      [{ typeId: 100 }, { typeId: 200 }],
+      [{ typeId: 34 }, { typeId: 35 }],
+    );
+    expect([...result].sort((a, b) => a - b)).toEqual([34, 35, 100, 200]);
+  });
+
+  it("de-duplicates ids shared between reward and required items", () => {
+    const result = collectLpStoreOfferTypeIds(
+      [{ typeId: 100 }, { typeId: 100 }],
+      [{ typeId: 100 }, { typeId: 200 }],
+    );
+    expect([...result].sort((a, b) => a - b)).toEqual([100, 200]);
+  });
+
+  it("returns an empty array when there are no offers", () => {
+    expect(collectLpStoreOfferTypeIds([], [])).toEqual([]);
+  });
+});

--- a/packages/hooks/jest.config.ts
+++ b/packages/hooks/jest.config.ts
@@ -1,0 +1,40 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  testEnvironment: "jsdom",
+  testMatch: ["<rootDir>/tests/**/*.test.tsx", "<rootDir>/tests/**/*.test.ts"],
+  transform: {
+    "^.+\\.tsx?$": [
+      "@swc/jest",
+      {
+        jsc: {
+          target: "es2022",
+          parser: {
+            syntax: "typescript",
+            tsx: true,
+          },
+          transform: {
+            react: {
+              runtime: "automatic",
+            },
+          },
+        },
+        module: {
+          type: "commonjs",
+        },
+      },
+    ],
+  },
+  // Transform ESM packages that need to be compiled
+  transformIgnorePatterns: [
+    "/node_modules/(?!(@mantine|@tabler|@jitaspace|@tiptap))",
+  ],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  collectCoverage: true,
+  coverageDirectory: "coverage",
+  coverageReporters: ["lcov", "text"],
+  clearMocks: true,
+  restoreMocks: true,
+};
+
+export default config;

--- a/packages/hooks/jest.setup.ts
+++ b/packages/hooks/jest.setup.ts
@@ -1,0 +1,5 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { TextDecoder, TextEncoder } from "util";
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "prepublishOnly": "pnpm build",
+    "test": "jest",
     "type-check": "tsc --jsx react-jsx --noEmit"
   },
   "dependencies": {
@@ -45,12 +46,20 @@
     "react-dom": "^19.2.6"
   },
   "devDependencies": {
+    "@jest/globals": "^30.4.1",
     "@jitaspace/eslint-config": "workspace:*",
     "@jitaspace/prettier-config": "workspace:*",
     "@jitaspace/tsconfig": "workspace:*",
+    "@swc/core": "^1.15.40",
+    "@swc/jest": "^0.2.39",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/jest": "^30.0.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.1.6",
     "eslint": "^9.39.4",
+    "jest": "^30.4.2",
+    "jest-environment-jsdom": "^30.4.1",
     "prettier": "^3.8.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/packages/hooks/src/hooks/market/fuzzworkAggregates.ts
+++ b/packages/hooks/src/hooks/market/fuzzworkAggregates.ts
@@ -1,0 +1,68 @@
+import type { GetAggregatesQueryResponse } from "@jitaspace/fuzzworks-market-client";
+
+export type FuzzworkMarketAggregateStats = {
+  weightedAverage: number;
+  max: number;
+  stddev: number;
+  median: number;
+  volume: number;
+  orderCount: number;
+  percentile: number;
+};
+
+export type FuzzworkTypeMarketAggregate = {
+  buy: FuzzworkMarketAggregateStats;
+  sell: FuzzworkMarketAggregateStats;
+};
+
+// Fuzzwork serves aggregates over a GET with the type IDs in the query string.
+// The endpoint returns HTTP 414 (URI Too Long) once the URL grows past ~8KB
+// (roughly 1000+ type IDs), so requests covering many types — e.g. the "all LP
+// offers" page — must be split into chunks and merged. 500 keeps each URL well
+// under the limit with comfortable margin for longer type IDs.
+export const FUZZWORK_TYPES_PER_REQUEST = 500;
+
+/** Split a list of type IDs into request-sized chunks. */
+export function chunkTypeIds(
+  typeIds: number[],
+  size: number = FUZZWORK_TYPES_PER_REQUEST,
+): number[][] {
+  const chunks: number[][] = [];
+  for (let i = 0; i < typeIds.length; i += size) {
+    chunks.push(typeIds.slice(i, i + size));
+  }
+  return chunks;
+}
+
+// Fuzzwork returns every number as a string; the raw per-side stats mirror
+// FuzzworkMarketAggregateStats with string values.
+type RawAggregateStats = Record<keyof FuzzworkMarketAggregateStats, string>;
+
+function parseStats(stats: RawAggregateStats): FuzzworkMarketAggregateStats {
+  return {
+    max: Number(stats.max),
+    median: Number(stats.median),
+    orderCount: Number(stats.orderCount),
+    percentile: Number(stats.percentile),
+    stddev: Number(stats.stddev),
+    volume: Number(stats.volume),
+    weightedAverage: Number(stats.weightedAverage),
+  };
+}
+
+/**
+ * Convert a (merged) Fuzzwork aggregates response — keyed by type ID, with all
+ * numbers as strings — into a map of typed numeric aggregates.
+ */
+export function parseFuzzworkAggregates(
+  response: GetAggregatesQueryResponse,
+): Record<string, FuzzworkTypeMarketAggregate> {
+  const result: Record<string, FuzzworkTypeMarketAggregate> = {};
+  for (const [typeId, stat] of Object.entries(response)) {
+    result[typeId] = {
+      buy: parseStats(stat.buy as RawAggregateStats),
+      sell: parseStats(stat.sell as RawAggregateStats),
+    };
+  }
+  return result;
+}

--- a/packages/hooks/src/hooks/market/useFuzzworkRegionalMarketAggregates.ts
+++ b/packages/hooks/src/hooks/market/useFuzzworkRegionalMarketAggregates.ts
@@ -6,27 +6,12 @@ import { useQuery } from "@tanstack/react-query";
 import type { GetAggregatesQueryResponse } from "@jitaspace/fuzzworks-market-client";
 import { getAggregates } from "@jitaspace/fuzzworks-market-client";
 
-export type FuzzworkMarketAggregateStats = {
-  weightedAverage: number;
-  max: number;
-  stddev: number;
-  median: number;
-  volume: number;
-  orderCount: number;
-  percentile: number;
-};
+import { chunkTypeIds, parseFuzzworkAggregates } from "./fuzzworkAggregates";
 
-export type FuzzworkTypeMarketAggregate = {
-  buy: FuzzworkMarketAggregateStats;
-  sell: FuzzworkMarketAggregateStats;
-};
-
-// Fuzzwork serves aggregates over a GET with the type IDs in the query string.
-// The endpoint returns HTTP 414 (URI Too Long) once the URL grows past ~8KB
-// (roughly 1000+ type IDs), so requests covering many types — e.g. the "all LP
-// offers" page — must be split into chunks and merged. 500 keeps each URL well
-// under the limit with comfortable margin for longer type IDs.
-const FUZZWORK_TYPES_PER_REQUEST = 500;
+export type {
+  FuzzworkMarketAggregateStats,
+  FuzzworkTypeMarketAggregate,
+} from "./fuzzworkAggregates";
 
 export const useFuzzworkRegionalMarketAggregates = (
   typeIds: number[],
@@ -47,17 +32,8 @@ export const useFuzzworkRegionalMarketAggregates = (
     // max every 5 minutes
     refetchInterval: 5 * 60 * 1000,
     queryFn: async () => {
-      const chunks: number[][] = [];
-      for (
-        let i = 0;
-        i < sortedTypeIds.length;
-        i += FUZZWORK_TYPES_PER_REQUEST
-      ) {
-        chunks.push(sortedTypeIds.slice(i, i + FUZZWORK_TYPES_PER_REQUEST));
-      }
-
       const responses = await Promise.all(
-        chunks.map((chunk) =>
+        chunkTypeIds(sortedTypeIds).map((chunk) =>
           getAggregates({
             // FIXME: Generator wont support specifying array of integers for a query parameter.
             //        As a workaround, we set it as a string and convert it here instead.
@@ -74,34 +50,11 @@ export const useFuzzworkRegionalMarketAggregates = (
     },
   });
 
-  // Fuzzworks returns all the numbers as strings... we just convert it here to numbers
-  const data = useMemo(() => {
-    if (!query.data) return null;
-    const result: Record<string, FuzzworkTypeMarketAggregate> = {};
-    Object.entries(query.data).forEach(([typeId, stat]) => {
-      result[typeId] = {
-        buy: {
-          max: Number(stat.buy.max),
-          median: Number(stat.buy.median),
-          orderCount: Number(stat.buy.orderCount),
-          percentile: Number(stat.buy.percentile),
-          stddev: Number(stat.buy.stddev),
-          volume: Number(stat.buy.volume),
-          weightedAverage: Number(stat.buy.weightedAverage),
-        },
-        sell: {
-          max: Number(stat.sell.max),
-          median: Number(stat.sell.median),
-          orderCount: Number(stat.sell.orderCount),
-          percentile: Number(stat.sell.percentile),
-          stddev: Number(stat.sell.stddev),
-          volume: Number(stat.sell.volume),
-          weightedAverage: Number(stat.sell.weightedAverage),
-        },
-      };
-    });
-    return result;
-  }, [query.data]);
+  // Fuzzworks returns all the numbers as strings... we convert them to numbers here.
+  const data = useMemo(
+    () => (query.data ? parseFuzzworkAggregates(query.data) : null),
+    [query.data],
+  );
 
   return {
     ...query,

--- a/packages/hooks/src/hooks/market/useFuzzworkRegionalMarketAggregates.ts
+++ b/packages/hooks/src/hooks/market/useFuzzworkRegionalMarketAggregates.ts
@@ -1,8 +1,10 @@
 "use client";
 
 import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 
-import { useGetAggregates } from "@jitaspace/fuzzworks-market-client";
+import type { GetAggregatesQueryResponse } from "@jitaspace/fuzzworks-market-client";
+import { getAggregates } from "@jitaspace/fuzzworks-market-client";
 
 export type FuzzworkMarketAggregateStats = {
   weightedAverage: number;
@@ -19,6 +21,13 @@ export type FuzzworkTypeMarketAggregate = {
   sell: FuzzworkMarketAggregateStats;
 };
 
+// Fuzzwork serves aggregates over a GET with the type IDs in the query string.
+// The endpoint returns HTTP 414 (URI Too Long) once the URL grows past ~8KB
+// (roughly 1000+ type IDs), so requests covering many types — e.g. the "all LP
+// offers" page — must be split into chunks and merged. 500 keeps each URL well
+// under the limit with comfortable margin for longer type IDs.
+const FUZZWORK_TYPES_PER_REQUEST = 500;
+
 export const useFuzzworkRegionalMarketAggregates = (
   typeIds: number[],
   regionId: number,
@@ -27,26 +36,49 @@ export const useFuzzworkRegionalMarketAggregates = (
     () => typeIds.toSorted((a, b) => a - b),
     [typeIds],
   );
-  const query = useGetAggregates(
-    {
-      // FIXME: Generator wont support specifying array of integers for a query parameter.
-      //        As a workaround, we set it as a string and convert it here instead.
-      types: sortedTypeIds.join(","),
-      region: regionId,
+
+  const query = useQuery({
+    queryKey: [
+      "fuzzwork-regional-market-aggregates",
+      regionId,
+      sortedTypeIds,
+    ] as const,
+    enabled: sortedTypeIds.length > 0,
+    // max every 5 minutes
+    refetchInterval: 5 * 60 * 1000,
+    queryFn: async () => {
+      const chunks: number[][] = [];
+      for (
+        let i = 0;
+        i < sortedTypeIds.length;
+        i += FUZZWORK_TYPES_PER_REQUEST
+      ) {
+        chunks.push(sortedTypeIds.slice(i, i + FUZZWORK_TYPES_PER_REQUEST));
+      }
+
+      const responses = await Promise.all(
+        chunks.map((chunk) =>
+          getAggregates({
+            // FIXME: Generator wont support specifying array of integers for a query parameter.
+            //        As a workaround, we set it as a string and convert it here instead.
+            types: chunk.join(","),
+            region: regionId,
+          }),
+        ),
+      );
+
+      return responses.reduce<GetAggregatesQueryResponse>(
+        (acc, res) => Object.assign(acc, res.data),
+        {},
+      );
     },
-    {
-      query: {
-        // max every 5 minutes
-        refetchInterval: 5 * 60 * 1000,
-      },
-    },
-  );
+  });
 
   // Fuzzworks returns all the numbers as strings... we just convert it here to numbers
   const data = useMemo(() => {
-    if (!query.data?.data) return null;
+    if (!query.data) return null;
     const result: Record<string, FuzzworkTypeMarketAggregate> = {};
-    Object.entries(query.data.data).forEach(([typeId, stat]) => {
+    Object.entries(query.data).forEach(([typeId, stat]) => {
       result[typeId] = {
         buy: {
           max: Number(stat.buy.max),
@@ -69,7 +101,7 @@ export const useFuzzworkRegionalMarketAggregates = (
       };
     });
     return result;
-  }, [query.data?.data]);
+  }, [query.data]);
 
   return {
     ...query,

--- a/packages/hooks/tests/fuzzworkAggregates.test.ts
+++ b/packages/hooks/tests/fuzzworkAggregates.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { GetAggregatesQueryResponse } from "@jitaspace/fuzzworks-market-client";
+
+import {
+  chunkTypeIds,
+  FUZZWORK_TYPES_PER_REQUEST,
+  parseFuzzworkAggregates,
+} from "../src/hooks/market/fuzzworkAggregates";
+
+describe("chunkTypeIds", () => {
+  it("returns no chunks for an empty list", () => {
+    expect(chunkTypeIds([])).toEqual([]);
+  });
+
+  it("returns a single chunk when under the limit", () => {
+    const ids = Array.from({ length: 250 }, (_, i) => i);
+    const chunks = chunkTypeIds(ids);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual(ids);
+  });
+
+  it("returns a single chunk at exactly the limit", () => {
+    const ids = Array.from({ length: FUZZWORK_TYPES_PER_REQUEST }, (_, i) => i);
+    expect(chunkTypeIds(ids)).toHaveLength(1);
+  });
+
+  it("splits past the limit into evenly-sized chunks plus a remainder", () => {
+    const ids = Array.from({ length: 1100 }, (_, i) => i);
+    const chunks = chunkTypeIds(ids);
+    expect(chunks.map((c) => c.length)).toEqual([500, 500, 100]);
+    // every id is preserved exactly once, in order
+    expect(chunks.flat()).toEqual(ids);
+  });
+
+  it("honours a custom chunk size", () => {
+    expect(chunkTypeIds([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+});
+
+describe("parseFuzzworkAggregates", () => {
+  it("returns an empty map for an empty response", () => {
+    expect(parseFuzzworkAggregates({})).toEqual({});
+  });
+
+  it("converts Fuzzwork's string numbers into typed numeric aggregates", () => {
+    const raw = {
+      "34": {
+        buy: {
+          weightedAverage: "5.5",
+          max: "6",
+          stddev: "0.5",
+          median: "5",
+          volume: "1000",
+          orderCount: "10",
+          percentile: "5.95",
+        },
+        sell: {
+          weightedAverage: "7.5",
+          max: "8",
+          stddev: "0.6",
+          median: "7",
+          volume: "2000",
+          orderCount: "20",
+          percentile: "7.05",
+        },
+      },
+    } as unknown as GetAggregatesQueryResponse;
+
+    const parsed = parseFuzzworkAggregates(raw);
+
+    expect(parsed["34"]).toEqual({
+      buy: {
+        weightedAverage: 5.5,
+        max: 6,
+        stddev: 0.5,
+        median: 5,
+        volume: 1000,
+        orderCount: 10,
+        percentile: 5.95,
+      },
+      sell: {
+        weightedAverage: 7.5,
+        max: 8,
+        stddev: 0.6,
+        median: 7,
+        volume: 2000,
+        orderCount: 20,
+        percentile: 7.05,
+      },
+    });
+    expect(typeof parsed["34"]!.buy.percentile).toBe("number");
+  });
+});

--- a/packages/hooks/tests/useFuzzworkRegionalMarketAggregates.test.tsx
+++ b/packages/hooks/tests/useFuzzworkRegionalMarketAggregates.test.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// Replace the generated Fuzzwork client so the hook never makes a real request
+// (and the real axios client is never loaded). @swc/jest does not hoist
+// jest.mock above imports, so the module under test is required lazily below,
+// after the mock is registered.
+jest.mock("@jitaspace/fuzzworks-market-client", () => ({
+  __esModule: true,
+  getAggregates: jest.fn(),
+}));
+
+const { getAggregates: mockGetAggregates } =
+  require("@jitaspace/fuzzworks-market-client") as {
+    getAggregates: jest.MockedFunction<
+      (params: { types: string; region: number }) => Promise<{ data: unknown }>
+    >;
+  };
+
+const { useFuzzworkRegionalMarketAggregates } =
+  require("../src/hooks/market/useFuzzworkRegionalMarketAggregates") as typeof import("../src/hooks/market/useFuzzworkRegionalMarketAggregates");
+
+const REGION = 10000002;
+
+function rawStat(seed: number) {
+  const s = String(seed);
+  return {
+    weightedAverage: s,
+    max: s,
+    stddev: s,
+    median: s,
+    volume: s,
+    orderCount: s,
+    percentile: s,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useFuzzworkRegionalMarketAggregates", () => {
+  beforeEach(() => {
+    mockGetAggregates.mockImplementation((params) => {
+      const data: Record<string, unknown> = {};
+      for (const id of params.types.split(",")) {
+        data[id] = { buy: rawStat(Number(id)), sell: rawStat(Number(id)) };
+      }
+      return Promise.resolve({ data });
+    });
+  });
+
+  it("splits a large type list into 500-sized chunked requests and merges them", async () => {
+    const typeIds = Array.from({ length: 1100 }, (_, i) => 1000 + i);
+
+    const { result } = renderHook(
+      () => useFuzzworkRegionalMarketAggregates(typeIds, REGION),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // 1100 ids -> chunks of 500, 500, 100
+    expect(mockGetAggregates).toHaveBeenCalledTimes(3);
+    const callSizes = mockGetAggregates.mock.calls.map(
+      ([p]) => p.types.split(",").length,
+    );
+    expect(callSizes).toEqual([500, 500, 100]);
+    // region is forwarded
+    expect(mockGetAggregates.mock.calls[0]![0].region).toBe(REGION);
+
+    // merged + parsed: every id present, numbers (not strings)
+    expect(Object.keys(result.current.data ?? {})).toHaveLength(1100);
+    expect(result.current.data?.["1000"]?.buy.percentile).toBe(1000);
+    expect(typeof result.current.data?.["2099"]?.sell.volume).toBe("number");
+  });
+
+  it("is disabled and fetches nothing when there are no type ids", () => {
+    const { result } = renderHook(
+      () => useFuzzworkRegionalMarketAggregates([], REGION),
+      { wrapper: createWrapper() },
+    );
+
+    expect(mockGetAggregates).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1430,6 +1430,9 @@ importers:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.15)(immer@11.1.4)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@jest/globals':
+        specifier: ^30.4.1
+        version: 30.4.1
       '@jitaspace/eslint-config':
         specifier: workspace:*
         version: link:../../tooling/eslint
@@ -1439,6 +1442,21 @@ importers:
       '@jitaspace/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@swc/core':
+        specifier: ^1.15.40
+        version: 1.15.40
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.40)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/jest':
+        specifier: ^30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1448,6 +1466,12 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
+      jest:
+        specifier: ^30.4.2
+        version: 30.4.2(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.9.3))
+      jest-environment-jsdom:
+        specifier: ^30.4.1
+        version: 30.4.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -52,6 +52,7 @@ sonar.javascript.lcov.reportPaths=\
   packages/esi-metadata/coverage/lcov.info,\
   packages/eve-data/coverage/lcov.info,\
   packages/eve-scrape/coverage/lcov.info,\
+  packages/hooks/coverage/lcov.info,\
   packages/datatable-tanstack/coverage/lcov.info,\
   packages/datatable-mantine/coverage/lcov.info,\
   packages/sde-utils/coverage/lcov.info,\


### PR DESCRIPTION
Fixes #455

## Problem

On `/lp-store/all`, sorting by **Jita 5% Buy ISK/LP** put a ~1536 ISK/LP item on top, while a single corporation page (e.g. Thukker Mix) showed offers worth ~3123 ISK/LP. Since each corp store is *included* in "all", the global maximum was obviously wrong — an internal inconsistency, not stale market data (which is why it persisted after Fuzzwork's data refreshed).

## Root cause

Both pages render the same table, which fetches Jita prices only for the `types` it is handed. The two pages built that list differently:

- **Per-corp page** included **reward + required** item type IDs ✅
- **`/all` page** included **required items only** ❌ (`apps/web/app/lp-store/all/page.tsx`)

With reward items unpriced on `/all`, the accessor `((reward 5% buy) − iskCost − requiredCost) / lpCost` collapsed to `(0 − costs)/lp ≤ 0` for almost every offer. Only offers whose reward item *happened* to also be a required item elsewhere got a real price, so the sort surfaced those few "accidentally priced" items instead of the genuinely best offers.

## Fix

1. **Include reward item type IDs** in the `/all` price lookup, mirroring the per-corp page.
2. **Chunk the Fuzzwork request.** Pricing reward + required items across every corp exceeds Fuzzwork's URL limit — the single GET returns **HTTP 414** past ~1000 type IDs and yields *no* prices, which would make `/all` worse. `useFuzzworkRegionalMarketAggregates` now requests in chunks of 500 and merges (`packages/hooks/src/hooks/market/useFuzzworkRegionalMarketAggregates.ts`).
3. **Guard zero-LP cost.** Item-exchange offers (`lp_cost = 0`) divided by zero; without a guard the fix would float them to the top as "Infinity ISK/LP". They now render blank and sort out of the way (both tables, Buy + Sell ISK/LP columns).

## Verification

Reproduced both code paths against public ESI (`/loyalty/stores/{corp}/offers/`) + live Fuzzwork, no DB required:

- Fuzzwork single GET: `200` at 1000 types, **`414` at 1500+** → confirms chunking is required.
- `/all` (fixed) now matches the per-corp page **to the cent** for every Thukker Mix offer, e.g.:

  | offer | per-corp | /all |
  |------:|---------:|-----:|
  | 4772  | 2794.28  | 2794.28 |
  | 4773  | 2576.08  | 2576.08 |
  | 16203 | 2467.67  | 2467.67 |
  | 16199 | 2339.91  | 2339.91 |

- The zero-LP item-exchange offer no longer renders as "Infinity ISK/LP".

`pnpm type-check` is clean for the touched files (the repo's pre-existing baseline errors in `eve-icons`/`ui` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)