### PR TITLE
fix(background-jobs): backfill stargate destinations in a 2nd pass to avoid a self-FK violation

### DIFF
--- a/packages/background-jobs/jobs/scrape/sde/ingestSdeStargates.ts
+++ b/packages/background-jobs/jobs/scrape/sde/ingestSdeStargates.ts
@@ -1,3 +1,5 @@
+import pLimit from "p-limit";
+
 import type { Prisma } from "../../../db";
 import { defineJob } from "../../../core";
 import { prisma } from "../../../db";
@@ -31,6 +33,14 @@ export const ingestSdeStargates = defineJob<
     ]);
     const systemNames = solarSystemNames(files["mapSolarSystems.yaml"]);
 
+    // Pass 1: ingest every column EXCEPT the self-referential destinationStargateId.
+    // Stargates reference each other (a gate and its destination point both ways, so
+    // the graph is cyclic), and Prisma sub-batches `createMany` to respect the
+    // bind-param limit — so a gate whose destination lands in a later INSERT batch
+    // violates the self-FK on insert, and no insert order can satisfy a cycle.
+    // Leaving `destinationStargateId` off the row keeps it out of the managed
+    // column set (so it defaults to NULL on create and is never touched here); it's
+    // backfilled in pass 2 once every stargate row exists.
     const stargates = await ingestSdeTable({
       filename: "mapStargates.yaml",
       records: files["mapStargates.yaml"],
@@ -49,11 +59,50 @@ export const ingestSdeStargates = defineJob<
           name: `Stargate (${destinationSystem ?? ""})`,
           solarSystemId: requiredNumber(record.solarSystemID),
           typeId: requiredNumber(record.typeID),
-          destinationStargateId: optionalNumber(destination.stargateID),
           isDeleted: false,
         };
       },
     });
-    return { stats: { stargates }, elapsed: performance.now() - start };
+
+    // Pass 2: backfill destinationStargateId now that every stargate row exists, so
+    // the self-FK is always satisfiable. Diffed against the current values so
+    // re-runs are no-ops and so it coexists with `scrapeEsiStargates` (which also
+    // sets this column); concurrency-bounded individual updates (each is one row).
+    const desired = Object.entries(files["mapStargates.yaml"]).map(
+      ([key, record]) => {
+        const destination = ((record as Record<string, unknown>).destination ??
+          {}) as Record<string, unknown>;
+        return {
+          stargateId: Number(key),
+          destinationStargateId: optionalNumber(destination.stargateID),
+        };
+      },
+    );
+    const current = new Map(
+      (
+        await prisma.stargate.findMany({
+          select: { stargateId: true, destinationStargateId: true },
+        })
+      ).map((row) => [row.stargateId, row.destinationStargateId]),
+    );
+    const toBackfill = desired.filter(
+      (entry) => current.get(entry.stargateId) !== entry.destinationStargateId,
+    );
+    const limit = pLimit(20);
+    await Promise.all(
+      toBackfill.map((entry) =>
+        limit(() =>
+          prisma.stargate.update({
+            where: { stargateId: entry.stargateId },
+            data: { destinationStargateId: entry.destinationStargateId },
+          }),
+        ),
+      ),
+    );
+
+    return {
+      stats: { stargates, destinationsBackfilled: toBackfill.length },
+      elapsed: performance.now() - start,
+    };
   },
 });


### PR DESCRIPTION
## Problem

`ingest-sde-stargates` sets `destinationStargateId` — a **self-referential FK** — at create time. Prisma sub-batches `createMany` to stay under the bind-param limit, and stargates form reference **cycles** (a gate and its destination point at each other), so when a gate's destination lands in a *later* INSERT batch the self-FK (`Stargate_destinationStargateId_fkey`) is violated. No insert order can satisfy a cycle, so this fails on a fresh DB / `bootstrapDatabase` (where every stargate is created).

## Fix — two-pass insert + backfill

1. **Pass 1** ingests every column *except* `destinationStargateId`. Leaving it off the row keeps it out of `ingestSdeTable`'s managed-column set, so it defaults to `NULL` on create and is never touched here. `createMany` can now sub-batch freely — no self-references to satisfy.
2. **Pass 2** backfills `destinationStargateId` once every stargate row exists. It's diffed against current values, so re-runs are no-ops and it coexists with `scrapeEsiStargates` (which also writes this column).

## Verification (real CockroachDB)

Reproduced and fixed against a throwaway `cockroachdb/cockroach:v24.1.0`:

- **Repro:** the current `createMany`-with-dest on 14k cyclically-referenced stargates → `Foreign key constraint violated: Stargate_destinationStargateId_fkey`.
- **Fix (real code path):** running the actual `ingestSdeTable` pass + the backfill against CockroachDB → 14000 created, every destination backfilled (`gate1.dest=7001`), **no FK error**; an idempotent re-run reports `created/modified/deleted: 0`, `equal: 14000`, `backfilled: 0`.

`tsc`, `eslint`, `prettier`, and the `jest` suite pass. Both `@jitaspace/background-jobs` packages are `private`, so no changeset.

> Scope note: on the already-populated prod DB this was likely a no-op anyway (stargates exist, destinations already set by `scrapeEsiStargates`); the real beneficiary is a fresh DB / `bootstrapDatabase`. Still a correctness fix that removes a latent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)