### PR TITLE
fix(db-history): don't push the viewer's schema on deploy

### DIFF
--- a/packages/db-history/package.json
+++ b/packages/db-history/package.json
@@ -12,7 +12,7 @@
     "db:studio": "prisma studio --browser none",
     "db:generate": "pnpm with-env prisma generate",
     "db:generate:watch": "pnpm with-env prisma generate --watch",
-    "db:push": "pnpm with-env prisma db push",
+    "db:push": "echo 'skip: @jitaspace/db-history is read-only — the eve-builds schema is owned by the ingestion pipeline, never pushed from the web app'",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "postinstall": "pnpm db:generate",


### PR DESCRIPTION
## Problem
The deploy runs `turbo db:push`, which fans out to **every** package with a `db:push` script. The new `@jitaspace/db-history` has one, so the deploy tried to push its schema and failed:

```
@jitaspace/db-history:db:push: Error: P1001: Can't reach database server at `localhost:26257`
```

(no `HISTORY_DATABASE_URL` in the deploy env → Prisma's localhost fallback).

## Fix
`db-history` is a **read-only viewer** — the eve-builds schema is owned by the ingestion pipeline, so the web app must never push it (and a push from the merged schema would actually *drop* the `size`/`hash` columns the live DB now carries). This makes `db:push` a documented no-op so `turbo db:push` succeeds and only the app's own `@jitaspace/db` is pushed. The viewer's Prisma **client** is still generated normally via `postinstall → db:generate`.

## Runtime follow-up (separate from this PR)
For the `/history` pages to return data once deployed, set in the Vercel project (Production + Preview):
- `HISTORY_DATABASE_URL` — the eve-builds connection string
- `HISTORY_DATABASE_SCHEMA` — `history`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
