### PR TITLE
refactor(kv): drop @jitaspace/esi-client dependency

### DIFF
--- a/packages/kv/index.ts
+++ b/packages/kv/index.ts
@@ -1,8 +1,6 @@
 import Queue from "bull";
 import { createClient } from "redis";
 
-import type { GetWarsWarId200 } from "@jitaspace/esi-client";
-
 export interface CreateKvOptions {
   /** Redis connection URL. */
   redisUrl: string;
@@ -29,7 +27,11 @@ export async function createKv({ redisUrl }: CreateKvOptions) {
         "corporationIds",
         redisUrl,
       ),
-      war: new Queue<GetWarsWarId200[]>("wars", redisUrl),
+      // Payload type is intentionally `unknown`: kv is a generic Redis/queue
+      // wrapper with no knowledge of EVE domain shapes. Consumers assert the
+      // concrete element type at their call site (e.g. the wars drain handler
+      // in @jitaspace/background-jobs).
+      war: new Queue<unknown>("wars", redisUrl),
     },
   };
 

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -15,7 +15,6 @@
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {
-    "@jitaspace/esi-client": "workspace:*",
     "bull": "^4.16.5",
     "redis": "^5.12.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1639,9 +1639,6 @@ importers:
 
   packages/kv:
     dependencies:
-      '@jitaspace/esi-client':
-        specifier: workspace:*
-        version: link:../esi-client
       bull:
         specifier: ^4.16.5
         version: 4.16.5


### PR DESCRIPTION
## What

`@jitaspace/kv` is a generic Redis/queue wrapper, but it imported the EVE-specific `GetWarsWarId200` type from `@jitaspace/esi-client` solely to type the war Bull queue as `Queue<GetWarsWarId200[]>`. This pulled the entire ESI client into kv's dependency graph for a single type annotation.

This PR makes the war queue payload-agnostic and removes the dependency:

- `packages/kv/index.ts`: drop the `import type { GetWarsWarId200 }`; type the war queue as `Queue<unknown>`.
- `packages/kv/package.json`: remove `@jitaspace/esi-client` from `dependencies` (it was never in `devDependencies`). Lockfile updated to match.

## Why

`kv` is meant to be a domain-agnostic Redis/queue wrapper — it has no business knowing about ESI response shapes. Even as an `import type` (erased at compile time), the package-level dependency edge meant the ESI client appeared in kv's graph. Removing it keeps the boundary clean.

## Where the type now lives

No call-site assertion was needed, because the concrete element type was already owned by the consumer, not kv:

- **Consumer** (`background-jobs/jobs/scrape/redis/processWarsQueue.ts`) never reads `kv.queues.war`. It drains via `drainQueue<GetWarsWarId200[]>("wars", ...)`, which constructs its **own** typed `Queue<T>` by name — so `job.data` is correctly typed independently of kv. `@jitaspace/background-jobs` keeps its own (legitimate) `@jitaspace/esi-client` dependency.
- **Producer** (`background-jobs/jobs/scrape/everef/backfillWars.ts`) is the only reader of `kv.queues.war`; it calls `.add(...)`, and `Queue<unknown>.add(data: unknown)` accepts any argument — so it still type-checks unchanged.

## Verification

- `pnpm --filter @jitaspace/kv type-check` → pass
- `pnpm --filter @jitaspace/background-jobs type-check` → pass (after `pnpm db:generate`, a fresh-worktree prerequisite)
- `@jitaspace/esi-client` confirmed absent from `packages/kv/package.json` and the kv entry in `pnpm-lock.yaml`.

No changeset: both affected packages are `private`, and there is no end-user-visible effect (backend queue plumbing only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)