### PR TITLE
fix(background-jobs): run SDE typeDogma additively so it coexists with the ESI scraper

### DIFF
--- a/packages/background-jobs/helpers/ingestSdeCompositeTable.ts
+++ b/packages/background-jobs/helpers/ingestSdeCompositeTable.ts
@@ -4,6 +4,22 @@ import type { CrudStatistics } from "../types";
 import type { SoftDeleteDelegate } from "./ingestSdeTable";
 import { excludeObjectKeys, updateTable } from "../utils";
 
+// CockroachDB/Postgres cap bind parameters per statement (Postgres wire limit:
+// 65535). The composite soft-delete builds an `OR` of N composite keys, spending
+// `keyFields.length` params per row — and Prisma does NOT split an `OR` across
+// statements the way it transparently chunks `createMany` / `IN (...)`. So cap
+// each soft-delete `OR` well under the limit (30000 / a 2-column key = 15000
+// rows per statement, leaving ample headroom under 65535).
+const MAX_DELETE_PARAMS = 30000;
+
+const chunkArray = <T>(items: T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let offset = 0; offset < items.length; offset += size) {
+    chunks.push(items.slice(offset, offset + size));
+  }
+  return chunks;
+};
+
 /**
  * Diff-ingest a derived set of rows into a table with a (possibly composite)
  * primary key — like {@link import("./ingestSdeTable").ingestSdeTable} but for
@@ -21,6 +37,13 @@ import { excludeObjectKeys, updateTable } from "../utils";
  * Chunking by scope keeps the soft-delete correct — the scope bounds both the
  * local fetch and the remote rows, so within a chunk a local row with no
  * matching remote row is still detected and soft-deleted.
+ *
+ * Pass `softDelete: false` when another writer also owns the table — e.g. the
+ * ESI `scrapeEsiTypes` scraper also fills TypeAttribute / TypeEffect. The local
+ * fetch is then filtered to the remote keys, so the diff only creates/updates
+ * and never soft-deletes rows the other writer owns (the same "never delete what
+ * the SDE didn't fetch" guarantee {@link import("./ingestSdeTable").ingestSdeTable}
+ * gives for single-key tables).
  */
 export async function ingestSdeCompositeTable<
   Row extends Record<string, unknown>,
@@ -33,6 +56,12 @@ export async function ingestSdeCompositeTable<
   concurrency?: number;
   /** Parent (scope) ids diffed/written per chunk (bounds peak memory). */
   scopeChunkSize?: number;
+  /**
+   * Soft-delete local rows absent from the SDE (default true). Set false to
+   * coexist with another writer of the same table: the diff then only
+   * creates/updates and never deletes (see the function docs).
+   */
+  softDelete?: boolean;
 }): Promise<CrudStatistics> {
   const {
     delegate,
@@ -42,6 +71,7 @@ export async function ingestSdeCompositeTable<
     scopeIds,
     concurrency = 20,
     scopeChunkSize = 5000,
+    softDelete = true,
   } = opts;
   const limit = pLimit(concurrency);
 
@@ -81,17 +111,26 @@ export async function ingestSdeCompositeTable<
     const chunkRows = chunkScopeIds.flatMap(
       (scope) => rowsByScope.get(scope) ?? [],
     );
+    // Additive (coexist) mode: drop local rows whose key isn't in the SDE before
+    // diffing, so they're never seen as "deleted". This is the composite-key
+    // equivalent of scoping the fetch — a single WHERE can't express "key IN
+    // (these pairs)" cheaply — and gives the same never-delete-another-writer's-
+    // rows guarantee as `ingestSdeTable`.
+    const remoteKeys = softDelete ? null : new Set(chunkRows.map(keyOf));
     const chunkStats = await updateTable({
       idAccessor: keyOf,
       fetchLocalEntries: async () =>
         delegate
           .findMany({ where: { [scopeField]: { in: chunkScopeIds } } })
-          .then((local) =>
-            local.map(
+          .then((local) => {
+            const managed = local.map(
               (row) =>
                 excludeObjectKeys(row, ["updatedAt", "createdAt"]) as Row,
-            ),
-          ),
+            );
+            return remoteKeys
+              ? managed.filter((row) => remoteKeys.has(keyOf(row)))
+              : managed;
+          }),
       fetchRemoteEntries: () => Promise.resolve(chunkRows),
       batchCreate: (created) =>
         limit(() => delegate.createMany({ data: created })),
@@ -103,13 +142,23 @@ export async function ingestSdeCompositeTable<
             ),
           ),
         ),
+      // Chunk the soft-delete so a large `OR` never exceeds the DB's bind-param
+      // limit (see MAX_DELETE_PARAMS). In additive mode `deleted` is always
+      // empty (the fetch above filtered to remote keys), so this is a no-op.
       batchDelete: (deleted) =>
-        deleted.length === 0
-          ? Promise.resolve()
-          : delegate.updateMany({
-              data: { isDeleted: true },
-              where: { OR: deleted.map(keyValues) },
-            }),
+        Promise.all(
+          chunkArray(
+            deleted,
+            Math.max(1, Math.floor(MAX_DELETE_PARAMS / keyFields.length)),
+          ).map((slice) =>
+            limit(() =>
+              delegate.updateMany({
+                data: { isDeleted: true },
+                where: { OR: slice.map(keyValues) },
+              }),
+            ),
+          ),
+        ),
     });
     stats.created += chunkStats.created;
     stats.modified += chunkStats.modified;

--- a/packages/background-jobs/jobs/scrape/sde/ingestSdeTypeDogma.ts
+++ b/packages/background-jobs/jobs/scrape/sde/ingestSdeTypeDogma.ts
@@ -62,12 +62,18 @@ export const ingestSdeTypeDogma = defineJob<
         })),
     );
 
+    // TypeAttribute / TypeEffect are also written by the ESI `scrapeEsiTypes`
+    // scraper (from `/universe/types/{id}` dogma), which currently reports more
+    // attributes than the SDE typeDogma.yaml lists. Run additively (never
+    // soft-delete) so this SDE ingest only fills/refreshes rows and never
+    // removes the ESI scraper's — the two writers coexist instead of fighting.
     const typeAttributes = await ingestSdeCompositeTable({
       delegate: prisma.typeAttribute,
       rows: attributeRows,
       keyFields: ["typeId", "attributeId"],
       scopeField: "typeId",
       scopeIds: typeIds,
+      softDelete: false,
     });
 
     const typeEffects = await ingestSdeCompositeTable({
@@ -76,6 +82,7 @@ export const ingestSdeTypeDogma = defineJob<
       keyFields: ["typeId", "effectId"],
       scopeField: "typeId",
       scopeIds: typeIds,
+      softDelete: false,
     });
 
     return {

--- a/packages/background-jobs/tests/ingestSdeCompositeTable.test.ts
+++ b/packages/background-jobs/tests/ingestSdeCompositeTable.test.ts
@@ -1,0 +1,113 @@
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+import type { ingestSdeCompositeTable as IngestSdeCompositeTable } from "../helpers/ingestSdeCompositeTable";
+
+// The helper pulls in p-limit (ESM) and, via ../utils, inngest + the zod-checked
+// env. Stub them so the test exercises only the diff/filter/chunk orchestration.
+// (@swc/jest doesn't hoist jest.mock, and p-limit crashes if loaded for real, so
+// the helper is imported lazily in beforeAll — after these mocks are registered.)
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => unknown) => fn(),
+}));
+jest.mock("inngest", () => ({
+  NonRetriableError: class NonRetriableError extends Error {},
+}));
+jest.mock("../env", () => ({ env: { NODE_ENV: "test" } }));
+
+let ingestSdeCompositeTable: typeof IngestSdeCompositeTable;
+
+beforeAll(async () => {
+  ({ ingestSdeCompositeTable } =
+    await import("../helpers/ingestSdeCompositeTable"));
+});
+
+// Index signature so Row satisfies the helper's `Record<string, unknown>` bound
+// (interfaces, unlike type aliases, don't get one implicitly).
+interface Row extends Record<string, unknown> {
+  typeId: number;
+  attributeId: number;
+  value: number;
+  isDeleted: boolean;
+}
+
+// Local (DB) rows carry timestamps the helper must strip before diffing.
+const withTimestamps = (rows: Row[]) =>
+  rows.map((row) => ({
+    ...row,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }));
+
+const makeDelegate = (local: Record<string, unknown>[]) => ({
+  findMany: jest.fn((_args?: unknown) => Promise.resolve(local)),
+  createMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+  update: jest.fn((_args?: unknown) => Promise.resolve({})),
+  updateMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+});
+
+describe("ingestSdeCompositeTable", () => {
+  it("never soft-deletes another writer's rows when softDelete is false", async () => {
+    // DB holds an ESI-only row (1:20) the SDE doesn't list — it must survive.
+    const delegate = makeDelegate(
+      withTimestamps([
+        { typeId: 1, attributeId: 10, value: 99, isDeleted: false }, // shared, value differs → update
+        { typeId: 1, attributeId: 20, value: 9, isDeleted: false }, // ESI-only → must NOT be deleted
+      ]),
+    );
+    const rows: Row[] = [
+      { typeId: 1, attributeId: 10, value: 5, isDeleted: false }, // shared
+      { typeId: 1, attributeId: 30, value: 7, isDeleted: false }, // SDE-only → create
+    ];
+
+    const stats = await ingestSdeCompositeTable({
+      delegate,
+      rows,
+      keyFields: ["typeId", "attributeId"],
+      scopeField: "typeId",
+      scopeIds: [1],
+      softDelete: false,
+    });
+
+    // Additive: create the SDE-only row, refresh the shared one, delete nothing.
+    expect(delegate.updateMany).not.toHaveBeenCalled();
+    expect(delegate.createMany).toHaveBeenCalledWith({ data: [rows[1]] });
+    expect(delegate.update).toHaveBeenCalledTimes(1);
+    expect(delegate.update).toHaveBeenCalledWith({
+      data: rows[0],
+      where: { typeId_attributeId: { typeId: 1, attributeId: 10 } },
+    });
+    expect(stats).toMatchObject({ created: 1, modified: 1, deleted: 0 });
+  });
+
+  it("chunks the soft-delete OR so it stays under the bind-param limit", async () => {
+    // 15001 local rows with no SDE counterpart → all deleted. With a 2-column
+    // key the cap is 15000 keys/statement, so this must split into 2 updateMany.
+    const delegate = makeDelegate(
+      withTimestamps(
+        Array.from({ length: 15001 }, (_, i) => ({
+          typeId: 1,
+          attributeId: i,
+          value: 0,
+          isDeleted: false,
+        })),
+      ),
+    );
+
+    const stats = await ingestSdeCompositeTable({
+      delegate,
+      rows: [], // SDE lists nothing for type 1 → everything is a delete
+      keyFields: ["typeId", "attributeId"],
+      scopeField: "typeId",
+      scopeIds: [1],
+    });
+
+    expect(stats.deleted).toBe(15001);
+    expect(delegate.updateMany).toHaveBeenCalledTimes(2);
+    const orSizes = delegate.updateMany.mock.calls.map(
+      ([args]) => (args as { where: { OR: unknown[] } }).where.OR.length,
+    );
+    expect(Math.max(...orSizes)).toBeLessThanOrEqual(15000);
+    expect(orSizes.reduce((sum, n) => sum + n, 0)).toBe(15001);
+  });
+});


### PR DESCRIPTION
## Problem

On the 4 GB machine, `ingest-sde-all` clears the OOM but fails in `ingest-sde-type-dogma`:

> Invalid `prisma.typeAttribute.updateMany()` invocation: The query parameter limit supported by your database is exceeded.

Two issues, one symptom:

1. **Un-chunked composite soft-delete.** `ingestSdeCompositeTable` soft-deletes via `where: { OR: deleted.map(keyValues) }`. Prisma transparently chunks `createMany` and `IN (...)`, but **not** an `OR` of composite keys — so the whole delete set goes into one statement and overflows CockroachDB's 65535-placeholder cap.

2. **Two writers for the same tables (the root cause of the huge delete set).** `TypeAttribute` / `TypeEffect` are written by both the long-standing ESI scraper (`scrapeEsiTypes`, from `/universe/types/{id}` dogma) and the new SDE job. ESI currently reports many more `(typeId, attributeId)` pairs than the SDE `typeDogma.yaml` lists, so the SDE job's diff flagged ≥32767 ESI-owned rows as "deleted" in a single 5000-type scope-chunk. Chunking alone would have let the job quietly soft-delete tens of thousands of legitimate ESI dogma rows on prod.

## Fix — additive coexistence

- `ingestSdeCompositeTable` gains a `softDelete` option (default `true`). With `softDelete: false`, the local fetch is filtered to the remote keys before diffing, so the diff only creates/updates and **never deletes** — the composite-key equivalent of how `ingestSdeTable` already coexists with the ESI scrapers.
- `ingest-sde-type-dogma` runs with `softDelete: false`: it fills/refreshes SDE attributes and effects but never removes the ESI scraper's rows. On the populated prod DB it's effectively idempotent for these tables, and there's no `OR` to overflow the param limit.
- The `OR` soft-delete is now chunked (`MAX_DELETE_PARAMS`) for the genuinely SDE-owned composite tables (blueprints, typeLists, …) that still soft-delete, so they can't hit the cap either.

## Tests / verification

- New `tests/ingestSdeCompositeTable.test.ts`: additive mode never deletes an ESI-only row (still creates/updates); the soft-delete splits a 15001-row delete into 2 statements, each ≤ 15000 keys.
- `tsc --noEmit`, `eslint`, and the full `jest` suite (41/41) pass.

Both `@jitaspace/background-jobs` packages are `private`, so no changeset.

> Out of scope: the deeper "SDE takes over and we drop the slow ESI per-type dogma fan-out" — that needs verifying SDE coverage ⊇ ESI first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)