### PR TITLE
feat(background-jobs): auto-trigger ingest-sde-all when a new SDE is published

### DIFF
--- a/packages/background-jobs/jobs/index.ts
+++ b/packages/background-jobs/jobs/index.ts
@@ -106,6 +106,7 @@ import {
   scrapeSdeStationServices,
   scrapeZkillboardRecentKills,
   updateWars,
+  watchSde,
 } from "./scrape";
 import { testPing } from "./test";
 
@@ -222,6 +223,7 @@ export const jobs: JobDefinition[] = [
   scrapeZkillboardRecentKills,
   testPing,
   updateWars,
+  watchSde,
 ];
 
 /** Jobs indexed by id, for resolving `ctx.send`/`ctx.invoke` targets. */

--- a/packages/background-jobs/jobs/scrape/sde/index.ts
+++ b/packages/background-jobs/jobs/scrape/sde/index.ts
@@ -65,3 +65,4 @@ export * from "./scrapeSdeIcons";
 export * from "./scrapeSdeNpcCorporationDivisions";
 export * from "./scrapeSdeRaces";
 export * from "./scrapeSdeStationServices";
+export * from "./watchSde";

--- a/packages/background-jobs/jobs/scrape/sde/watchSde.ts
+++ b/packages/background-jobs/jobs/scrape/sde/watchSde.ts
@@ -1,0 +1,52 @@
+import { latestSdeLastModified } from "@jitaspace/sde-utils";
+
+import { defineJob } from "../../../core";
+import { getRedis } from "../../../kv";
+
+export interface WatchSdeEventPayload {
+  data: Record<string, never>;
+}
+
+// Redis key holding the SDE archive `Last-Modified` we last kicked an ingest for.
+const LAST_SEEN_KEY = "sde:last-modified-ingested";
+
+/**
+ * Hourly watcher that triggers `ingest-sde-all` when CCP publishes a new SDE.
+ *
+ * It `HEAD`s the archive for its `Last-Modified` (cheap — no ~97 MB download) and
+ * compares to the value stored in Redis. On a change it fires `ingest-sde-all`
+ * (fire-and-forget — it runs on its own roomy machine) and records the new value,
+ * so the next poll is a no-op until CCP republishes.
+ *
+ * The stored timestamp is the entire state and is loss-tolerant: losing it just
+ * kicks one redundant — and idempotent — ingest. And because `ingest-sde-all` is
+ * a full diff, a missed trigger self-corrects on the next publish.
+ *
+ * Detection uses `Last-Modified`, NOT `SDE_CHECKSUM_URL` (which still points at
+ * the old S3 export — a different artifact than the developers.eveonline.com
+ * archive we download). Switch to comparing the `ETag` if it ever proves flaky.
+ */
+export const watchSde = defineJob<WatchSdeEventPayload["data"]>({
+  id: "watch-sde",
+  name: "Watch for new SDE releases",
+  description:
+    "Hourly HEAD on the SDE archive; triggers ingest-sde-all when its Last-Modified changes.",
+  trigger: { type: "cron", cron: "TZ=UTC 0 * * * *" },
+  singleton: true,
+  // One HEAD request + one Redis op — the smallest machine is plenty.
+  machine: "micro",
+  handler: async (ctx) => {
+    const lastModified = (await latestSdeLastModified()).toISOString();
+    const redis = await getRedis();
+
+    if ((await redis.get(LAST_SEEN_KEY)) === lastModified) {
+      ctx.logger.info(`SDE unchanged (${lastModified}); not re-ingesting.`);
+      return { changed: false, lastModified };
+    }
+
+    await ctx.send("ingest-sde-all", {});
+    await redis.set(LAST_SEEN_KEY, lastModified);
+    ctx.logger.info(`New SDE (${lastModified}); triggered ingest-sde-all.`);
+    return { changed: true, lastModified };
+  },
+});

--- a/packages/background-jobs/tests/registry.test.ts
+++ b/packages/background-jobs/tests/registry.test.ts
@@ -71,11 +71,12 @@ describe("background-jobs registry", () => {
     }
   });
 
-  it("has exactly one cron job (updateWars)", () => {
+  it("registers exactly the expected cron jobs", () => {
     const cronJobIds = jobs
       .filter((job) => job.trigger.type === "cron")
-      .map((job) => job.id);
-    expect(cronJobIds).toEqual(["esi-update-wars"]);
+      .map((job) => job.id)
+      .sort((a, b) => a.localeCompare(b));
+    expect(cronJobIds).toEqual(["esi-update-wars", "watch-sde"]);
   });
 
   it("resolves every job by id through the registry", () => {

--- a/packages/background-jobs/tests/watchSde.test.ts
+++ b/packages/background-jobs/tests/watchSde.test.ts
@@ -1,0 +1,69 @@
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+import type { watchSde as WatchSde } from "../jobs/scrape/sde/watchSde";
+
+// @swc/jest doesn't hoist jest.mock, so these mock fns are declared first and the
+// factories close over them; the job is imported lazily in beforeAll (after the
+// mocks register). The real @jitaspace/sde-utils barrel also won't resolve under
+// jest, so it must be mocked regardless.
+const latestSdeLastModified = jest.fn<() => Promise<Date>>();
+const redisGet = jest.fn<(key: string) => Promise<string | null>>();
+const redisSet = jest.fn<(key: string, value: string) => Promise<unknown>>();
+
+jest.mock("@jitaspace/sde-utils", () => ({ latestSdeLastModified }));
+jest.mock("../kv", () => ({
+  getRedis: () => Promise.resolve({ get: redisGet, set: redisSet }),
+}));
+
+let watchSde: typeof WatchSde;
+
+beforeAll(async () => {
+  ({ watchSde } = await import("../jobs/scrape/sde/watchSde"));
+});
+
+const STORE_KEY = "sde:last-modified-ingested";
+const MODIFIED = new Date("2026-06-19T11:05:00Z");
+const MODIFIED_ISO = MODIFIED.toISOString();
+
+const run = (seen: string | null) => {
+  latestSdeLastModified.mockResolvedValue(MODIFIED);
+  redisGet.mockResolvedValue(seen);
+  redisSet.mockResolvedValue("OK");
+  const send = jest.fn<(id: string, payload: unknown) => Promise<void>>(() =>
+    Promise.resolve(),
+  );
+  const ctx = {
+    payload: {},
+    attempt: 1,
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    send,
+    invoke: jest.fn(),
+    run: jest.fn(),
+    sleep: jest.fn(),
+  } as unknown as Parameters<typeof watchSde.handler>[0];
+  return { result: watchSde.handler(ctx), send };
+};
+
+describe("watch-sde", () => {
+  it("triggers ingest-sde-all and records the timestamp when the SDE changed", async () => {
+    const { result, send } = run(null); // never seen
+    await expect(result).resolves.toMatchObject({
+      changed: true,
+      lastModified: MODIFIED_ISO,
+    });
+    expect(send).toHaveBeenCalledWith("ingest-sde-all", {});
+    expect(redisSet).toHaveBeenCalledWith(STORE_KEY, MODIFIED_ISO);
+  });
+
+  it("does nothing when the stored timestamp already matches", async () => {
+    const { result, send } = run(MODIFIED_ISO); // already ingested this version
+    await expect(result).resolves.toMatchObject({ changed: false });
+    expect(send).not.toHaveBeenCalled();
+    expect(redisSet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

A new hourly cron job, **`watch-sde`**, triggers `ingest-sde-all` whenever CCP publishes a new SDE — so the DB stays in sync with no manual runs.

## How

- `HEAD`s the archive (`latestSdeLastModified()` — no ~97 MB download) and compares its `Last-Modified` to a Redis key (`sde:last-modified-ingested`).
- On a change → `ctx.send("ingest-sde-all")` (fire-and-forget; the heavy job runs on its own 4 GB machine) and stores the new timestamp.
- Runs on the `micro` machine — one HEAD + one Redis op.

## Why this shape

- **State is one loss-tolerant timestamp.** Lose it (e.g. a Redis flush) and the worst case is a single redundant, *idempotent* ingest. Redis is already the established pattern here (the zKill / evekill cursor jobs use it on Trigger.dev).
- **Self-correcting.** `ingest-sde-all` is a full diff, so even a missed trigger catches up on the next publish.
- **`Last-Modified`, not `SDE_CHECKSUM_URL`** — the checksum URL still points at the *old* S3 export, a different artifact than the `developers.eveonline.com` archive we download. (Swap to comparing `ETag` if `Last-Modified` ever proves flaky — a one-line change in the helper.)
- **Hourly** so an off-cycle republish isn't missed by ~a day; cheap enough that frequency is free. Tighten to a post-downtime window (`TZ=UTC */20 11-13 * * *`) if you'd prefer fewer runs.

## Verification

- New `tests/watchSde.test.ts`: changed SDE → triggers + stores; unchanged → no-op.
- Registry test updated to expect the second cron job. `tsc` / `eslint` / `prettier` and the full `jest` suite (43) pass.

Both `@jitaspace/background-jobs` packages are `private`, so no changeset.

## Deploy

New cron task → after merge + Trigger.dev deploy, **promote**, and it shows under Schedules. No new env (it reuses `REDIS_URL`). The first run after deploy triggers one ingest (Redis key empty), then settles into no-ops until the next SDE publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)