### PR TITLE
chore(hooks): remove unused @jitaspace/evetycoon-client dependency

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -30,7 +30,6 @@
     "@jitaspace/auth-utils": "workspace:*",
     "@jitaspace/esi-client": "workspace:*",
     "@jitaspace/esi-metadata": "workspace:*",
-    "@jitaspace/evetycoon-client": "workspace:*",
     "@jitaspace/fuzzworks-market-client": "workspace:*",
     "@jitaspace/sde-client": "workspace:*",
     "@react-hook/cache": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1548,9 +1548,6 @@ importers:
       '@jitaspace/esi-metadata':
         specifier: workspace:*
         version: link:../esi-metadata
-      '@jitaspace/evetycoon-client':
-        specifier: workspace:*
-        version: link:../evetycoon-client
       '@jitaspace/fuzzworks-market-client':
         specifier: workspace:*
         version: link:../fuzzworks-market-client


### PR DESCRIPTION
## What

Removes `@jitaspace/evetycoon-client` from `@jitaspace/hooks`. It was declared as a production dependency but **no file under `packages/hooks/src/` imports it** — the evetycoon API is non-functional due to CORS (as noted in its README), and the client was never wired into any hook.

## Why

Dead dependency. A case-insensitive sweep of all 107 files under `packages/hooks/src/` found zero references to `evetycoon`/`tycoon` in any form; the only occurrence in the whole package was the `package.json` declaration line itself.

## Changes

- `packages/hooks/package.json` — drop the `@jitaspace/evetycoon-client` dependency line.
- `pnpm-lock.yaml` — drop the matching 3-line entry from the `packages/hooks` importer block so `pnpm install --frozen-lockfile` stays in sync (edited surgically to avoid lockfile quote-style churn).

Net diff: **4 deletions**, no source changes.

## Verification

- ✅ `pnpm --filter @jitaspace/hooks type-check` — passes (exit 0).
- ✅ `pnpm --filter @jitaspace/hooks lint` — output is **identical to baseline** (`78 errors, 35 warnings`, all pre-existing debt in unrelated files; confirmed by stashing the diff and re-running). `pnpm lint` is not a CI gate in this repo and this change adds nothing to it.
- ✅ `pnpm install --frozen-lockfile` (CI-equivalent) — succeeds, confirming `package.json` ↔ lockfile are in sync.
- ✅ `@jitaspace/evetycoon-client` no longer appears anywhere in the hooks package (source, config, or `node_modules` — a fresh frozen install does not re-link it).

## Reviewer notes

- No changeset: `@jitaspace/hooks` is `"private": true`.
- `@jitaspace/hooks` was the **sole consumer** of `@jitaspace/evetycoon-client` in the monorepo, so the `packages/evetycoon-client` package is now orphaned. It is **intentionally left untouched** here — removing the package outright (vs. keeping it for a future server-side CORS proxy) is a separate decision left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)