### PR TITLE
fix(background-jobs): run ingest-sde-all on a 4 GB machine (fixes OOM)

### DIFF
--- a/packages/background-jobs-triggerdev/src/adapter.ts
+++ b/packages/background-jobs-triggerdev/src/adapter.ts
@@ -83,6 +83,7 @@ const taskOptions = (job: JobDefinition) => {
       ? {}
       : { retry: { maxAttempts: job.retries + 1 } }),
     ...(job.maxDurationSeconds ? { maxDuration: job.maxDurationSeconds } : {}),
+    ...(job.machine ? { machine: job.machine } : {}),
   };
 };
 

--- a/packages/background-jobs/core/defineJob.ts
+++ b/packages/background-jobs/core/defineJob.ts
@@ -2,6 +2,20 @@ import type { JobContext } from "./context";
 
 export type JobTrigger = { type: "event" } | { type: "cron"; cron: string };
 
+/**
+ * Resource preset for a run, matching Trigger.dev's machine presets. Only the
+ * Trigger.dev adapter honours it (Inngest manages resources itself); use it for
+ * memory/CPU-heavy jobs like the in-process `ingest-sde-all` pipeline.
+ */
+export type JobMachine =
+  | "micro"
+  | "small-1x"
+  | "small-2x"
+  | "medium-1x"
+  | "medium-2x"
+  | "large-1x"
+  | "large-2x";
+
 export interface JobDefinition<Payload = unknown, Result = unknown> {
   /**
    * Stable identifier. Doubles as the Inngest function id + trigger event name
@@ -24,6 +38,8 @@ export interface JobDefinition<Payload = unknown, Result = unknown> {
   retries?: number;
   /** Per-job execution cap in seconds. Maps to Trigger maxDuration; advisory on Inngest. */
   maxDurationSeconds?: number;
+  /** Resource preset (Trigger.dev only). For memory/CPU-heavy jobs. */
+  machine?: JobMachine;
   // Method syntax (not an arrow property) so `handler`'s parameter is checked
   // bivariantly — this lets a `JobDefinition<SpecificPayload>` live in a
   // `JobDefinition[]` (= `JobDefinition<unknown>[]`) registry without `any`.

--- a/packages/background-jobs/jobs/scrape/sde/ingestSde.ts
+++ b/packages/background-jobs/jobs/scrape/sde/ingestSde.ts
@@ -113,6 +113,11 @@ export const ingestSde = defineJob<IngestSdeEventPayload["data"]>({
   retries: 1,
   // Generous cap for the whole in-process pipeline; raise if a full run nears it.
   maxDurationSeconds: 3600,
+  // Running every ingest in one process peaks around ~1.3 GB (the type/dogma and
+  // moons sections), so it needs a roomy machine — the default presets OOM-kill
+  // it. 4 GB gives V8 headroom to GC under the working set; bump to large-1x if a
+  // future SDE grows it further.
+  machine: "medium-2x",
   handler: async (ctx) => {
     // Run every ingest in THIS process (not as child tasks) so the SDE archive
     // is downloaded only once. The lazy import breaks the module cycle (the


### PR DESCRIPTION
## What

Running `ingest-sde-all` on Trigger.dev fails with:

```
TASK_PROCESS_OOM_KILLED: Run was terminated due to running out of memory
```

## Why

`ingest-sde-all` runs the entire SDE pipeline **in one process** (so the ~97 MB archive is downloaded once instead of 58×). Even with the diff chunking that keeps peak memory around **~1.3 GB** (measured locally — it completes under a 2 GB heap), that's more than Trigger.dev's default machine, so the run gets OOM-killed in the type/dogma + moons sections.

## Fix

- Add an optional `machine` preset to the platform-agnostic `JobDefinition` (honoured by the Trigger.dev adapter via `task({ machine })`; the Inngest adapter ignores it).
- Set `ingest-sde-all` to **`medium-2x` (4 GB)** — enough headroom for V8 to GC under the ~1.3 GB working set. (Bump to `large-1x` if a future SDE grows it further.)

No other job changes machine, so the rest stay on the default.

## ⚠️ Requires the chunked pipeline

This machine bump only works **together with the diff chunking** that landed in #604 (helpers + `ingest-sde-type-dogma`). Without chunking the pipeline needs >8 GB and no reasonable machine helps. So: make sure the latest `main` is deployed to Trigger.dev **and promoted** before re-running. (As an immediate test you can also set the machine on `ingest-sde-all` from the Trigger.dev dashboard.)

## Verification

`pnpm type-check` (both `@jitaspace/background-jobs` and `@jitaspace/background-jobs-triggerdev`), 39 tests, lint, and prettier all pass. The ~1.3 GB peak is from the local full-pipeline dry-run (completes under a constrained 2 GB heap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)