### PR TITLE
fix(background-jobs): updateWars crashes with `index is not defined`

### DIFF
--- a/.changeset/fix-update-wars-index.md
+++ b/.changeset/fix-update-wars-index.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed EVE wars not updating — the scheduled hourly wars sync was crashing on every run with a `ReferenceError`, so war state (start/finish dates, ISK destroyed, etc.) had gone stale.

--- a/packages/background-jobs/jobs/scrape/esi/updateWars.ts
+++ b/packages/background-jobs/jobs/scrape/esi/updateWars.ts
@@ -65,7 +65,7 @@ export const updateWars = defineJob<UpdateActiveWarsEventPayload["data"]>({
       missingWarIds: new Set([...missingWarIds, ...warsToUpdate]),
     });
 
-    for (const warId of warsToUpdate) {
+    for (const [index, warId] of warsToUpdate.entries()) {
       const requestStartedAt = Date.now();
       await getWarsWarId(warId)
         .then(({ data: war }) => ({


### PR DESCRIPTION
## What

The hourly `esi-update-wars` cron has been throwing on **every run** for the past few days:

```
ReferenceError: index is not defined
    at Object.handler (updateWars.ts:94:7)
```

## Cause

A refactor changed the war-update loop to a `for…of`:

```ts
for (const warId of warsToUpdate) {
  …
  if (index < warsToUpdate.length - 1) {   // ← `index` no longer exists
    // throttle 500ms between ESI requests, skip after the last
  }
}
```

…but left the rate-limit guard referencing `index`, which the `for…of` no longer defines — so the handler crashes before updating any war, and war state (start/finish dates, ISK destroyed, ships killed, …) has gone stale.

## Fix

Restore the index via `warsToUpdate.entries()`, preserving the "don't delay after the last request" behaviour:

```ts
for (const [index, warId] of warsToUpdate.entries()) {
```

One line. No behaviour change beyond making the loop run again.

## Verification

Type-checked against a fully-generated workspace (`pnpm type-check` on `@jitaspace/background-jobs`, clean). The change is a standard `number[].entries()` destructuring, so `index`/`warId` are both `number`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)