### PR TITLE
feat(web): add database dashboard to status page

### DIFF
--- a/.changeset/status-database-dashboard.md
+++ b/.changeset/status-database-dashboard.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Added a Database dashboard to the Server Status page showing the estimated number of records in every table, refreshed every few minutes.

--- a/apps/web/app/status/actions.ts
+++ b/apps/web/app/status/actions.ts
@@ -1,11 +1,17 @@
 "use server";
 
+import type { DatabaseStatusResponse } from "~/lib/databaseStatus";
 import type {
   InngestApiEvent,
   InngestStatusResponse,
 } from "~/lib/inngestStatus";
 import type { TriggerApiRun, TriggerStatusResponse } from "~/lib/triggerStatus";
+import { prisma } from "~/lib/db";
 import { env } from "~/env";
+import {
+  buildDatabaseStatusResponse,
+  DATABASE_STATUS_STALE_MINUTES,
+} from "~/lib/databaseStatus";
 import {
   buildInngestStatusResponse,
   collectTerminalRuns,
@@ -233,4 +239,83 @@ export async function getTriggerStatus(): Promise<TriggerStatusResponse> {
     };
   }
   return triggerCache.payload;
+}
+
+// ---------------------------------------------------------------------------
+// Database status
+//
+// Reports the estimated row count of every table in the connected database for
+// the status-page dashboard. The Prisma client must never reach the client;
+// this function only returns aggregated, plain-number counts. Responses are
+// cached for a few minutes so status-page polling does not hit the database on
+// every load.
+// ---------------------------------------------------------------------------
+
+const DATABASE_CACHE_TTL_MS = DATABASE_STATUS_STALE_MINUTES * 60 * 1000;
+
+/** A row-count estimate for one base table. */
+interface TableRowStatistic {
+  table_name: string;
+  // The pg adapter returns CockroachDB INT8 as a string to avoid precision
+  // loss; bigint/number are tolerated too, and the LEFT JOIN yields null for a
+  // table with no statistics yet. `Number(... ?? 0)` normalizes all of these.
+  estimated_row_count: string | number | bigint | null;
+}
+
+let databaseCache: {
+  expiresAt: number;
+  payload: DatabaseStatusResponse;
+} | null = null;
+
+const computeDatabaseStatus = async (): Promise<DatabaseStatusResponse> => {
+  const fetchedAt = new Date();
+
+  try {
+    // CockroachDB exposes cheap, pre-computed row-count estimates from the
+    // latest automatic table statistics. We deliberately use these instead of
+    // a `SELECT count(*)` per table: an exact count would full-scan every
+    // table (some with millions of rows) on the production cluster on every
+    // cache miss. The estimates are refreshed automatically and are plenty for
+    // a status dashboard (this is what CockroachDB's own DB Console shows).
+    //
+    // `crdb_internal.table_row_statistics` is cluster-wide, so we join against
+    // `crdb_internal.tables` and scope to the connected database's public
+    // schema to list exactly our application's tables. The LEFT JOIN keeps
+    // tables that have no statistics yet (estimate comes back null → 0).
+    const rows = await prisma.$queryRaw<TableRowStatistic[]>`
+      SELECT t.name AS table_name, s.estimated_row_count AS estimated_row_count
+      FROM crdb_internal.tables AS t
+      LEFT JOIN crdb_internal.table_row_statistics AS s ON s.table_id = t.table_id
+      WHERE t.database_name = current_database()
+        AND t.schema_name = 'public'
+        AND t.state = 'PUBLIC'
+    `;
+
+    return buildDatabaseStatusResponse({
+      rows: rows.map((row) => ({
+        name: row.table_name,
+        rowCount: Number(row.estimated_row_count ?? 0),
+      })),
+      fetchedAt,
+    });
+  } catch (error) {
+    return buildDatabaseStatusResponse({
+      rows: [],
+      fetchedAt,
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+};
+
+export async function getDatabaseStatus(): Promise<DatabaseStatusResponse> {
+  if (!databaseCache || Date.now() >= databaseCache.expiresAt) {
+    const payload = await computeDatabaseStatus();
+    databaseCache = {
+      payload,
+      expiresAt:
+        Date.now() +
+        (payload.error ? ERROR_CACHE_TTL_MS : DATABASE_CACHE_TTL_MS),
+    };
+  }
+  return databaseCache.payload;
 }

--- a/apps/web/app/status/page.client.tsx
+++ b/apps/web/app/status/page.client.tsx
@@ -35,6 +35,7 @@ import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
 
 import type { SdeLastModifiedResponse, VercelStatusResponse } from "./types";
 import { env } from "~/env";
+import { DatabaseDashboard } from "../../components/Status/DatabaseDashboard";
 import { EsiRateLimitDashboard } from "../../components/Status/EsiRateLimitDashboard";
 import { EsiStatusDashboard } from "../../components/Status/EsiStatusDashboard";
 import { InngestJobsDashboard } from "../../components/Status/InngestJobsDashboard";
@@ -302,6 +303,8 @@ export default function StatusPage({
         <InngestJobsDashboard />
 
         <TriggerJobsDashboard />
+
+        <DatabaseDashboard />
 
         <EsiRateLimitDashboard />
       </Stack>

--- a/apps/web/components/Status/DatabaseDashboard.tsx
+++ b/apps/web/components/Status/DatabaseDashboard.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Alert,
+  Badge,
+  Group,
+  Loader,
+  Paper,
+  ScrollArea,
+  SimpleGrid,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from "@mantine/core";
+import { IconAlertCircle, IconDatabase } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { DATABASE_STATUS_STALE_MINUTES } from "~/lib/databaseStatus";
+import { getDatabaseStatus } from "~/app/status/actions";
+
+const REFETCH_INTERVAL_MS = DATABASE_STATUS_STALE_MINUTES * 60 * 1000;
+
+export function DatabaseDashboard() {
+  const { data, error, isLoading } = useQuery({
+    // Data comes from a server function (app/status/actions.ts), not a public
+    // route — React Query invokes it like any async function. The server
+    // function caches for a few minutes, so this polling is cheap.
+    queryKey: ["database-status"],
+    queryFn: () => getDatabaseStatus(),
+    refetchInterval: REFETCH_INTERVAL_MS,
+    staleTime: REFETCH_INTERVAL_MS,
+  });
+
+  const nonEmptyTables = useMemo(
+    () => data?.tables.filter((table) => table.rowCount > 0).length ?? 0,
+    [data],
+  );
+
+  return (
+    <Stack gap="md">
+      <Group justify="space-between" align="flex-end">
+        <Stack gap={0}>
+          <Group gap="xs">
+            <IconDatabase size={20} />
+            <Title order={3}>Database</Title>
+          </Group>
+          <Text size="xs" c="dimmed">
+            Estimated record counts for every table, from CockroachDB table
+            statistics · cached for {DATABASE_STATUS_STALE_MINUTES} minutes
+          </Text>
+        </Stack>
+        {data && !data.error && (
+          <Badge color="blue" variant="light">
+            {data.totals.rows.toLocaleString()} records
+          </Badge>
+        )}
+      </Group>
+
+      {isLoading && (
+        <Group justify="center" py="xl">
+          <Loader size="sm" />
+        </Group>
+      )}
+
+      {error && (
+        <Alert
+          icon={<IconAlertCircle size="1rem" />}
+          color="red"
+          variant="light"
+        >
+          Failed to load database status: {error.message}
+        </Alert>
+      )}
+
+      {data?.error && (
+        <Alert
+          icon={<IconAlertCircle size="1rem" />}
+          color="yellow"
+          variant="light"
+        >
+          Database status is currently unavailable: {data.error}
+        </Alert>
+      )}
+
+      {data && !data.error && (
+        <>
+          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+            <Paper withBorder p="md" shadow="xs">
+              <Text size="xs" c="dimmed">
+                Tables
+              </Text>
+              <Text size="xl" fw={700}>
+                {data.totals.tables.toLocaleString()}
+              </Text>
+              <Text size="xs" c="dimmed">
+                {nonEmptyTables.toLocaleString()} with records
+              </Text>
+            </Paper>
+
+            <Paper withBorder p="md" shadow="xs">
+              <Text size="xs" c="dimmed">
+                Total Records
+              </Text>
+              <Text size="xl" fw={700}>
+                {data.totals.rows.toLocaleString()}
+              </Text>
+              <Text size="xs" c="dimmed">
+                estimated across all tables
+              </Text>
+            </Paper>
+
+            <Paper withBorder p="md" shadow="xs">
+              <Text size="xs" c="dimmed">
+                Largest Table
+              </Text>
+              <Text size="xl" fw={700}>
+                {data.tables[0]?.rowCount.toLocaleString() ?? "0"}
+              </Text>
+              <Text size="xs" c="dimmed" truncate>
+                {data.tables[0]?.label ?? "-"}
+              </Text>
+            </Paper>
+          </SimpleGrid>
+
+          {data.tables.length === 0 ? (
+            <Alert
+              icon={<IconAlertCircle size="1rem" />}
+              color="gray"
+              variant="light"
+            >
+              No tables were reported by the database.
+            </Alert>
+          ) : (
+            <ScrollArea.Autosize mah={480}>
+              <Table
+                withTableBorder
+                striped
+                highlightOnHover
+                stickyHeader
+                verticalSpacing="xs"
+                fz="sm"
+              >
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Table</Table.Th>
+                    <Table.Th ta="right">Records</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {data.tables.map((table) => (
+                    <Table.Tr key={table.name}>
+                      <Table.Td>
+                        <Text size="sm" fw={600}>
+                          {table.label}
+                        </Text>
+                        <Text size="xs" c="dimmed">
+                          {table.name}
+                        </Text>
+                      </Table.Td>
+                      <Table.Td ta="right">
+                        <Badge
+                          variant="light"
+                          color={table.rowCount > 0 ? "blue" : "gray"}
+                        >
+                          {table.rowCount.toLocaleString()}
+                        </Badge>
+                      </Table.Td>
+                    </Table.Tr>
+                  ))}
+                </Table.Tbody>
+              </Table>
+            </ScrollArea.Autosize>
+          )}
+
+          <Text size="xs" c="dimmed">
+            Updated {new Date(data.fetchedAt).toLocaleTimeString()} · approximate
+            counts from table statistics · refreshes every{" "}
+            {DATABASE_STATUS_STALE_MINUTES} minutes
+          </Text>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/apps/web/lib/databaseStatus.ts
+++ b/apps/web/lib/databaseStatus.ts
@@ -1,0 +1,118 @@
+/**
+ * Types and pure aggregation logic for the database status server function
+ * (`app/status/actions.ts`) and the status-page dashboard.
+ *
+ * The counts are CockroachDB's estimated row counts (read from the latest
+ * table statistics via `crdb_internal.table_row_statistics`), not exact
+ * `count(*)` results — see `getDatabaseStatus` for why. This module only
+ * shapes/aggregates the rows; the actual query lives in the server function.
+ *
+ * Keep this module free of server-only imports — client components import
+ * types and constants from it.
+ */
+
+/**
+ * How long a database snapshot is cached server-side (and effectively how
+ * stale the dashboard may be). The request asked for "stale for a few
+ * minutes"; CockroachDB's statistics themselves only refresh periodically, so
+ * a shorter window would not buy fresher numbers anyway.
+ */
+export const DATABASE_STATUS_STALE_MINUTES = 5;
+
+export interface DatabaseTableStat {
+  /** Physical table name (equals the Prisma model name — no `@@map` is used). */
+  name: string;
+  /** Human-friendly label derived from the table name. */
+  label: string;
+  /** Estimated number of rows, from CockroachDB table statistics. */
+  rowCount: number;
+}
+
+export interface DatabaseStatusResponse {
+  fetchedAt: string;
+  /** Server-side cache window, in minutes. */
+  staleMinutes: number;
+  /**
+   * The counts are always estimates from table statistics; kept explicit so
+   * the UI can label them honestly and so the meaning is obvious to callers.
+   */
+  approximate: boolean;
+  /** Set when the database could not be reached. */
+  error?: string;
+  /** All tables, sorted by descending row count. */
+  tables: DatabaseTableStat[];
+  totals: {
+    tables: number;
+    rows: number;
+  };
+}
+
+/** Acronyms that should stay upper-cased in humanized table labels. */
+const ACRONYMS: Record<string, string> = {
+  npc: "NPC",
+  esi: "ESI",
+  sde: "SDE",
+  id: "ID",
+  ids: "IDs",
+  url: "URL",
+};
+
+/**
+ * Turn a physical table name into a display label, e.g.
+ * `KillmailVictimItems` → "Killmail Victim Items",
+ * `NpcCorporationDivision` → "NPC Corporation Division",
+ * `_prisma_migrations` → "Prisma Migrations".
+ */
+export const humanizeTableName = (name: string): string => {
+  const words = name
+    .replace(/_/g, " ")
+    // split runs of capitals followed by a capital+lowercase: "IDList" → "ID List"
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    // split lowercase/digit → uppercase boundaries: "killmailVictim" → "killmail Victim"
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(" ")
+    .filter(Boolean);
+
+  return words
+    .map((word) => {
+      const acronym = ACRONYMS[word.toLowerCase()];
+      if (acronym) return acronym;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
+};
+
+export const buildDatabaseStatusResponse = ({
+  rows,
+  fetchedAt,
+  staleMinutes = DATABASE_STATUS_STALE_MINUTES,
+  error,
+}: {
+  rows: { name: string; rowCount: number }[];
+  fetchedAt: Date;
+  staleMinutes?: number;
+  error?: string;
+}): DatabaseStatusResponse => {
+  const tables: DatabaseTableStat[] = rows
+    .map((row) => ({
+      name: row.name,
+      label: humanizeTableName(row.name),
+      // Guard against NaN/negative estimates so totals stay sane.
+      rowCount: Number.isFinite(row.rowCount) ? Math.max(0, row.rowCount) : 0,
+    }))
+    .sort((a, b) => b.rowCount - a.rowCount || a.name.localeCompare(b.name));
+
+  const rowsTotal = tables.reduce((sum, table) => sum + table.rowCount, 0);
+
+  return {
+    fetchedAt: fetchedAt.toISOString(),
+    staleMinutes,
+    approximate: true,
+    ...(error ? { error } : {}),
+    tables,
+    totals: {
+      tables: tables.length,
+      rows: rowsTotal,
+    },
+  };
+};

--- a/apps/web/tests/databaseDashboard.test.tsx
+++ b/apps/web/tests/databaseDashboard.test.tsx
@@ -1,0 +1,115 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+
+// Type-only import: erased at compile time, so it does not defeat the
+// jest.mock below the way a value import of the component would.
+import type * as DatabaseDashboardModule from "../components/Status/DatabaseDashboard";
+import type { DatabaseStatusResponse } from "~/lib/databaseStatus";
+
+const mockGetDatabaseStatus = jest.fn<() => Promise<DatabaseStatusResponse>>();
+
+// The dashboard gets its data from a server function; stub it. jest.mock is not
+// hoisted above static imports in this setup, so the component under test is
+// require()d lazily inside renderDashboard, like statusPage.test.tsx does.
+jest.mock("~/app/status/actions", () => ({
+  getDatabaseStatus: () => mockGetDatabaseStatus(),
+}));
+
+const statusFixture: DatabaseStatusResponse = {
+  fetchedAt: new Date(Date.UTC(2026, 5, 10, 12, 0, 0)).toISOString(),
+  staleMinutes: 5,
+  approximate: true,
+  tables: [
+    { name: "KillmailVictim", label: "Killmail Victim", rowCount: 1234567 },
+    { name: "MarketGroup", label: "Market Group", rowCount: 50000 },
+    { name: "SolarSystem", label: "Solar System", rowCount: 0 },
+  ],
+  totals: { tables: 3, rows: 1284567 },
+};
+
+function renderDashboard() {
+  const { DatabaseDashboard } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("../components/Status/DatabaseDashboard") as typeof DatabaseDashboardModule;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <DatabaseDashboard />
+      </QueryClientProvider>
+    </MantineProvider>,
+  );
+}
+
+describe("DatabaseDashboard", () => {
+  beforeEach(() => {
+    mockGetDatabaseStatus.mockReset();
+  });
+
+  it("renders table rows, counts and totals", async () => {
+    mockGetDatabaseStatus.mockResolvedValue(statusFixture);
+
+    renderDashboard();
+
+    // Wait for data to load (the title renders even while loading). The largest
+    // table's label appears both in its row and in the "Largest Table" card.
+    expect(
+      (await screen.findAllByText("Killmail Victim")).length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Database")).toBeInTheDocument();
+    expect(screen.getByText("Market Group")).toBeInTheDocument();
+    // Physical table name is shown beneath the humanized label.
+    expect(screen.getByText("KillmailVictim")).toBeInTheDocument();
+
+    // Largest-table count + total records (toLocaleString) appear.
+    expect(screen.getAllByText("1,234,567").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("1,284,567").length).toBeGreaterThanOrEqual(1);
+
+    // 2 of 3 tables have records.
+    expect(screen.getByText("2 with records")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when no tables are reported", async () => {
+    mockGetDatabaseStatus.mockResolvedValue({
+      ...statusFixture,
+      tables: [],
+      totals: { tables: 0, rows: 0 },
+    });
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText(/No tables were reported by the database/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a warning when the server function reports an upstream error", async () => {
+    mockGetDatabaseStatus.mockResolvedValue({
+      ...statusFixture,
+      error: "connection refused",
+    });
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText(/Database status is currently unavailable/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an error when the server function itself fails", async () => {
+    mockGetDatabaseStatus.mockRejectedValue(new Error("boom"));
+
+    renderDashboard();
+
+    expect(
+      await screen.findByText(/Failed to load database status/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/databaseStatus.test.ts
+++ b/apps/web/tests/databaseStatus.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ */
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  buildDatabaseStatusResponse,
+  DATABASE_STATUS_STALE_MINUTES,
+  humanizeTableName,
+} from "~/lib/databaseStatus";
+
+describe("humanizeTableName", () => {
+  it("splits PascalCase model names into words", () => {
+    expect(humanizeTableName("Character")).toBe("Character");
+    expect(humanizeTableName("CharacterCorporationMembership")).toBe(
+      "Character Corporation Membership",
+    );
+    expect(humanizeTableName("KillmailVictimItems")).toBe(
+      "Killmail Victim Items",
+    );
+  });
+
+  it("upper-cases known acronyms", () => {
+    expect(humanizeTableName("NpcCorporationDivision")).toBe(
+      "NPC Corporation Division",
+    );
+  });
+
+  it("handles snake_case / leading-underscore names", () => {
+    expect(humanizeTableName("_prisma_migrations")).toBe("Prisma Migrations");
+  });
+});
+
+describe("buildDatabaseStatusResponse", () => {
+  const fetchedAt = new Date(Date.UTC(2026, 5, 10, 8, 0, 0));
+
+  it("sorts tables by descending row count and computes totals", () => {
+    const response = buildDatabaseStatusResponse({
+      rows: [
+        { name: "Character", rowCount: 10 },
+        { name: "Type", rowCount: 500 },
+        { name: "Region", rowCount: 0 },
+      ],
+      fetchedAt,
+    });
+
+    expect(response.tables.map((table) => table.name)).toEqual([
+      "Type",
+      "Character",
+      "Region",
+    ]);
+    expect(response.tables[0]?.label).toBe("Type");
+    expect(response.totals.tables).toBe(3);
+    expect(response.totals.rows).toBe(510);
+    expect(response.approximate).toBe(true);
+    expect(response.staleMinutes).toBe(DATABASE_STATUS_STALE_MINUTES);
+    expect(response.fetchedAt).toBe(fetchedAt.toISOString());
+    expect(response.error).toBeUndefined();
+  });
+
+  it("breaks row-count ties by table name", () => {
+    const response = buildDatabaseStatusResponse({
+      rows: [
+        { name: "Beta", rowCount: 5 },
+        { name: "Alpha", rowCount: 5 },
+      ],
+      fetchedAt,
+    });
+    expect(response.tables.map((table) => table.name)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+  });
+
+  it("clamps non-finite or negative estimates to zero", () => {
+    const response = buildDatabaseStatusResponse({
+      rows: [
+        { name: "Bad", rowCount: Number.NaN },
+        { name: "Negative", rowCount: -7 },
+        { name: "Good", rowCount: 3 },
+      ],
+      fetchedAt,
+    });
+    expect(response.totals.rows).toBe(3);
+    expect(
+      response.tables.find((table) => table.name === "Bad")?.rowCount,
+    ).toBe(0);
+    expect(
+      response.tables.find((table) => table.name === "Negative")?.rowCount,
+    ).toBe(0);
+  });
+
+  it("returns an error payload with no tables", () => {
+    const response = buildDatabaseStatusResponse({
+      rows: [],
+      fetchedAt,
+      error: "connection refused",
+    });
+    expect(response.error).toBe("connection refused");
+    expect(response.tables).toEqual([]);
+    expect(response.totals).toEqual({ tables: 0, rows: 0 });
+  });
+});

--- a/apps/web/tests/statusPage.test.tsx
+++ b/apps/web/tests/statusPage.test.tsx
@@ -65,6 +65,10 @@ jest.mock("../components/Status/TriggerJobsDashboard", () => ({
   TriggerJobsDashboard: () => <div>Trigger Jobs Dashboard</div>,
 }));
 
+jest.mock("../components/Status/DatabaseDashboard", () => ({
+  DatabaseDashboard: () => <div>Database Dashboard</div>,
+}));
+
 jest.mock("next/link", () => ({
   __esModule: true,
   default: ({
@@ -166,6 +170,7 @@ describe("Status Page", () => {
     // Dashboards render
     expect(screen.getByText("Rate Limit Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Inngest Jobs Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Database Dashboard")).toBeInTheDocument();
   });
 
   it("renders outdated branches and partial ESI degradation", () => {


### PR DESCRIPTION
## What

Adds a **Database** dashboard to the Server Status page (`/status`), next to the existing Inngest and Trigger.dev dashboards. It shows the estimated number of records in **every table**:

- Summary cards: **Tables**, **Total Records**, **Largest Table**
- A sorted (descending) table of all tables, with a humanized label (`AgentType` → "Agent Type"), the physical table name beneath, and a count badge
- Loading / upstream-error / empty states matching the other dashboards

## Why

Requested: a DB dashboard similar to the Trigger.dev one, showing record counts for all tables, served stale for a few minutes.

## How

- **`getDatabaseStatus`** server function ([apps/web/app/status/actions.ts](https://github.com/joaomlneto/jitaspace/blob/claude/blissful-rosalind-c7a267/apps/web/app/status/actions.ts)) with a module-level cache (**~5 min**, 15 s on error) — the DB is hit at most once per 5 minutes globally regardless of traffic ("serve stale for a few minutes").
- Counts come from CockroachDB's **estimated** table statistics (the same source its DB Console uses), deliberately **not** `SELECT count(*)` per table — exact counts would full-scan 50+ tables (some with millions of rows) on the production cluster on every cache miss. Counts are labeled "approximate" in the UI.
- Pure types/logic in [apps/web/lib/databaseStatus.ts](https://github.com/joaomlneto/jitaspace/blob/claude/blissful-rosalind-c7a267/apps/web/lib/databaseStatus.ts) (client-import-safe), component in [apps/web/components/Status/DatabaseDashboard.tsx](https://github.com/joaomlneto/jitaspace/blob/claude/blissful-rosalind-c7a267/apps/web/components/Status/DatabaseDashboard.tsx).

## Reviewer notes

- ⚠️ **Query scoping is load-bearing:** `crdb_internal.table_row_statistics` is **cluster-wide** (it reports tables across *all* databases — ~381 in testing). The query joins `crdb_internal.tables` and filters on `current_database()` + `schema_name = 'public'` + `state = 'PUBLIC'` to return just our ~53 app tables. This was caught during live verification against a real CockroachDB.
- Estimates come from CockroachDB's `__auto__` statistics, which **lag** — a freshly-populated table can briefly read a stale/0 count until auto-collection runs. This is acceptable for a status dashboard and is labeled approximate. If exact counts are preferred, the 5-min cache makes `count(*)` affordable — easy to switch.
- The list includes Prisma's implicit m2m join tables (`_DogmaEffectToType`, `_StationToStationService`) — intentional ("all tables").

## Verification

- Live-tested in a browser against a throwaway Docker CockroachDB (schema pushed + seeded) — renders correct data, no console errors.
- Full web test suite: **809 tests / 110 suites pass**; new files at 100% coverage.
- `pnpm type-check` and `pnpm lint` clean for all new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)