### PR TITLE
refactor(triggerdev): derive tasks from the registry (no hand-written export list)

### DIFF
--- a/packages/background-jobs-triggerdev/README.md
+++ b/packages/background-jobs-triggerdev/README.md
@@ -14,8 +14,9 @@ Trigger.dev task (or a scheduled task for the cron job) and exported from
   `triggerAndWait().unwrap()`, `sleep`→`wait.for`, `singleton`/`concurrencyLimit`→
   `queue.concurrencyLimit`, `retries`→`retry.maxAttempts = retries + 1`,
   `NonRetriableError`→`AbortTaskRunError`).
-- `src/trigger/index.ts` — one literal named export per job, so the build can
-  statically index each task. Generated from the registry; keep in sync.
+- `src/trigger/index.ts` — loops `registry.jobs` and registers one Trigger task
+  per job, so the set can't drift from the registry. Trigger v4 indexes by
+  registration, not export, so nothing here is exported.
 
 ## Setup
 

--- a/packages/background-jobs-triggerdev/src/adapter.ts
+++ b/packages/background-jobs-triggerdev/src/adapter.ts
@@ -7,13 +7,13 @@ import {
   wait,
 } from "@trigger.dev/sdk";
 
-import { NonRetriableError } from "@jitaspace/background-jobs";
 import type {
   JobContext,
   JobDefinition,
   JobDuration,
   JobLogger,
 } from "@jitaspace/background-jobs";
+import { NonRetriableError } from "@jitaspace/background-jobs";
 
 // Minimal shape we need from a created task to back `ctx.invoke`.
 interface TriggerableTask {
@@ -122,8 +122,8 @@ const runJob = async (
 
 /**
  * Wrap a platform-agnostic job as a Trigger.dev task (or scheduled task for
- * cron jobs). Must be called from a top-level named export so the Trigger build
- * can index the task — see `src/trigger/index.ts`.
+ * cron jobs). Calling this registers the task with Trigger; v4 indexes tasks by
+ * registration rather than export; `src/trigger/index.ts` iterates the registry.
  */
 export function toTriggerTask(job: JobDefinition) {
   const created =

--- a/packages/background-jobs-triggerdev/src/trigger/index.ts
+++ b/packages/background-jobs-triggerdev/src/trigger/index.ts
@@ -2,52 +2,10 @@ import { registry } from "@jitaspace/background-jobs";
 
 import { toTriggerTask } from "../adapter";
 
-// One literal named export per job — required so the Trigger.dev build can
-// statically index each task. Generated from the @jitaspace/background-jobs
-// registry; keep in sync if jobs are added or removed.
-export const backfillEvekillAllianceIdsTask = toTriggerTask(registry.get("backfill-evekill-alliance-ids"));
-export const backfillEvekillCharacterIdsTask = toTriggerTask(registry.get("backfill-evekill-character-ids"));
-export const backfillEvekillCorporationIdsTask = toTriggerTask(registry.get("backfill-evekill-corporation-ids"));
-export const backfillEverefKillmailsTask = toTriggerTask(registry.get("backfill-everef-killmails"));
-export const backfillEverefWarsTask = toTriggerTask(registry.get("backfill-everef-wars"));
-export const bootstrapDatabaseTask = toTriggerTask(registry.get("bootstrap-database"));
-export const esiUpdateWarsTask = toTriggerTask(registry.get("esi-update-wars"));
-export const pingTask = toTriggerTask(registry.get("ping"));
-export const processRedisAllianceIdsTask = toTriggerTask(registry.get("process-redis-alliance-ids"));
-export const processRedisCharacterIdsTask = toTriggerTask(registry.get("process-redis-character-ids"));
-export const processRedisCorporationIdsTask = toTriggerTask(registry.get("process-redis-corporation-ids"));
-export const processRedisWarsTask = toTriggerTask(registry.get("process-redis-wars"));
-export const scrapeEsiAlliancesTask = toTriggerTask(registry.get("scrape-esi-alliances"));
-export const scrapeEsiAncestriesTask = toTriggerTask(registry.get("scrape-esi-ancestries"));
-export const scrapeEsiBloodlinesTask = toTriggerTask(registry.get("scrape-esi-bloodlines"));
-export const scrapeEsiCategoriesTask = toTriggerTask(registry.get("scrape-esi-categories"));
-export const scrapeEsiConstellationsTask = toTriggerTask(registry.get("scrape-esi-constellations"));
-export const scrapeEsiCorporationsTask = toTriggerTask(registry.get("scrape-esi-corporations"));
-export const scrapeEsiDogmaAttributesTask = toTriggerTask(registry.get("scrape-esi-dogma-attributes"));
-export const scrapeEsiDogmaEffectsTask = toTriggerTask(registry.get("scrape-esi-dogma-effects"));
-export const scrapeEsiFactionsTask = toTriggerTask(registry.get("scrape-esi-factions"));
-export const scrapeEsiGraphicsTask = toTriggerTask(registry.get("scrape-esi-graphics"));
-export const scrapeEsiGroupsTask = toTriggerTask(registry.get("scrape-esi-groups"));
-export const scrapeEsiLoyaltyStoreOffersTask = toTriggerTask(registry.get("scrape-esi-loyalty-store-offers"));
-export const scrapeEsiMarketGroupsTask = toTriggerTask(registry.get("scrape-esi-market-groups"));
-export const scrapeEsiMoonsTask = toTriggerTask(registry.get("scrape-esi-moons"));
-export const scrapeEsiNpcCorporationsTask = toTriggerTask(registry.get("scrape-esi-npc-corporations"));
-export const scrapeEsiPlanetsTask = toTriggerTask(registry.get("scrape-esi-planets"));
-export const scrapeEsiRacesTask = toTriggerTask(registry.get("scrape-esi-races"));
-export const scrapeEsiRegionsTask = toTriggerTask(registry.get("scrape-esi-regions"));
-export const scrapeEsiSolarSystemsTask = toTriggerTask(registry.get("scrape-esi-solar-systems"));
-export const scrapeEsiStargatesTask = toTriggerTask(registry.get("scrape-esi-stargates"));
-export const scrapeEsiStationsTask = toTriggerTask(registry.get("scrape-esi-stations"));
-export const scrapeEsiTypesTask = toTriggerTask(registry.get("scrape-esi-types"));
-export const scrapeEsiWarsTask = toTriggerTask(registry.get("scrape-esi-wars"));
-export const scrapeHoboleaksAgentTypesTask = toTriggerTask(registry.get("scrape-hoboleaks-agent-types"));
-export const scrapeHoboleaksDogmaEffectCategoriesTask = toTriggerTask(registry.get("scrape-hoboleaks-dogma-effect-categories"));
-export const scrapeHoboleaksDogmaUnitsTask = toTriggerTask(registry.get("scrape-hoboleaks-dogma-units"));
-export const scrapeSdeAgentsTask = toTriggerTask(registry.get("scrape-sde-agents"));
-export const scrapeSdeDogmaAttributeCategoriesTask = toTriggerTask(registry.get("scrape-sde-dogma-attribute-categories"));
-export const scrapeSdeDogmaEffectModifiersTask = toTriggerTask(registry.get("scrape-sde-dogma-effect-modifiers"));
-export const scrapeSdeIconsTask = toTriggerTask(registry.get("scrape-sde-icons"));
-export const scrapeSdeNpcCorporationDivisionsTask = toTriggerTask(registry.get("scrape-sde-npc-corporation-divisions"));
-export const scrapeSdeRacesTask = toTriggerTask(registry.get("scrape-sde-races"));
-export const scrapeSdeStationServicesTask = toTriggerTask(registry.get("scrape-sde-station-services"));
-export const scrapeZkillboardRecentKillsTask = toTriggerTask(registry.get("scrape-zkillboard-recent-kills"));
+// Register one Trigger.dev task per job, straight from the registry — so the set
+// can never drift from @jitaspace/background-jobs. Trigger v4 indexes tasks by
+// registration (the task()/schedules.task() call inside toTriggerTask), not by
+// export ("hidden tasks"), so nothing here needs to be exported.
+for (const job of registry.jobs) {
+  toTriggerTask(job);
+}


### PR DESCRIPTION
Eliminates the drift risk in `src/trigger/index.ts` by **removing the hand-written list entirely** rather than guarding it with a test.

## Before → after

```ts
// before — 46 lines kept in sync with the registry by hand:
export const backfillEvekillAllianceIdsTask = toTriggerTask(registry.get("backfill-evekill-alliance-ids"));
export const backfillEvekillCharacterIdsTask = toTriggerTask(registry.get("backfill-evekill-character-ids"));
// …44 more…

// after — drift is structurally impossible, and nothing is exported:
for (const job of registry.jobs) {
  toTriggerTask(job);
}
```

Add or remove a job in `@jitaspace/background-jobs` and the Trigger task set follows automatically — nothing to edit here.

## Why this is safe in v4

Trigger **v4 removed the "tasks must be exported" requirement** ([upgrade docs](https://trigger.dev/docs/upgrade-to-v4), ["hidden tasks"](https://trigger.dev/docs/hidden-tasks)) — it indexes tasks by **registration** (the `task()` / `schedules.task()` call inside `toTriggerTask`), not by inspecting module exports. So looping the registry registers all 46 without exporting anything. The loop is a top-level side-effecting statement and the package isn't marked `sideEffects: false`, so it survives bundling. (The old "must export" comment was v3-era; the Inngest adapter already maps the registry the same way.)

Type-check passes. Private package, so no changeset.

## ⚠️ Verify before merging (it touches the indexing path)

I can't index-test this from CI, so please confirm it indexes all 46 in a **non-prod** env first:

```bash
cd packages/background-jobs-triggerdev
TRIGGER_PROJECT_REF=proj_ayitxvivgbxyvlhfkpdx npx trigger.dev@latest dev
```

The Dev environment should show **all 46 tasks** (incl. the `esi-update-wars` schedule). If it does → safe to merge. If it shows fewer, v4's registration-based detection isn't behaving as documented — revert is a one-liner (`git revert`) since the explicit exports are in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)