### PR TITLE
refactor(auth): decouple auth packages from Next.js

### DIFF
--- a/.changeset/decouple-auth-from-next.md
+++ b/.changeset/decouple-auth-from-next.md
@@ -1,0 +1,22 @@
+---
+"@jitaspace/auth": minor
+"@jitaspace/auth-utils": patch
+"@jitaspace/web": patch
+---
+
+refactor(auth): remove the Next.js dependency from the auth layer
+
+`@jitaspace/auth` and `@jitaspace/auth-utils` no longer depend on `next`, so the
+authentication logic is framework-agnostic and reusable by a future second
+consumer (e.g. a mobile backend).
+
+- `@jitaspace/auth` — `refreshTokenApiRouteHandler` now takes and returns Web
+  standard `Request`/`Response` (`(request: Request) => Promise<Response>`,
+  using `Response.json()`), replacing the Next.js Pages Router
+  `(req: NextApiRequest, res: NextApiResponse)` signature. This drops the only
+  `next` import in the package.
+- `@jitaspace/auth-utils` — removed an unused `next` dependency (it imported
+  nothing from it).
+- `@jitaspace/web` — the SSO token-refresh server action now invokes the handler
+  with a `Request` and reads the `Response`, removing the hand-rolled
+  `NextApiResponse` adapter. No user-facing behaviour change.

--- a/apps/web/components/EsiClientSSOAccessTokenInjector.actions.ts
+++ b/apps/web/components/EsiClientSSOAccessTokenInjector.actions.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import type { NextApiRequest, NextApiResponse } from "next";
-
 import { refreshTokenApiRouteHandler } from "@jitaspace/auth";
 
 type RefreshTokenApiResponseBody =
@@ -16,44 +14,21 @@ interface RefreshTokenApiResult {
   body: RefreshTokenApiResponseBody | undefined;
 }
 
-const createNextApiResponseAdapter = () => {
-  let statusCode = 200;
-  let body: RefreshTokenApiResponseBody | undefined;
-
-  const response = {
-    setHeader() {
-      return response;
-    },
-    status(code: number) {
-      statusCode = code;
-      return response;
-    },
-    json(value: RefreshTokenApiResponseBody) {
-      body = value;
-      return response;
-    },
-  } as unknown as NextApiResponse<RefreshTokenApiResponseBody>;
-
-  return {
-    response,
-    result: () => ({ statusCode, body }),
-  };
-};
-
 const refreshCharacterTokenResult = async (
   refreshTokenData: string,
 ): Promise<RefreshTokenApiResult> => {
-  const { response, result } = createNextApiResponseAdapter();
-
-  await refreshTokenApiRouteHandler(
-    {
+  // `refreshTokenApiRouteHandler` is a framework-agnostic Web handler
+  // (Request -> Response). We invoke it in-process here; the URL is unused by
+  // the handler and only exists to satisfy the `Request` constructor.
+  const response = await refreshTokenApiRouteHandler(
+    new Request("https://jita.space/api/auth/refresh-token", {
+      method: "POST",
       body: refreshTokenData,
-    } as NextApiRequest,
-    response,
+    }),
   );
 
-  const { statusCode, body } = result();
-  return { statusCode, body };
+  const body = (await response.json()) as RefreshTokenApiResponseBody;
+  return { statusCode: response.status, body };
 };
 
 export async function refreshCharacterToken(refreshTokenData: string) {

--- a/packages/auth-utils/package.json
+++ b/packages/auth-utils/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@jitaspace/esi-metadata": "workspace:*",
-    "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -17,7 +17,6 @@
     "@hapi/iron": "^7.0.1",
     "@jitaspace/auth-utils": "workspace:*",
     "@jitaspace/esi-metadata": "workspace:*",
-    "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6"
   },

--- a/packages/auth/src/refreshTokenApiRouteHandler.ts
+++ b/packages/auth/src/refreshTokenApiRouteHandler.ts
@@ -1,4 +1,3 @@
-import { type NextApiRequest, type NextApiResponse } from "next";
 import { HttpStatusCode } from "axios";
 import z from "zod";
 
@@ -23,17 +22,18 @@ const ACCESS_TOKEN_TOO_OLD_TIME = 30 * 24 * 3600 * 1000; // 30 days
 // TODO: Support optionally requesting a subset of existing scopes
 // See https://docs.esi.evetech.net/docs/sso/refreshing_access_tokens.html
 
+/**
+ * Framework-agnostic handler that refreshes an EVE SSO access token.
+ *
+ * Takes and returns Web standard `Request`/`Response` so it can be wired up to
+ * any runtime (Next.js Route Handler, server action, plain fetch server, a
+ * future mobile backend, …) without depending on Next.js. The request body is
+ * the sealed `tokenRefreshData` string produced by {@link sealDataWithAuthSecret}.
+ */
 export const refreshTokenApiRouteHandler = async (
-  req: NextApiRequest,
-  res: NextApiResponse<
-    | { error: string }
-    | {
-        accessToken: string;
-        refreshTokenData: string;
-      }
-  >,
-) => {
-  const body = req.body;
+  request: Request,
+): Promise<Response> => {
+  const body = await request.text();
 
   // Confirm body is an (encrypted) string
   z.string().parse(body);
@@ -55,23 +55,26 @@ export const refreshTokenApiRouteHandler = async (
     Date.now() <
     accessTokenExpiration * 1000 - REFRESH_TOKEN_BEFORE_EXP_TIME
   ) {
-    return res
-      .status(HttpStatusCode.TooEarly)
-      .json({ error: "Token is not expired nor is about to expire." });
+    return Response.json(
+      { error: "Token is not expired nor is about to expire." },
+      { status: HttpStatusCode.TooEarly },
+    );
   }
 
   // Check if access token is too old to be refreshed
   if (Date.now() > accessTokenExpiration * 1000 + ACCESS_TOKEN_TOO_OLD_TIME) {
-    return res
-      .status(HttpStatusCode.Gone)
-      .json({ error: "Access token is too old. Must reauthenticate." });
+    return Response.json(
+      { error: "Access token is too old. Must reauthenticate." },
+      { status: HttpStatusCode.Gone },
+    );
   }
 
   // check if null
   if (env.EVE_CLIENT_ID === undefined || env.EVE_CLIENT_SECRET === undefined) {
-    return res
-      .status(HttpStatusCode.InternalServerError)
-      .json({ error: "EVE_CLIENT_ID or EVE_CLIENT_SECRET is undefined" });
+    return Response.json(
+      { error: "EVE_CLIENT_ID or EVE_CLIENT_SECRET is undefined" },
+      { status: HttpStatusCode.InternalServerError },
+    );
   }
 
   // Attempt to refresh token
@@ -85,9 +88,10 @@ export const refreshTokenApiRouteHandler = async (
   const payload = getEveSsoAccessTokenPayload(access_token);
 
   if (!payload)
-    return res
-      .status(HttpStatusCode.InternalServerError)
-      .json({ error: "Unable to decode payload of refreshed token." });
+    return Response.json(
+      { error: "Unable to decode payload of refreshed token." },
+      { status: HttpStatusCode.InternalServerError },
+    );
 
   const sealedRefreshData = await sealDataWithAuthSecret({
     data: {
@@ -97,7 +101,7 @@ export const refreshTokenApiRouteHandler = async (
     secret: env.NEXTAUTH_SECRET,
   });
 
-  return res.json({
+  return Response.json({
     accessToken: access_token,
     refreshTokenData: sealedRefreshData,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,9 +459,6 @@ importers:
       '@jitaspace/esi-metadata':
         specifier: workspace:*
         version: link:../esi-metadata
-      next:
-        specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -508,9 +505,6 @@ importers:
       '@jitaspace/esi-metadata':
         specifier: workspace:*
         version: link:../esi-metadata
-      next:
-        specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.27.4)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6


### PR DESCRIPTION
## What & why

`packages/auth` and `packages/auth-utils` both listed `next` as a production dependency, coupling the auth layer to Next.js. This removes that coupling so the authentication logic is framework-agnostic — reusable by a future second consumer (e.g. a mobile backend), not just `apps/web`.

## Audit findings

- **`packages/auth`** — a single `next` usage: `src/refreshTokenApiRouteHandler.ts` imported `NextApiRequest`/`NextApiResponse` (type-only) to type a Pages Router API handler. Nothing else in the package touched Next.js.
- **`packages/auth-utils`** — **zero** `next` references anywhere; the dependency was entirely unused.

## Changes

- **`@jitaspace/auth`** — `refreshTokenApiRouteHandler` migrated from the Next.js Pages Router `(req: NextApiRequest, res: NextApiResponse)` signature to the Web standard **`(request: Request) => Promise<Response>`** (body via `request.text()`, responses via `Response.json(data, { status })`). Removes the only `next` import in the package. It stays in `packages/auth` as a plain framework-agnostic function — nothing in it is Next.js-specific (it uses the package's own `env.ts`).
- **`@jitaspace/auth-utils`** — removed the unused `next` dependency.
- **`@jitaspace/web`** — the SSO token-refresh server action (`EsiClientSSOAccessTokenInjector.actions.ts`) now builds a `Request` and reads `response.status` / `await response.json()`, deleting the hand-rolled `NextApiResponse` adapter (and its own `next` type import). The public `refreshCharacterToken` contract is unchanged. **No user-facing behaviour change.**

After this change, `next` no longer appears in `dependencies` of either auth package, and the lockfile is trimmed by exactly the two corresponding importer blocks (no churn).

## Verification

| Check | Result |
|---|---|
| `"next"` in either `package.json` | 0 (removed) |
| `pnpm --filter @jitaspace/auth-utils type-check` | ✅ exit 0 |
| `pnpm --filter @jitaspace/auth type-check` | ✅ exit 0 |
| `pnpm --filter @jitaspace/web type-check` | 323 errors — **byte-identical to the pristine-`main` baseline** (stash → re-run → empty `diff`), so **0 introduced**. All pre-existing (image-asset module decls, `Anchor/*` Mantine typing, jest-mock test typing). |
| Prettier (changed files) | ✅ clean |
| `@jitaspace/auth` tests | ✅ 14/14 across 4 suites |

A changeset is included (`@jitaspace/auth` minor, `auth-utils` + `web` patch), mirroring the prior `env-injection-factories` decoupling precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
