### PR TITLE
fix(web): value LP store reward by quantity, not as a single unit

### DIFF
--- a/.changeset/lp-store-reward-quantity.md
+++ b/.changeset/lp-store-reward-quantity.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed LP Store prices for offers that grant more than one item (most ammunition, sold in lots of up to 5000). These offers were valued as if you received a single unit, so their Jita price, profit, and ISK/LP all came out far too low — often deeply negative — making genuinely profitable offers look like guaranteed losses and sinking them to the bottom when sorting by ISK/LP. The reward is now valued as the full stack you receive.

--- a/apps/web/components/LPStore/LoyaltyPointsTable.tsx
+++ b/apps/web/components/LPStore/LoyaltyPointsTable.tsx
@@ -4,7 +4,6 @@ import { memo, useMemo } from "react";
 import { Group, Stack, Text, Tooltip } from "@mantine/core";
 
 import type { DataTableColumn } from "@jitaspace/datatable";
-import type { FuzzworkTypeMarketAggregate } from "@jitaspace/hooks";
 import {
   CorporationName,
   TypeAnchor,
@@ -18,9 +17,22 @@ import {
   TypeAvatar,
 } from "@jitaspace/ui";
 
+import type { AugmentedOffer } from "./pricing";
 import { DataTable } from "~/components/DataTable";
 import { usePreferencesStore } from "~/lib/preferences";
 import { LoyaltyPointsTableClassic } from "./LoyaltyPointsTableClassic";
+import {
+  buyIskPerLp,
+  buyProfit,
+  requiredItemsBuyCost,
+  requiredItemsSellCost,
+  requiredItemsSplitCost,
+  rewardBuyValue,
+  rewardSellValue,
+  rewardSplitValue,
+  sellIskPerLp,
+  sellProfit,
+} from "./pricing";
 
 interface LoyaltyPointsTableProps {
   corporations: {
@@ -46,45 +58,7 @@ interface LoyaltyPointsTableProps {
   }[];
 }
 
-type AugmentedOffer = {
-  offerId: number;
-  corporationId: number;
-  typeId: number;
-  quantity: number;
-  akCost: number | null;
-  lpCost: number;
-  iskCost: number;
-  requiredItems: {
-    typeId: number;
-    quantity: number;
-    marketStats?: FuzzworkTypeMarketAggregate;
-  }[];
-  typeName: string | undefined;
-  corporationName: string | undefined;
-  marketStats?: FuzzworkTypeMarketAggregate;
-};
-
 type LpColumn = DataTableColumn<AugmentedOffer>;
-
-// ---------------------------------------------------------------------------
-// Derived-value helpers used in multiple accessors
-// ---------------------------------------------------------------------------
-
-function requiredItemsSellCost(row: AugmentedOffer): number {
-  return row.requiredItems
-    .map(
-      (item) => (item.marketStats?.sell.percentile ?? 0) * (item.quantity ?? 1),
-    )
-    .reduce((a, b) => a + b, 0);
-}
-
-function requiredItemsBuyCost(row: AugmentedOffer): number {
-  return row.requiredItems
-    .map(
-      (item) => (item.marketStats?.buy.percentile ?? 0) * (item.quantity ?? 1),
-    )
-    .reduce((a, b) => a + b, 0);
-}
 
 // ---------------------------------------------------------------------------
 // Shared cell renderers — agnostic signature: (row, value) => ReactNode
@@ -360,7 +334,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jita5psell",
           header: "Jita 5% Sell Price",
-          accessor: (row) => row.marketStats?.sell.percentile,
+          accessor: rewardSellValue,
           sortable: true,
           defaultVisible: false,
           align: "right",
@@ -385,9 +359,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jita5psellprofit",
           header: "Jita 5% Sell Profit",
-          accessor: (row) =>
-            (row.marketStats?.sell.percentile ?? 0) -
-            requiredItemsSellCost(row),
+          accessor: sellProfit,
           sortable: true,
           defaultVisible: false,
           align: "right",
@@ -396,13 +368,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jita5psellisklp",
           header: "Jita 5% Sell ISK/LP",
-          accessor: (row) =>
-            row.lpCost > 0
-              ? ((row.marketStats?.sell.percentile ?? 0) -
-                  (row.iskCost ?? 0) -
-                  requiredItemsSellCost(row)) /
-                row.lpCost
-              : undefined,
+          accessor: sellIskPerLp,
           sortable: true,
           align: "right",
           cell: iskPerLpCell,
@@ -410,7 +376,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jita5pbuy",
           header: "Jita 5% Buy Price",
-          accessor: (row) => row.marketStats?.buy.percentile,
+          accessor: rewardBuyValue,
           sortable: true,
           defaultVisible: false,
           align: "right",
@@ -436,8 +402,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jita5pbuyprofit",
           header: "Jita 5% Buy Profit",
-          accessor: (row) =>
-            (row.marketStats?.buy.percentile ?? 0) - requiredItemsBuyCost(row),
+          accessor: buyProfit,
           sortable: true,
           defaultVisible: false,
           align: "right",
@@ -446,13 +411,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jita5pbuyisklp",
           header: "Jita 5% Buy ISK/LP",
-          accessor: (row) =>
-            row.lpCost > 0
-              ? ((row.marketStats?.buy.percentile ?? 0) -
-                  (row.iskCost ?? 0) -
-                  requiredItemsBuyCost(row)) /
-                row.lpCost
-              : undefined,
+          accessor: buyIskPerLp,
           sortable: true,
           align: "right",
           cell: iskPerLpCell,
@@ -460,12 +419,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "jitasplit",
           header: "Jita Split",
-          accessor: (row) =>
-            row.marketStats?.buy && row.marketStats?.sell
-              ? (row.marketStats.buy.percentile +
-                  row.marketStats.sell.percentile) /
-                2
-              : undefined,
+          accessor: rewardSplitValue,
           sortable: true,
           defaultVisible: false,
           align: "right",
@@ -474,16 +428,7 @@ const LoyaltyPointsTableExperimental = memo(
         {
           id: "reqitemsjitasplit",
           header: "Required Items Jita 5% Split",
-          accessor: (row) =>
-            row.requiredItems
-              .map(
-                (item) =>
-                  (((item.marketStats?.buy.percentile ?? 0) +
-                    (item.marketStats?.sell.percentile ?? 0)) /
-                    2) *
-                  (item.quantity ?? 1),
-              )
-              .reduce((a, b) => a + b, 0),
+          accessor: requiredItemsSplitCost,
           sortable: true,
           defaultVisible: false,
           align: "right",

--- a/apps/web/components/LPStore/LoyaltyPointsTableClassic.tsx
+++ b/apps/web/components/LPStore/LoyaltyPointsTableClassic.tsx
@@ -10,7 +10,6 @@ import { memo, useMemo } from "react";
 import { Group, Stack, Text, Tooltip } from "@mantine/core";
 import { MantineReactTable, useMantineReactTable } from "mantine-react-table";
 
-import type { FuzzworkTypeMarketAggregate } from "@jitaspace/hooks";
 import {
   CorporationName,
   EveEntitySelect,
@@ -24,6 +23,20 @@ import {
   ISKAmount,
   TypeAvatar,
 } from "@jitaspace/ui";
+
+import type { AugmentedOffer } from "./pricing";
+import {
+  buyIskPerLp,
+  buyProfit,
+  requiredItemsBuyCost,
+  requiredItemsSellCost,
+  requiredItemsSplitCost,
+  rewardBuyValue,
+  rewardSellValue,
+  rewardSplitValue,
+  sellIskPerLp,
+  sellProfit,
+} from "./pricing";
 
 interface LoyaltyPointsTableProps {
   corporations: {
@@ -48,24 +61,6 @@ interface LoyaltyPointsTableProps {
     }[];
   }[];
 }
-
-type AugmentedOffer = {
-  offerId: number;
-  corporationId: number;
-  typeId: number;
-  quantity: number;
-  akCost: number | null;
-  lpCost: number;
-  iskCost: number;
-  requiredItems: {
-    typeId: number;
-    quantity: number;
-    marketStats?: FuzzworkTypeMarketAggregate;
-  }[];
-  typeName: string | undefined;
-  corporationName: string | undefined;
-  marketStats?: FuzzworkTypeMarketAggregate;
-};
 
 // ---------------------------------------------------------------------------
 // Filter renderers (factories closing over the sorted option lists)
@@ -461,7 +456,7 @@ export const LoyaltyPointsTableClassic = memo(
         {
           id: "jita5psell",
           header: "Jita 5% Sell Price",
-          accessorKey: "marketStats.sell.percentile",
+          accessorFn: rewardSellValue,
           size: 10,
           Cell: iskAmountValueCell,
         },
@@ -477,54 +472,27 @@ export const LoyaltyPointsTableClassic = memo(
           id: "reqitemsjita5psell",
           header: "Required Items Jita 5% Sell",
           size: 10,
-          accessorFn: (row) =>
-            row.requiredItems
-              .map(
-                (item) =>
-                  (item.marketStats?.sell.percentile ?? 0) *
-                  (item.quantity ?? 1),
-              )
-              .reduce((a, b) => a + b, 0),
+          accessorFn: requiredItemsSellCost,
           Cell: iskAmountValueCell,
         },
         {
           id: "jita5psellprofit",
           header: "Jita 5% Sell Profit",
           size: 10,
-          accessorFn: (row) =>
-            (row.marketStats?.sell.percentile ?? 0) -
-            row.requiredItems
-              .map(
-                (item) =>
-                  (item.marketStats?.sell.percentile ?? 0) *
-                  (item.quantity ?? 1),
-              )
-              .reduce((a, b) => a + b, 0),
+          accessorFn: sellProfit,
           Cell: iskAmountValueCell,
         },
         {
           id: "jita5psellisklp",
           header: "Jita 5% Sell ISK/LP",
           size: 10,
-          accessorFn: (row) =>
-            row.lpCost > 0
-              ? ((row.marketStats?.sell.percentile ?? 0) -
-                  (row.iskCost ?? 0) -
-                  row.requiredItems
-                    .map(
-                      (item) =>
-                        (item.marketStats?.sell.percentile ?? 0) *
-                        (item.quantity ?? 1),
-                    )
-                    .reduce((a, b) => a + b, 0)) /
-                row.lpCost
-              : undefined,
+          accessorFn: sellIskPerLp,
           Cell: iskPerLpValueCell,
         },
         {
           id: "jita5pbuy",
           header: "Jita 5% Buy Price",
-          accessorKey: "marketStats.buy.percentile",
+          accessorFn: rewardBuyValue,
           size: 10,
           Cell: iskAmountValueCell,
         },
@@ -540,76 +508,35 @@ export const LoyaltyPointsTableClassic = memo(
           id: "reqitemsjita5pbuy",
           header: "Required Items Jita 5% Buy",
           size: 10,
-          accessorFn: (row) =>
-            row.requiredItems
-              .map(
-                (item) =>
-                  (item.marketStats?.buy.percentile ?? 0) *
-                  (item.quantity ?? 1),
-              )
-              .reduce((a, b) => a + b, 0),
+          accessorFn: requiredItemsBuyCost,
           Cell: iskAmountValueCell,
         },
         {
           id: "jita5pbuyprofit",
           header: "Jita 5% Buy Profit",
           size: 10,
-          accessorFn: (row) =>
-            (row.marketStats?.buy.percentile ?? 0) -
-            row.requiredItems
-              .map(
-                (item) =>
-                  (item.marketStats?.buy.percentile ?? 0) *
-                  (item.quantity ?? 1),
-              )
-              .reduce((a, b) => a + b, 0),
+          accessorFn: buyProfit,
           Cell: iskAmountValueCell,
         },
         {
           id: "jita5pbuyisklp",
           header: "Jita 5% Buy ISK/LP",
           size: 10,
-          accessorFn: (row) =>
-            row.lpCost > 0
-              ? ((row.marketStats?.buy.percentile ?? 0) -
-                  (row.iskCost ?? 0) -
-                  row.requiredItems
-                    .map(
-                      (item) =>
-                        (item.marketStats?.buy.percentile ?? 0) *
-                        (item.quantity ?? 1),
-                    )
-                    .reduce((a, b) => a + b, 0)) /
-                row.lpCost
-              : undefined,
+          accessorFn: buyIskPerLp,
           Cell: iskPerLpValueCell,
         },
         {
           id: "jitasplit",
           header: "Jita Split",
           size: 10,
-          accessorFn: (row) =>
-            row.marketStats?.buy && row.marketStats?.sell
-              ? (row.marketStats.buy.percentile +
-                  row.marketStats.sell.percentile) /
-                2
-              : null,
+          accessorFn: rewardSplitValue,
           Cell: iskAmountValueCell,
         },
         {
           id: "reqitemsjitasplit",
           header: "Required Items Jita 5% Split",
           size: 10,
-          accessorFn: (row) =>
-            row.requiredItems
-              .map(
-                (item) =>
-                  (((item.marketStats?.buy.percentile ?? 0) +
-                    (item.marketStats?.sell.percentile ?? 0)) /
-                    2) *
-                  (item.quantity ?? 1),
-              )
-              .reduce((a, b) => a + b, 0),
+          accessorFn: requiredItemsSplitCost,
           Cell: iskAmountValueCell,
         },
       ],

--- a/apps/web/components/LPStore/pricing.ts
+++ b/apps/web/components/LPStore/pricing.ts
@@ -1,0 +1,128 @@
+import type { FuzzworkTypeMarketAggregate } from "@jitaspace/hooks";
+
+/**
+ * An LP store offer augmented with Jita market aggregates for its reward item
+ * and each of its required items.
+ */
+export interface AugmentedOffer {
+  offerId: number;
+  corporationId: number;
+  typeId: number;
+  quantity: number;
+  akCost: number | null;
+  lpCost: number;
+  iskCost: number;
+  requiredItems: {
+    typeId: number;
+    quantity: number;
+    marketStats?: FuzzworkTypeMarketAggregate;
+  }[];
+  typeName: string | undefined;
+  corporationName: string | undefined;
+  marketStats?: FuzzworkTypeMarketAggregate;
+}
+
+// ---------------------------------------------------------------------------
+// Reward value
+//
+// An offer grants `quantity` units of the reward item, so the value of what you
+// receive is the per-unit Jita price times the quantity. Forgetting to multiply
+// by the quantity made every multi-unit offer — most notably ammunition, which
+// is sold in lots of up to 5000 — look like a guaranteed loss, because the
+// required items WERE priced per-unit × quantity while the reward was counted as
+// a single unit. The reward value is `undefined` (not 0) when the item is
+// unpriced, so price columns render blank rather than "0 ISK".
+// ---------------------------------------------------------------------------
+
+export function rewardSellValue(offer: AugmentedOffer): number | undefined {
+  return offer.marketStats === undefined
+    ? undefined
+    : offer.marketStats.sell.percentile * offer.quantity;
+}
+
+export function rewardBuyValue(offer: AugmentedOffer): number | undefined {
+  return offer.marketStats === undefined
+    ? undefined
+    : offer.marketStats.buy.percentile * offer.quantity;
+}
+
+export function rewardSplitValue(offer: AugmentedOffer): number | undefined {
+  return offer.marketStats === undefined
+    ? undefined
+    : ((offer.marketStats.buy.percentile + offer.marketStats.sell.percentile) /
+        2) *
+        offer.quantity;
+}
+
+// ---------------------------------------------------------------------------
+// Required-items cost — the market value of the items you must hand in, each
+// priced per-unit × quantity. Unpriced items contribute 0.
+// ---------------------------------------------------------------------------
+
+export function requiredItemsSellCost(offer: AugmentedOffer): number {
+  return offer.requiredItems.reduce(
+    (sum, item) =>
+      sum + (item.marketStats?.sell.percentile ?? 0) * item.quantity,
+    0,
+  );
+}
+
+export function requiredItemsBuyCost(offer: AugmentedOffer): number {
+  return offer.requiredItems.reduce(
+    (sum, item) =>
+      sum + (item.marketStats?.buy.percentile ?? 0) * item.quantity,
+    0,
+  );
+}
+
+export function requiredItemsSplitCost(offer: AugmentedOffer): number {
+  return offer.requiredItems.reduce(
+    (sum, item) =>
+      sum +
+      (((item.marketStats?.buy.percentile ?? 0) +
+        (item.marketStats?.sell.percentile ?? 0)) /
+        2) *
+        item.quantity,
+    0,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Profit — reward value minus the cost of the required items, valued on the
+// same side of the order book.
+// ---------------------------------------------------------------------------
+
+export function sellProfit(offer: AugmentedOffer): number {
+  return (rewardSellValue(offer) ?? 0) - requiredItemsSellCost(offer);
+}
+
+export function buyProfit(offer: AugmentedOffer): number {
+  return (rewardBuyValue(offer) ?? 0) - requiredItemsBuyCost(offer);
+}
+
+// ---------------------------------------------------------------------------
+// ISK per loyalty point — the net ISK gained (reward value minus ISK cost and
+// required items) divided by the LP spent. Returns `undefined` for offers with
+// no LP cost (e.g. item-exchange offers) so the column stays blank instead of
+// dividing by zero into Infinity.
+// ---------------------------------------------------------------------------
+
+export function sellIskPerLp(offer: AugmentedOffer): number | undefined {
+  if (offer.lpCost <= 0) return undefined;
+  return (
+    ((rewardSellValue(offer) ?? 0) -
+      offer.iskCost -
+      requiredItemsSellCost(offer)) /
+    offer.lpCost
+  );
+}
+
+export function buyIskPerLp(offer: AugmentedOffer): number | undefined {
+  if (offer.lpCost <= 0) return undefined;
+  return (
+    ((rewardBuyValue(offer) ?? 0) -
+      offer.iskCost -
+      requiredItemsBuyCost(offer)) /
+    offer.lpCost
+  );
+}

--- a/apps/web/tests/lpStorePricing.test.ts
+++ b/apps/web/tests/lpStorePricing.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { FuzzworkTypeMarketAggregate } from "@jitaspace/hooks";
+
+import type { AugmentedOffer } from "../components/LPStore/pricing";
+import {
+  buyIskPerLp,
+  buyProfit,
+  requiredItemsBuyCost,
+  requiredItemsSellCost,
+  requiredItemsSplitCost,
+  rewardBuyValue,
+  rewardSellValue,
+  rewardSplitValue,
+  sellIskPerLp,
+  sellProfit,
+} from "../components/LPStore/pricing";
+
+// Minimal aggregate where only the buy/sell percentile matters to the pricing
+// helpers; the remaining stats are filled with the same value for brevity.
+function stats(buy: number, sell: number): FuzzworkTypeMarketAggregate {
+  const side = (percentile: number) => ({
+    percentile,
+    volume: 0,
+    weightedAverage: percentile,
+    max: percentile,
+    stddev: 0,
+    median: percentile,
+    orderCount: 0,
+  });
+  return { buy: side(buy), sell: side(sell) };
+}
+
+function offer(overrides: Partial<AugmentedOffer> = {}): AugmentedOffer {
+  return {
+    offerId: 1,
+    corporationId: 1,
+    typeId: 100,
+    quantity: 1,
+    akCost: null,
+    lpCost: 100,
+    iskCost: 50,
+    requiredItems: [],
+    typeName: "Reward",
+    corporationName: "Corp",
+    marketStats: undefined,
+    ...overrides,
+  };
+}
+
+describe("LP store pricing — reward value accounts for quantity", () => {
+  it("prices a single-unit reward at the unit price", () => {
+    const o = offer({ quantity: 1, marketStats: stats(1000, 1200) });
+    expect(rewardSellValue(o)).toBe(1200);
+    expect(rewardBuyValue(o)).toBe(1000);
+    expect(rewardSplitValue(o)).toBe(1100);
+  });
+
+  it("multiplies the reward value by the quantity granted", () => {
+    const o = offer({ quantity: 5000, marketStats: stats(2025, 2100) });
+    // The headline bug: a 5000-unit ammo stack must be valued as 5000 × unit,
+    // not as a single unit.
+    expect(rewardSellValue(o)).toBe(2100 * 5000);
+    expect(rewardBuyValue(o)).toBe(2025 * 5000);
+    expect(rewardSplitValue(o)).toBe(((2025 + 2100) / 2) * 5000);
+  });
+
+  it("returns undefined when the reward is unpriced", () => {
+    const o = offer({ quantity: 10, marketStats: undefined });
+    expect(rewardSellValue(o)).toBeUndefined();
+    expect(rewardBuyValue(o)).toBeUndefined();
+    expect(rewardSplitValue(o)).toBeUndefined();
+  });
+});
+
+describe("LP store pricing — required items priced per-unit × quantity", () => {
+  it("sums each required item's price times its quantity", () => {
+    const o = offer({
+      requiredItems: [
+        { typeId: 200, quantity: 2, marketStats: stats(10, 20) },
+        { typeId: 300, quantity: 3, marketStats: stats(100, 200) },
+      ],
+    });
+    expect(requiredItemsSellCost(o)).toBe(20 * 2 + 200 * 3);
+    expect(requiredItemsBuyCost(o)).toBe(10 * 2 + 100 * 3);
+    expect(requiredItemsSplitCost(o)).toBe(15 * 2 + 150 * 3);
+  });
+
+  it("treats unpriced required items as zero cost", () => {
+    const o = offer({
+      requiredItems: [{ typeId: 200, quantity: 5, marketStats: undefined }],
+    });
+    expect(requiredItemsSellCost(o)).toBe(0);
+    expect(requiredItemsBuyCost(o)).toBe(0);
+    expect(requiredItemsSplitCost(o)).toBe(0);
+  });
+});
+
+describe("LP store pricing — profit and ISK/LP", () => {
+  it("computes profit as reward stack value minus required-items cost", () => {
+    const o = offer({
+      quantity: 5,
+      marketStats: stats(1000, 1200),
+      requiredItems: [{ typeId: 200, quantity: 2, marketStats: stats(10, 20) }],
+    });
+    expect(sellProfit(o)).toBe(1200 * 5 - 20 * 2);
+    expect(buyProfit(o)).toBe(1000 * 5 - 10 * 2);
+  });
+
+  it("turns a multi-unit ammo offer profitable once quantity is applied", () => {
+    // Real Caldari Navy shape (offer 3587): 5000× reward, 5500 LP, 5.5M ISK,
+    // 5000× base charge required. Pre-fix this evaluated to ~ -1,402 ISK/LP.
+    const o = offer({
+      quantity: 5000,
+      lpCost: 5500,
+      iskCost: 5_500_000,
+      marketStats: stats(2025, 2100),
+      requiredItems: [
+        { typeId: 2506, quantity: 5000, marketStats: stats(360, 442) },
+      ],
+    });
+    const expected = (2100 * 5000 - 5_500_000 - 442 * 5000) / 5500;
+    expect(sellIskPerLp(o)).toBeCloseTo(expected, 6);
+    expect(sellIskPerLp(o)).toBeGreaterThan(0);
+  });
+
+  it("computes sell and buy ISK/LP net of ISK cost and required items", () => {
+    const o = offer({
+      quantity: 1,
+      lpCost: 100,
+      iskCost: 50,
+      marketStats: stats(1000, 1200),
+      requiredItems: [{ typeId: 200, quantity: 2, marketStats: stats(10, 20) }],
+    });
+    expect(sellIskPerLp(o)).toBeCloseTo((1200 - 50 - 20 * 2) / 100, 6);
+    expect(buyIskPerLp(o)).toBeCloseTo((1000 - 50 - 10 * 2) / 100, 6);
+  });
+
+  it("returns undefined ISK/LP for zero-LP (item-exchange) offers", () => {
+    const o = offer({ lpCost: 0, marketStats: stats(1000, 1200) });
+    expect(sellIskPerLp(o)).toBeUndefined();
+    expect(buyIskPerLp(o)).toBeUndefined();
+  });
+
+  it("falls back to zero reward value when unpriced", () => {
+    const o = offer({ lpCost: 100, iskCost: 50, marketStats: undefined });
+    expect(sellProfit(o)).toBe(0);
+    expect(buyProfit(o)).toBe(0);
+    expect(sellIskPerLp(o)).toBeCloseTo(-50 / 100, 6);
+  });
+});


### PR DESCRIPTION
## The bug

The LP Store priced every **multi-quantity** offer as if you received a **single unit** of the reward, even though the *required* items you hand in were correctly priced per-unit × quantity. The value math therefore compared 1 unit received against (e.g.) 5,000 units paid.

Multi-quantity offers are pervasive — ~10–17% of each NPC corp's catalog, almost all ammunition sold in lots of 5/10/…/5000.

### Concrete example — Caldari Navy offer 3587
5,000× Antimatter Charge for 5,500 LP + 5.5M ISK + 5,000× base charge (verified against live ESI + Fuzzwork Jita prices):

| Column | Before | After (correct) |
|---|---|---|
| Jita 5% Sell Price | 2,100 ISK (1 charge) | 10,500,000 ISK (5,000 charges) |
| Jita 5% Sell **ISK/LP** | **−1,402** (looks like a loss) | **+507** (profitable) |

Sorting by ISK/LP — the whole point of the page — pushed these offers to the bottom with meaningless negative values, hiding genuinely good ones. Quantity = 1 offers were unaffected, so nothing looked wrong under the default Offer-ID sort.

## The fix

The reward value never got multiplied by `offer.quantity`. The pricing math was also **duplicated and already divergent** across the two table implementations (`LoyaltyPointsTable` experimental + `LoyaltyPointsTableClassic`), which is how the bug hid in plain sight.

- Extracted all the pricing formulas into a single, pure, unit-tested module: `apps/web/components/LPStore/pricing.ts`.
- The reward is now valued as `unit price × quantity` for the **Sell/Buy Price**, **Profit**, **ISK/LP**, and **Jita Split** columns, on both the buy and sell sides.
- Both tables now consume the same helpers via bare-reference accessors, so they can't drift again.
- Required-items costs and the `lpCost = 0` divide-by-zero guard are unchanged (already correct).

## Verification

- New pure unit test `apps/web/tests/lpStorePricing.test.ts` covers each helper, including the 5,000-unit ammo regression case (asserts it's now profitable) and the zero-LP guard.
- Existing `LoyaltyPointsTable.test.tsx` render tests (both engines) still pass — **40/40** LP-related tests green.
- `pnpm type-check` clean for the changed files; new files lint-clean.
- The numbers above were validated by running the code's exact formula against live public ESI (`/loyalty/stores/…/offers/`) + Fuzzwork aggregates — no DB access needed.

User-facing changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)