### PR TITLE
fix(web): allow children in anchor wrapper prop types

### DIFF
--- a/apps/web/components/Anchor/CalendarEventOwnerAnchor.tsx
+++ b/apps/web/components/Anchor/CalendarEventOwnerAnchor.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import type { PropsWithChildren } from "react";
 import React, { memo } from "react";
 import { type AnchorProps } from "@mantine/core";
 import { useCalendarEvent } from "@jitaspace/hooks";
 import { CalendarEventOwnerAnchor as UICalendarEventOwnerAnchor } from "@jitaspace/ui";
 
-export type CalendarEventOwnerAnchorProps = AnchorProps & {
-  characterId?: number;
-  eventId?: number;
-};
+export type CalendarEventOwnerAnchorProps = PropsWithChildren<
+  AnchorProps & {
+    characterId?: number;
+    eventId?: number;
+  }
+>;
 
 export const CalendarEventOwnerAnchor = memo(
   ({ characterId, eventId, ...otherProps }: CalendarEventOwnerAnchorProps) => {

--- a/apps/web/components/Anchor/StargateDestinationAnchor.tsx
+++ b/apps/web/components/Anchor/StargateDestinationAnchor.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import type { PropsWithChildren } from "react";
 import React, { memo } from "react";
 import { type AnchorProps } from "@mantine/core";
 import { useStargate } from "@jitaspace/hooks";
 import { StargateDestinationAnchor as UIStargateDestinationAnchor } from "@jitaspace/ui";
 
-export type StargateDestinationAnchorProps = AnchorProps & {
-  stargateId?: number;
-};
+export type StargateDestinationAnchorProps = PropsWithChildren<
+  AnchorProps & {
+    stargateId?: number;
+  }
+>;
 
 export const StargateDestinationAnchor = memo(({ stargateId, ...otherProps }: StargateDestinationAnchorProps) => {
   const { data } = useStargate(stargateId ?? 0);

--- a/apps/web/components/Anchor/WarAggressorAnchor.tsx
+++ b/apps/web/components/Anchor/WarAggressorAnchor.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import type { PropsWithChildren } from "react";
 import React, { memo } from "react";
 import { type AnchorProps } from "@mantine/core";
 import { useWar } from "@jitaspace/hooks";
 import { WarAggressorAnchor as UIWarAggressorAnchor } from "@jitaspace/ui";
 
-export type WarAggressorAnchorProps = AnchorProps & {
-  warId?: number;
-};
+export type WarAggressorAnchorProps = PropsWithChildren<
+  AnchorProps & {
+    warId?: number;
+  }
+>;
 
 export const WarAggressorAnchor = memo(({ warId, ...otherProps }: WarAggressorAnchorProps) => {
   const { data: war } = useWar(warId ?? 0);

--- a/apps/web/components/Anchor/WarDefenderAnchor.tsx
+++ b/apps/web/components/Anchor/WarDefenderAnchor.tsx
@@ -1,13 +1,16 @@
 "use client";
 
+import type { PropsWithChildren } from "react";
 import React, { memo } from "react";
 import { type AnchorProps } from "@mantine/core";
 import { useWar } from "@jitaspace/hooks";
 import { WarDefenderAnchor as UIWarDefenderAnchor } from "@jitaspace/ui";
 
-export type WarDefenderAnchorProps = AnchorProps & {
-  warId?: number;
-};
+export type WarDefenderAnchorProps = PropsWithChildren<
+  AnchorProps & {
+    warId?: number;
+  }
+>;
 
 export const WarDefenderAnchor = memo(({ warId, ...otherProps }: WarDefenderAnchorProps) => {
   const { data: war } = useWar(warId ?? 0);


### PR DESCRIPTION
## What & why

`apps/web` failed its **local** production build at the TypeScript type-check step (`SKIP_ENV_VALIDATION=1 pnpm exec turbo run build --filter=@jitaspace/web`, or `pnpm type-check`). This does **not** fail CI — `next.config.mjs` sets `typescript: { ignoreBuildErrors: !!process.env.CI }` and `pnpm type-check` is not a CI gate — but it broke local `next build` / `type-check`.

Four `apps/web` anchor wrappers declared their props as `AnchorProps & {…}`, which omits `children`, yet are rendered **with** children:

| Component | Rendered with children at |
|---|---|
| `StargateDestinationAnchor` | `app/system/[systemId]/page.client.tsx:149` |
| `WarAggressorAnchor` | `app/war/[warId]/page.client.tsx:83` |
| `WarDefenderAnchor` | `app/war/[warId]/page.client.tsx:112` |
| `CalendarEventOwnerAnchor` | `Desktop/MobileCalendarEventList:50` |

```
Type error: Type '{ children: Element; stargateId: number; }' is not assignable to
type 'IntrinsicAttributes & AnchorProps & { stargateId?: number | undefined; }'.
  Property 'children' does not exist on type '… & { stargateId?: number }'.
```

## The fix

Wrap each wrapper's props type in `PropsWithChildren<…>`. The underlying `@jitaspace/ui` anchors already accept and forward `children` (their prop types include `Omit<React.HTMLProps<HTMLAnchorElement>, "ref" | "size">` and they destructure/forward `children`), so children already flowed through `...otherProps` at runtime — **this is a type-only fix with no observable behavior change.**

## Verification

- ✅ `next build` now compiles and advances **past all four** children errors.
- ✅ Baseline diff of `pnpm type-check` (stash-and-compare): this bug class went **5 → 0** own-source errors, **zero new errors introduced**.
- ✅ Import split (`import type { PropsWithChildren } from "react"`) matches the repo's prettier/import-order convention (precedent: `app/mantine-provider.tsx`).

## No changeset

Type-only fix with no end-user-observable effect (production CI already shipped via `ignoreBuildErrors`), so no `@jitaspace/web` changeset.

## Reviewer notes — out of scope

A fully-green local `next build` is **not** reached by this PR (intentionally scoped to the children bug). The next blocker is a **separate, pre-existing** issue: every `components/Anchor/*` wrapper spreads Mantine `AnchorProps` (whose `style: MantineStyleProp` can be an array) into a component typed with `React.HTMLProps<HTMLAnchorElement>` (`style: CSSProperties`), which doesn't type-check — plus long-standing typing debt in `RaceAvatar`, `RouteTable`, `StationLinkControl`, and the `tests/*` files. None are caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)