### PR TITLE
feat(web): add HTTP security headers

### DIFF
--- a/.changeset/web-security-headers.md
+++ b/.changeset/web-security-headers.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+feat(web): send HTTP security headers to harden the app. All routes now set X-Content-Type-Options, X-Frame-Options, Referrer-Policy and Permissions-Policy; page routes additionally get HSTS and a Content-Security-Policy. The CSP ships report-only for now — violations are reported to Sentry without blocking anything — while we validate coverage before enforcing it. API routes (/api/\*) are intentionally left without HSTS/CSP so programmatic consumers are unaffected.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -44,12 +44,15 @@ const jiti = createJiti(import.meta.url);
  *   - img:     EVE image CDNs (`images.evetech.net`, `web.ccpgamescdn.com`) and
  *              the item-icon host (`iec.jita.space`).
  *   - script:  Google Tag Manager.
- *   - connect: the EVE data plane the client-side React Query hooks fetch
- *              directly — ESI, the self-hosted SDE, and the EVE-Kill / EVE Tycoon
- *              / Fuzzwork market+killboard APIs — plus Google Analytics and the
- *              same-origin Sentry (`/monitoring`) and Umami (`/analytics`)
- *              proxies. (`report-uri` is exempt from `connect-src`, so the
- *              Sentry ingest host does not need to be listed here.)
+ *   - worker:  `blob:` for Sentry Session Replay's compression Web Worker.
+ *   - connect: data the client-side hooks (React Query / SWR) fetch directly —
+ *              the EVE data plane (ESI, the self-hosted SDE, the EVE-Kill / EVE
+ *              Tycoon / Fuzzwork market APIs, and the zKillboard killmail API),
+ *              `images.evetech.net` (also fetched as JSON to choose an image
+ *              variant, so it's in `connect-src` as well as `img-src`), Google
+ *              Analytics, and the same-origin Sentry (`/monitoring`) and Umami
+ *              (`/analytics`) proxies. (`report-uri` is exempt from
+ *              `connect-src`, so the Sentry ingest host isn't listed here.)
  */
 const contentSecurityPolicy = [
   "default-src 'self'",
@@ -61,11 +64,18 @@ const contentSecurityPolicy = [
   "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
   // Mantine emits inline styles; same per-request-nonce caveat as script-src.
   "style-src 'self' 'unsafe-inline'",
-  // Browser-side data fetches: the EVE data plane (ESI, self-hosted SDE, and the
-  // market/killboard clients), Google Analytics (incl. regional
-  // `*.google-analytics.com` collectors), and the same-origin Sentry/Umami
-  // proxies.
-  "connect-src 'self' https://esi.evetech.net https://sde.jita.space https://eve-kill.com https://evetycoon.com https://market.fuzzwork.co.uk https://www.google-analytics.com https://*.google-analytics.com /monitoring /analytics",
+  // Sentry Session Replay (enabled in instrumentation-client.ts) compresses
+  // events in a Web Worker loaded from a `blob:` URL. Without this it falls back
+  // to default-src 'self', which blocks the blob worker.
+  "worker-src 'self' blob:",
+  // Browser-side data fetches (client-side React Query / SWR hooks): the EVE
+  // data plane — ESI, self-hosted SDE, EVE-Kill / EVE Tycoon / Fuzzwork market,
+  // and the zKillboard killmail API (kill page + Travel panel) — plus
+  // images.evetech.net, which is also fetched as JSON to choose an image variant
+  // and so needs connect-src in addition to img-src. Then Google Analytics
+  // (incl. regional `*.google-analytics.com` collectors) and the same-origin
+  // Sentry/Umami proxies.
+  "connect-src 'self' https://esi.evetech.net https://sde.jita.space https://eve-kill.com https://evetycoon.com https://market.fuzzwork.co.uk https://images.evetech.net https://zkillboard.com https://www.google-analytics.com https://*.google-analytics.com /monitoring /analytics",
   "frame-ancestors 'none'",
   // Sentry Security (CSP) endpoint derived from the browser DSN — see the note
   // above on why this is NOT the `/monitoring` tunnel. TODO: `report-uri` is

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -56,6 +56,12 @@ const jiti = createJiti(import.meta.url);
  */
 const contentSecurityPolicy = [
   "default-src 'self'",
+  // Defense-in-depth (OWASP-recommended), both safe — the app uses neither a
+  // `<base>` tag nor `<object>`/`<embed>`. `base-uri` can't be constrained by
+  // any other directive, so pin it to block `<base href>` hijacking; `object-src
+  // 'none'` shuts off legacy plugin embedding vectors.
+  "base-uri 'self'",
+  "object-src 'none'",
   "img-src 'self' https://images.evetech.net https://web.ccpgamescdn.com https://iec.jita.space data:",
   // FUTURE WORK: `'unsafe-inline'` is unavoidable here until we emit a
   // per-request nonce (Next.js injects inline bootstrap scripts; GTM is loaded

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,9 +14,19 @@ const jiti = createJiti(import.meta.url);
  *
  * IMPORTANT: this is shipped **report-only** — it is sent as the
  * `Content-Security-Policy-Report-Only` header (see `headers()` below), so the
- * browser reports violations to Sentry (via the `report-uri` tunnel) WITHOUT
- * blocking anything. This lets us observe real-world violations against actual
- * traffic before switching to an enforced policy.
+ * browser reports violations WITHOUT blocking anything. This lets us observe
+ * real-world violations against actual traffic before switching to an enforced
+ * policy.
+ *
+ * Reports go to Sentry's Security ("CSP") endpoint, derived from the browser
+ * DSN in `instrumentation-client.ts`. NOTE: this is deliberately NOT the
+ * `/monitoring` route. That route is Sentry's envelope *tunnel* (`tunnelRoute`
+ * below) — it only understands the SDK's envelope transport format and would
+ * reject `application/csp-report` payloads, so browser CSP reports must be sent
+ * to the Security endpoint directly. It is cross-origin, so ad-blockers may drop
+ * a fraction of reports; acceptable for a report-only sampling phase. If we need
+ * ad-blocker-resistant capture later, add a same-origin `/api/csp-report` route
+ * that forwards to this endpoint.
  *
  * Path to an *enforced* policy (a separate, future task — do NOT enable here):
  *   1. Generate a per-request nonce in `middleware.ts`.
@@ -25,14 +35,25 @@ const jiti = createJiti(import.meta.url);
  *   3. Replace `'unsafe-inline'` with `'nonce-<value>'` below, then rename the
  *      header from `Content-Security-Policy-Report-Only` to
  *      `Content-Security-Policy` (and drop `'unsafe-inline'`).
+ *   4. Keep `connect-src` / `img-src` in sync as new external origins are added
+ *      — the report-only phase exists precisely to surface anything missing
+ *      before it can break a page.
  *
- * Origins allow-listed below are the ones the app legitimately talks to:
- * EVE image CDNs, Google Tag Manager / Analytics, and the Sentry (`/monitoring`)
- * and Umami (`/analytics`) same-origin proxies.
+ * Origins allow-listed below are the ones the app legitimately talks to from the
+ * browser:
+ *   - img:     EVE image CDNs (`images.evetech.net`, `web.ccpgamescdn.com`) and
+ *              the item-icon host (`iec.jita.space`).
+ *   - script:  Google Tag Manager.
+ *   - connect: the EVE data plane the client-side React Query hooks fetch
+ *              directly — ESI, the self-hosted SDE, and the EVE-Kill / EVE Tycoon
+ *              / Fuzzwork market+killboard APIs — plus Google Analytics and the
+ *              same-origin Sentry (`/monitoring`) and Umami (`/analytics`)
+ *              proxies. (`report-uri` is exempt from `connect-src`, so the
+ *              Sentry ingest host does not need to be listed here.)
  */
 const contentSecurityPolicy = [
   "default-src 'self'",
-  "img-src 'self' https://images.evetech.net https://web.ccpgamescdn.com data:",
+  "img-src 'self' https://images.evetech.net https://web.ccpgamescdn.com https://iec.jita.space data:",
   // FUTURE WORK: `'unsafe-inline'` is unavoidable here until we emit a
   // per-request nonce (Next.js injects inline bootstrap scripts; GTM is loaded
   // from googletagmanager.com). Removing it is the goal of the nonce migration
@@ -40,10 +61,17 @@ const contentSecurityPolicy = [
   "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
   // Mantine emits inline styles; same per-request-nonce caveat as script-src.
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' https://www.google-analytics.com /monitoring /analytics",
+  // Browser-side data fetches: the EVE data plane (ESI, self-hosted SDE, and the
+  // market/killboard clients), Google Analytics (incl. regional
+  // `*.google-analytics.com` collectors), and the same-origin Sentry/Umami
+  // proxies.
+  "connect-src 'self' https://esi.evetech.net https://sde.jita.space https://eve-kill.com https://evetycoon.com https://market.fuzzwork.co.uk https://www.google-analytics.com https://*.google-analytics.com /monitoring /analytics",
   "frame-ancestors 'none'",
-  // Sentry tunnel (see `tunnelRoute` below); report-only violations land here.
-  "report-uri /monitoring",
+  // Sentry Security (CSP) endpoint derived from the browser DSN — see the note
+  // above on why this is NOT the `/monitoring` tunnel. TODO: `report-uri` is
+  // deprecated in favour of the Reporting API (`Reporting-Endpoints` +
+  // `report-to`); migrate when we move to an enforced policy.
+  "report-uri https://o4507086334001152.ingest.de.sentry.io/api/4507086337540176/security/?sentry_key=8ce4a77ec56a1b9fa5c8081b394c3636",
 ].join("; ");
 
 /** @type {import("next").NextConfig} */
@@ -117,7 +145,9 @@ const config = {
       source: "/(.*)",
       headers: [
         { key: "X-Content-Type-Options", value: "nosniff" },
-        { key: "X-Frame-Options", value: "SAMEORIGIN" },
+        // DENY (not SAMEORIGIN) to match the CSP `frame-ancestors 'none'` — the
+        // app embeds none of its own pages in frames, so deny framing outright.
+        { key: "X-Frame-Options", value: "DENY" },
         { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
         {
           key: "Permissions-Policy",
@@ -126,10 +156,11 @@ const config = {
       ],
     },
     {
-      // HSTS + CSP are intentionally NOT applied to /api/* so programmatic
-      // consumers aren't constrained by a browser-oriented policy. The negative
-      // lookahead matches every path EXCEPT those starting with `api/` (it still
-      // matches the site root `/` and all page routes).
+      // HSTS + CSP are browser-oriented directives that have no effect on
+      // programmatic (non-browser) API consumers, so we scope them to page
+      // routes and keep /api/* responses header-light. The negative lookahead
+      // matches every path EXCEPT those starting with `api/` (it still matches
+      // the site root `/` and all page routes).
       source: "/((?!api/).*)",
       headers: [
         {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -9,6 +9,43 @@ const jiti = createJiti(import.meta.url);
  */
 !process.env.SKIP_ENV_VALIDATION && (await jiti.import("./env"));
 
+/**
+ * Content-Security-Policy for the web app.
+ *
+ * IMPORTANT: this is shipped **report-only** — it is sent as the
+ * `Content-Security-Policy-Report-Only` header (see `headers()` below), so the
+ * browser reports violations to Sentry (via the `report-uri` tunnel) WITHOUT
+ * blocking anything. This lets us observe real-world violations against actual
+ * traffic before switching to an enforced policy.
+ *
+ * Path to an *enforced* policy (a separate, future task — do NOT enable here):
+ *   1. Generate a per-request nonce in `middleware.ts`.
+ *   2. Thread that nonce through every Next.js `<Script>` and inline `<style>`
+ *      tag (e.g. `<Script nonce={nonce}>`, `<style nonce={nonce}>`).
+ *   3. Replace `'unsafe-inline'` with `'nonce-<value>'` below, then rename the
+ *      header from `Content-Security-Policy-Report-Only` to
+ *      `Content-Security-Policy` (and drop `'unsafe-inline'`).
+ *
+ * Origins allow-listed below are the ones the app legitimately talks to:
+ * EVE image CDNs, Google Tag Manager / Analytics, and the Sentry (`/monitoring`)
+ * and Umami (`/analytics`) same-origin proxies.
+ */
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "img-src 'self' https://images.evetech.net https://web.ccpgamescdn.com data:",
+  // FUTURE WORK: `'unsafe-inline'` is unavoidable here until we emit a
+  // per-request nonce (Next.js injects inline bootstrap scripts; GTM is loaded
+  // from googletagmanager.com). Removing it is the goal of the nonce migration
+  // described above.
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+  // Mantine emits inline styles; same per-request-nonce caveat as script-src.
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https://www.google-analytics.com /monitoring /analytics",
+  "frame-ancestors 'none'",
+  // Sentry tunnel (see `tunnelRoute` below); report-only violations land here.
+  "report-uri /monitoring",
+].join("; ");
+
 /** @type {import("next").NextConfig} */
 const config = {
   reactStrictMode: true,
@@ -70,6 +107,42 @@ const config = {
       // pretty /market/<typeId> URL; the client reads the id from the path.
       source: "/market/:typeId",
       destination: "/market",
+    },
+  ],
+
+  headers: async () => [
+    {
+      // Baseline hardening headers — safe to send on every response, including
+      // /api/* (they don't constrain programmatic JSON consumers of the API).
+      source: "/(.*)",
+      headers: [
+        { key: "X-Content-Type-Options", value: "nosniff" },
+        { key: "X-Frame-Options", value: "SAMEORIGIN" },
+        { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+        {
+          key: "Permissions-Policy",
+          value: "camera=(), microphone=(), geolocation=()",
+        },
+      ],
+    },
+    {
+      // HSTS + CSP are intentionally NOT applied to /api/* so programmatic
+      // consumers aren't constrained by a browser-oriented policy. The negative
+      // lookahead matches every path EXCEPT those starting with `api/` (it still
+      // matches the site root `/` and all page routes).
+      source: "/((?!api/).*)",
+      headers: [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+        {
+          // Report-only for now — see the `contentSecurityPolicy` doc comment
+          // above for why and for the path to an enforced policy.
+          key: "Content-Security-Policy-Report-Only",
+          value: contentSecurityPolicy,
+        },
+      ],
     },
   ],
 


### PR DESCRIPTION
## What & why

`apps/web/next.config.mjs` had no `headers()` config, so the app — which handles EVE SSO OAuth tokens and authenticated user data — sent no HTTP security headers. This adds baseline hardening headers on every route plus a **report-only** Content-Security-Policy on page routes.

> **Revised after review:** completed the CSP allow-list against the app's real browser-side traffic, corrected the CSP report sink, and added defense-in-depth directives. The values below reflect the final state of the branch.

## Headers

**All routes (incl. `/api/*`):**
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY` — aligned with CSP `frame-ancestors 'none'`; the app frames none of its own pages
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`

**Page routes only (`source: "/((?!api/).*)"`):**
- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
- `Content-Security-Policy-Report-Only`, built from the app's real browser-side origins:
  - baseline: `default-src 'self'`, `base-uri 'self'`, `object-src 'none'`
  - `img-src`: `images.evetech.net`, `web.ccpgamescdn.com`, `iec.jita.space`, `data:`
  - `script-src`: `'self' 'unsafe-inline' https://www.googletagmanager.com`
  - `style-src`: `'self' 'unsafe-inline'`
  - `worker-src`: `'self' blob:` (Sentry Replay's compression worker)
  - `connect-src`: ESI, SDE, EVE-Kill, EVE Tycoon, Fuzzwork, `images.evetech.net` (JSON variant lookup), `zkillboard.com`, Google Analytics (+ regional `*.google-analytics.com`), `/monitoring`, `/analytics`
  - `frame-ancestors 'none'`
  - `report-uri` → Sentry's DSN-derived **Security** endpoint (deliberately **not** the `/monitoring` envelope tunnel, which only accepts the SDK envelope format and rejects `application/csp-report`)

HSTS + CSP are scoped away from `/api/*`: they're browser-only directives with no effect on programmatic consumers.

## Report-only, not enforced

The CSP ships as `Content-Security-Policy-Report-Only` — violations are reported to Sentry **without blocking anything**, so coverage can be validated against real traffic first. Moving to enforcement is a separate task, documented in-code: generate a per-request nonce in `middleware.ts`, thread it through `<Script>` / inline `<style>`, drop `'unsafe-inline'`, keep `connect-src`/`img-src` in sync, then rename the header to `Content-Security-Policy`.

## Verification

Verified live against a local dev server: page routes carry the full CSP + HSTS + `X-Frame-Options: DENY`; `/api/*` carries only the four baseline headers (no HSTS, no CSP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)