### PR TITLE
fix(tiptap-eve): guard null editor on first render (crash on descriptions & mails)

### DIFF
--- a/.changeset/fix-tiptap-eve-null-editor-crash.md
+++ b/.changeset/fix-tiptap-eve-null-editor-crash.md
@@ -1,0 +1,11 @@
+---
+"@jitaspace/tiptap-eve": patch
+"@jitaspace/web": patch
+---
+
+Fixed a crash when viewing character descriptions and EVE mails.
+
+The rich-text renderer read the editor's HTML before the editor finished
+initializing, which threw on the first render and took the page down. The
+renderer now waits for the editor to be ready, so descriptions and mail
+bodies display correctly.

--- a/apps/web/components/EveMail/Editor/MailMessageEditor.tsx
+++ b/apps/web/components/EveMail/Editor/MailMessageEditor.tsx
@@ -32,6 +32,11 @@ export function MailMessageEditor({
     },
   });
 
+  // `editor` is null on the first render (TipTap creates it in an effect after
+  // mount; see useEveEditor). Subtract the wrapping <p></p> (7 chars) to get
+  // the real content length; 0 while the editor is still null.
+  const contentLength = (editor?.getHTML().length ?? 7) - 7;
+
   return (
     <Stack>
       <RichTextEditor editor={editor} mih={200} {...otherProps}>
@@ -57,11 +62,8 @@ export function MailMessageEditor({
           </RichTextEditor.ControlsGroup>
 
           <RichTextEditor.ControlsGroup ml="auto">
-            <Text
-              size="sm"
-              color={editor.getHTML().length - 7 >= 8000 ? "red" : "dimmed"}
-            >
-              {editor.getHTML().length - 7}/8000
+            <Text size="sm" color={contentLength >= 8000 ? "red" : "dimmed"}>
+              {contentLength}/8000
             </Text>
           </RichTextEditor.ControlsGroup>
         </RichTextEditor.Toolbar>

--- a/apps/web/components/EveMail/MailMessageViewer.tsx
+++ b/apps/web/components/EveMail/MailMessageViewer.tsx
@@ -48,16 +48,17 @@ export function MailMessageViewer({
     return externalLinkColor;
   };
 
-  const html = editor
-    .getHTML()
-    .replace(
-      /<a\b([^>]*)\bhref="([^"]*)"([^>]*)>/g,
-      (_, before: string, href: string, after: string) => {
-        const translatedHref = renderEveHref(href);
-        const color = getLinkColor(href, translatedHref);
-        return `<a${before}href="${translatedHref}"${after} style="color:${color};font-weight:600;">`;
-      },
-    );
+  // `editor` is null on the first render (TipTap creates it in an effect after
+  // mount; see useEveEditor). Render empty until then — the editor re-renders
+  // this component with the real HTML once it exists.
+  const html = (editor?.getHTML() ?? "").replace(
+    /<a\b([^>]*)\bhref="([^"]*)"([^>]*)>/g,
+    (_, before: string, href: string, after: string) => {
+      const translatedHref = renderEveHref(href);
+      const color = getLinkColor(href, translatedHref);
+      return `<a${before}href="${translatedHref}"${after} style="color:${color};font-weight:600;">`;
+    },
+  );
 
   const handleLinkInteraction = (
     e: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>,

--- a/packages/tiptap-eve/index.ts
+++ b/packages/tiptap-eve/index.ts
@@ -19,6 +19,13 @@ export const useEveEditor = (
 ) => {
   return useEditor(
     {
+      // TipTap 3 auto-detects Next.js and, unless this is set explicitly,
+      // returns `null` on the first render to avoid SSR hydration mismatches
+      // (it creates the editor in an effect after mount). Make that the
+      // explicit contract so it also holds outside Next, and so consumers
+      // know to tolerate a `null` editor on the first render. Callers can
+      // still override it via `options`.
+      immediatelyRender: false,
       extensions: [
         // TipTap 3's StarterKit now bundles Link, Underline and HardBreak.
         // Disable them here so they don't collide with the customized versions


### PR DESCRIPTION
## What

`apps/web` crashed whenever it rendered the tiptap-eve component — every character description and every EVE mail.

## Why

TipTap 3's `useEditor` **returns `null` on the first render in Next.js**. v3 auto-detects the Next runtime and defers editor creation to a post-mount effect (to avoid SSR hydration mismatches). From `@tiptap/react@3.26.0`:

```js
let immediatelyRender = explicit != null ? explicit : true;
if (isSSR) immediatelyRender = false;
else if (isNext && explicit === void 0) immediatelyRender = false;
return immediatelyRender ? this.createEditor() : null;   // ← null on first render
```

`useEveEditor` never set `immediatelyRender`, and both consumers dereferenced the editor unconditionally:
- `MailMessageViewer` → `editor.getHTML()`
- `MailMessageEditor` → `editor.getHTML().length` in the character counter

So the first render hit `Cannot read properties of null (reading 'getHTML')` and took the page down.

**Latent since the TipTap v2→v3 migration** (`02583ed1`). It was missed because every unit test *mocks* `useEveEditor`, and the null path only triggers under the real Next runtime (jsdom is detected as neither SSR nor Next, so the un-mocked hook returns a non-null editor there).

## Changes

- **`packages/tiptap-eve/index.ts`** — `useEveEditor` now sets `immediatelyRender: false` explicitly (TipTap's documented Next.js setting; makes the null-first-render contract explicit and silences the dev warning; still overridable via `options`).
- **`MailMessageViewer.tsx`** — null-guards `editor?.getHTML() ?? ""`; renders empty until the editor mounts, then re-renders with content.
- **`MailMessageEditor.tsx`** — null-guards the character counter.
- Changeset (patch: `@jitaspace/tiptap-eve` + `@jitaspace/web`, user-readable).

Deliberately **not** forcing `immediatelyRender: true` — that reintroduces SSR/hydration mismatches and is forced back to `false` during real SSR anyway.

## Verification

Ran a local `apps/web` dev server:

| Page | Result |
|------|--------|
| `/character/93345033` | renders, "No description" fallback (editor instantiated, `getHTML()` succeeds) — no crash |
| `/corporation/1000168` | full rich EVE-HTML description renders |

Both HTTP 200, **zero browser console errors**.

Tests: tiptap-eve **206/206**; web (`MailMessageViewer`, `EveMailComposeForm`, `characterPage`, `corporationPage`) **39/39**. Type-check: no new errors in the changed source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)