### PR TITLE
feat(web): redesign homepage with HUD headers and compact app cards

### DIFF
--- a/.changeset/homepage-redesign.md
+++ b/.changeset/homepage-redesign.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+Redesign the home page with a cleaner, denser layout. Every section (Pilots, Corporations, Alliances, and the tool groups) now shares a consistent header with an item count, and the Corporations and Alliances sections only appear when you actually have them. The Capsuleer Tools and Universe entries are now compact cards that fit more per row and reveal their description on hover. Adding a character is now a clearer "Add pilot" card.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,38 +1,21 @@
 "use client";
 
-import Link from "next/link";
-import {
-  Anchor,
-  Badge,
-  Burger,
-  Card,
-  Container,
-  Group,
-  rem,
-  SimpleGrid,
-  Text,
-  Title,
-  UnstyledButton,
-  useMantineColorScheme,
-  useMantineTheme,
-} from "@mantine/core";
-import { openContextModal } from "@mantine/modals";
+import { Burger, Container, SimpleGrid, Stack } from "@mantine/core";
+
 import { useShallow } from "zustand/shallow";
 
 import { AllianceCard } from "@jitaspace/eve-components";
 import { useAuthenticatedCharacterIds, useAuthStore } from "@jitaspace/hooks";
-import { CharacterAvatar } from "@jitaspace/ui";
 
 import { AuthenticatedCharacterCard, CorporationCard } from "~/components/Card";
 import { DevelopmentModeAlert } from "~/components/debug";
+import { AddPilotCard, AppCard, SectionHeader } from "~/components/Home";
 import { AllianceMenu, CorporationMenu } from "~/components/Menu";
 import { NewsCarousel } from "~/components/News";
 import { characterApps, universeApps } from "~/config/apps";
 import { env } from "~/env";
 
 export default function Page() {
-  const theme = useMantineTheme();
-  const { colorScheme } = useMantineColorScheme();
   const authenticatedCharacterIds = useAuthenticatedCharacterIds();
   const authenticatedCorporationIds = useAuthStore(
     useShallow((state) => {
@@ -60,190 +43,89 @@ export default function Page() {
   );
 
   return (
-    <Container size="xl">
-      <NewsCarousel />
-      {env.NODE_ENV === "development" && <DevelopmentModeAlert />}
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }}>
-        {authenticatedCharacterIds.map((characterId) => (
-          <AuthenticatedCharacterCard
-            characterId={characterId}
-            key={characterId}
+    <Container size="xl" py="md">
+      <Stack gap={48}>
+        <NewsCarousel />
+        {env.NODE_ENV === "development" && <DevelopmentModeAlert />}
+
+        <section>
+          <SectionHeader
+            title="Pilots"
+            count={authenticatedCharacterIds.length || undefined}
           />
-        ))}
-      </SimpleGrid>
-      <Group wrap="nowrap" gap="xs" mt="md" mb="xl">
-        <CharacterAvatar characterId={1} size="sm" />
-        <Anchor
-          onClick={() => {
-            openContextModal({
-              modal: "login",
-              title: "Login",
-              size: "xl",
-              innerProps: {},
-            });
-          }}
-        >
-          Add character
-        </Anchor>
-      </Group>
-      <Text c="dimmed">Corporations:</Text>
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }}>
-        {authenticatedCorporationIds.map((corporationId) => (
-          <CorporationCard
-            corporationId={corporationId}
-            key={corporationId}
-            headerRightSection={
-              <CorporationMenu corporationId={corporationId}>
-                <Burger size="sm" />
-              </CorporationMenu>
-            }
-          />
-        ))}
-      </SimpleGrid>
-      <Text c="dimmed">Alliances:</Text>
-      <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }}>
-        {authenticatedAllianceIds.map((allianceId) => (
-          <AllianceCard
-            allianceId={allianceId}
-            key={allianceId}
-            headerRightSection={
-              <AllianceMenu allianceId={allianceId}>
-                <Burger size="sm" />
-              </AllianceMenu>
-            }
-          />
-        ))}
-      </SimpleGrid>
-      <Title order={3}>Capsuleer Tools</Title>
-      <SimpleGrid spacing="xl" my="xl" cols={{ base: 1, xs: 2, sm: 3 }}>
-        {Object.values(characterApps).map((feature) => (
-          <UnstyledButton
-            component={Link}
-            href={feature.url ?? ""}
-            onClick={feature.onClick}
-            key={feature.name}
-          >
-            <Card
-              shadow="md"
-              radius="md"
-              styles={{
-                root: {
-                  height: "100%",
-                  transition: "transform 0.2s",
-                  border: `${rem(1)} solid ${
-                    colorScheme === "dark"
-                      ? theme.colors.dark[5]
-                      : theme.colors.gray[1]
-                  }`,
-                  /* // FIXME Mantine v7 migration
-              "&:hover": {
-                transform: "scale(1.05)",
-              },*/
-                },
-              }}
-              padding="xl"
-            >
-              <Container m={0} p={0} w={64} h={64}>
-                <feature.Icon
-                  height={64}
-                  width={64}
-                  color={theme.primaryColor}
+          <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+            {authenticatedCharacterIds.map((characterId) => (
+              <AuthenticatedCharacterCard
+                characterId={characterId}
+                key={characterId}
+              />
+            ))}
+            <AddPilotCard />
+          </SimpleGrid>
+        </section>
+
+        {authenticatedCorporationIds.length > 0 && (
+          <section>
+            <SectionHeader
+              title="Corporations"
+              count={authenticatedCorporationIds.length}
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+              {authenticatedCorporationIds.map((corporationId) => (
+                <CorporationCard
+                  corporationId={corporationId}
+                  key={corporationId}
+                  headerRightSection={
+                    <CorporationMenu corporationId={corporationId}>
+                      <Burger size="sm" />
+                    </CorporationMenu>
+                  }
                 />
-              </Container>
-              <Group>
-                <Text
-                  fz="lg"
-                  fw={500}
-                  style={{
-                    "&::after": {
-                      content: '""',
-                      display: "block",
-                      backgroundColor: theme.primaryColor,
-                      width: rem(45),
-                      height: rem(2),
-                      marginTop: theme.spacing.sm,
-                    },
-                  }}
-                  mt="md"
-                >
-                  {feature.name}
-                </Text>
-                {feature.tags?.map((tag) => (
-                  <Badge key={tag}>{tag}</Badge>
-                ))}
-              </Group>
-              <Text fz="sm" c="dimmed" mt="sm">
-                {feature.description}
-              </Text>
-            </Card>
-          </UnstyledButton>
-        ))}
-      </SimpleGrid>
-      <Title order={3}>Universe</Title>
-      <SimpleGrid spacing="xl" my="xl" cols={{ base: 1, xs: 2, sm: 3 }}>
-        {Object.values(universeApps).map((feature) => (
-          <UnstyledButton
-            component={Link}
-            href={feature.url ?? ""}
-            onClick={feature.onClick}
-            key={feature.name}
-          >
-            <Card
-              shadow="md"
-              radius="md"
-              styles={{
-                root: {
-                  height: "100%",
-                  transition: "transform 0.2s",
-                  border: `${rem(1)} solid ${
-                    colorScheme === "dark"
-                      ? theme.colors.dark[5]
-                      : theme.colors.gray[1]
-                  }`,
-                  /* // FIXME Mantine v7 migration
-                  "&:hover": {
-                    transform: "scale(1.05)",
-                  },*/
-                },
-              }}
-              padding="xl"
-            >
-              <Container m={0} p={0} w={64} h={64}>
-                <feature.Icon
-                  height={64}
-                  width={64}
-                  color={theme.primaryColor}
+              ))}
+            </SimpleGrid>
+          </section>
+        )}
+
+        {authenticatedAllianceIds.length > 0 && (
+          <section>
+            <SectionHeader
+              title="Alliances"
+              count={authenticatedAllianceIds.length}
+            />
+            <SimpleGrid cols={{ base: 1, sm: 2, lg: 3 }} spacing="lg">
+              {authenticatedAllianceIds.map((allianceId) => (
+                <AllianceCard
+                  allianceId={allianceId}
+                  key={allianceId}
+                  headerRightSection={
+                    <AllianceMenu allianceId={allianceId}>
+                      <Burger size="sm" />
+                    </AllianceMenu>
+                  }
                 />
-              </Container>
-              <Group>
-                <Text
-                  fz="lg"
-                  fw={500}
-                  style={{
-                    "&::after": {
-                      content: '""',
-                      display: "block",
-                      backgroundColor: theme.primaryColor,
-                      width: rem(45),
-                      height: rem(2),
-                      marginTop: theme.spacing.sm,
-                    },
-                  }}
-                  mt="md"
-                >
-                  {feature.name}
-                </Text>
-                {feature.tags?.map((tag) => (
-                  <Badge key={tag}>{tag}</Badge>
-                ))}
-              </Group>
-              <Text fz="sm" c="dimmed" mt="sm">
-                {feature.description}
-              </Text>
-            </Card>
-          </UnstyledButton>
-        ))}
-      </SimpleGrid>
+              ))}
+            </SimpleGrid>
+          </section>
+        )}
+
+        <section>
+          <SectionHeader title="Capsuleer Tools" />
+          <SimpleGrid spacing="md" cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
+            {Object.values(characterApps).map((app) => (
+              <AppCard app={app} key={app.name} />
+            ))}
+          </SimpleGrid>
+        </section>
+
+        <section>
+          <SectionHeader title="Universe" />
+          <SimpleGrid spacing="md" cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
+            {Object.values(universeApps).map((app) => (
+              <AppCard app={app} key={app.name} />
+            ))}
+          </SimpleGrid>
+        </section>
+      </Stack>
     </Container>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -15,6 +15,11 @@ import { NewsCarousel } from "~/components/News";
 import { characterApps, universeApps } from "~/config/apps";
 import { env } from "~/env";
 
+const toolSections = [
+  { title: "Capsuleer Tools", apps: characterApps },
+  { title: "Universe", apps: universeApps },
+];
+
 export default function Page() {
   const authenticatedCharacterIds = useAuthenticatedCharacterIds();
   const authenticatedCorporationIds = useAuthStore(
@@ -108,23 +113,16 @@ export default function Page() {
           </section>
         )}
 
-        <section>
-          <SectionHeader title="Capsuleer Tools" />
-          <SimpleGrid spacing="md" cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
-            {Object.values(characterApps).map((app) => (
-              <AppCard app={app} key={app.name} />
-            ))}
-          </SimpleGrid>
-        </section>
-
-        <section>
-          <SectionHeader title="Universe" />
-          <SimpleGrid spacing="md" cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
-            {Object.values(universeApps).map((app) => (
-              <AppCard app={app} key={app.name} />
-            ))}
-          </SimpleGrid>
-        </section>
+        {toolSections.map(({ title, apps }) => (
+          <section key={title}>
+            <SectionHeader title={title} />
+            <SimpleGrid spacing="md" cols={{ base: 1, xs: 2, sm: 3, lg: 4 }}>
+              {Object.values(apps).map((app) => (
+                <AppCard app={app} key={app.name} />
+              ))}
+            </SimpleGrid>
+          </section>
+        ))}
       </Stack>
     </Container>
   );

--- a/apps/web/components/Home/AddPilotCard.module.css
+++ b/apps/web/components/Home/AddPilotCard.module.css
@@ -1,0 +1,53 @@
+.card {
+    height: 100%;
+    width: 100%;
+    min-height: rem(180px);
+    padding: var(--mantine-spacing-lg);
+    border-radius: var(--mantine-radius-xs);
+    border: rem(1px) dashed color-mix(in srgb, var(--mantine-primary-color-filled) 32%, transparent);
+    background: linear-gradient(
+            180deg,
+            rgba(26, 33, 45, 0.25) 0%,
+            rgba(8, 11, 18, 0.35) 100%
+    );
+    transition:
+            transform 160ms ease,
+            border-color 160ms ease,
+            background 160ms ease;
+}
+
+.card:hover,
+.card:focus-visible {
+    transform: translateY(rem(-3px));
+    border-color: color-mix(in srgb, var(--mantine-primary-color-filled) 68%, transparent);
+    background: linear-gradient(
+            180deg,
+            rgba(36, 46, 60, 0.4) 0%,
+            rgba(12, 18, 28, 0.5) 100%
+    );
+}
+
+.plus {
+    width: rem(52px);
+    height: rem(52px);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--mantine-primary-color-filled);
+    border: rem(1px) solid color-mix(in srgb, var(--mantine-primary-color-filled) 45%, transparent);
+    box-shadow: 0 0 rem(18px) color-mix(in srgb, var(--mantine-primary-color-filled) 16%, transparent);
+    transition:
+            border-color 160ms ease,
+            box-shadow 160ms ease;
+}
+
+.card:hover .plus,
+.card:focus-visible .plus {
+    border-color: color-mix(in srgb, var(--mantine-primary-color-filled) 75%, transparent);
+    box-shadow: 0 0 rem(24px) color-mix(in srgb, var(--mantine-primary-color-filled) 26%, transparent);
+}
+
+.label {
+    letter-spacing: 0.06em;
+}

--- a/apps/web/components/Home/AddPilotCard.tsx
+++ b/apps/web/components/Home/AddPilotCard.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Stack, Text, UnstyledButton } from "@mantine/core";
+import { openContextModal } from "@mantine/modals";
+import { IconPlus } from "@tabler/icons-react";
+
+import classes from "./AddPilotCard.module.css";
+
+export function AddPilotCard() {
+  return (
+    <UnstyledButton
+      className={classes.card}
+      onClick={() => {
+        openContextModal({
+          modal: "login",
+          title: "Login",
+          size: "xl",
+          innerProps: {},
+        });
+      }}
+    >
+      <Stack align="center" justify="center" gap={10} h="100%">
+        <div className={classes.plus}>
+          <IconPlus size={26} stroke={1.5} />
+        </div>
+        <Text fw={600} tt="uppercase" className={classes.label}>
+          Add pilot
+        </Text>
+        <Text size="xs" c="dimmed" ta="center">
+          Sign in with EVE Online SSO
+        </Text>
+      </Stack>
+    </UnstyledButton>
+  );
+}

--- a/apps/web/components/Home/AppCard.module.css
+++ b/apps/web/components/Home/AppCard.module.css
@@ -1,0 +1,68 @@
+.button {
+    display: block;
+    height: 100%;
+    width: 100%;
+}
+
+.card {
+    height: 100%;
+    /* The Card root gets its panel look (bg/border/shadow) from the theme as
+       inline styles, so border-color / box-shadow are overridden with
+       !important on hover. transform has no inline value, so it animates
+       freely. */
+    transition:
+            transform 160ms ease,
+            border-color 160ms ease,
+            box-shadow 160ms ease;
+}
+
+.button:hover .card,
+.button:focus-visible .card {
+    transform: translateY(rem(-3px));
+    border-color: color-mix(in srgb, var(--mantine-primary-color-filled) 60%, transparent) !important;
+    box-shadow:
+            inset 0 rem(1px) 0 rgba(182, 210, 230, 0.18),
+            0 rem(12px) rem(26px) rgba(1, 10, 20, 0.6),
+            0 0 rem(22px) color-mix(in srgb, var(--mantine-primary-color-filled) 22%, transparent) !important;
+}
+
+.iconBox {
+    flex: 0 0 auto;
+    width: rem(44px);
+    height: rem(44px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--mantine-radius-xs);
+    border: rem(1px) solid color-mix(in srgb, var(--mantine-primary-color-filled) 22%, transparent);
+    background: linear-gradient(
+            180deg,
+            rgba(36, 46, 60, 0.5) 0%,
+            rgba(12, 18, 28, 0.55) 100%
+    );
+    transition:
+            border-color 160ms ease,
+            box-shadow 160ms ease;
+}
+
+.button:hover .iconBox,
+.button:focus-visible .iconBox {
+    border-color: color-mix(in srgb, var(--mantine-primary-color-filled) 55%, transparent);
+    box-shadow: 0 0 rem(14px) color-mix(in srgb, var(--mantine-primary-color-filled) 18%, transparent);
+}
+
+.arrow {
+    flex: 0 0 auto;
+    color: var(--mantine-primary-color-filled);
+    opacity: 0;
+    transform: translateX(rem(-4px));
+    transition:
+            opacity 160ms ease,
+            transform 160ms ease;
+}
+
+.button:hover .arrow,
+.button:focus-visible .arrow {
+    opacity: 0.85;
+    transform: translateX(0);
+}

--- a/apps/web/components/Home/AppCard.tsx
+++ b/apps/web/components/Home/AppCard.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { Card, Group, Text, Tooltip, UnstyledButton } from "@mantine/core";
+import { IconChevronRight } from "@tabler/icons-react";
+
+import type { JitaApp } from "~/config/apps";
+import classes from "./AppCard.module.css";
+
+export interface AppCardProps {
+  app: JitaApp;
+}
+
+export function AppCard({ app }: AppCardProps) {
+  return (
+    <Tooltip
+      label={app.description}
+      multiline
+      w={250}
+      withArrow
+      openDelay={200}
+      position="bottom"
+    >
+      <UnstyledButton
+        component={Link}
+        href={app.url ?? "#"}
+        onClick={app.onClick}
+        className={classes.button}
+      >
+        <Card className={classes.card} padding="md">
+          <Group wrap="nowrap" gap="sm" align="center">
+            <div className={classes.iconBox}>
+              <app.Icon width={30} height={30} alt={app.name} />
+            </div>
+            <Text fz="sm" fw={600} truncate style={{ flex: 1, minWidth: 0 }}>
+              {app.name}
+            </Text>
+            <IconChevronRight size={16} stroke={1.5} className={classes.arrow} />
+          </Group>
+        </Card>
+      </UnstyledButton>
+    </Tooltip>
+  );
+}

--- a/apps/web/components/Home/AppCard.tsx
+++ b/apps/web/components/Home/AppCard.tsx
@@ -11,7 +11,7 @@ export interface AppCardProps {
   app: JitaApp;
 }
 
-export function AppCard({ app }: AppCardProps) {
+export function AppCard({ app }: Readonly<AppCardProps>) {
   return (
     <Tooltip
       label={app.description}

--- a/apps/web/components/Home/SectionHeader.module.css
+++ b/apps/web/components/Home/SectionHeader.module.css
@@ -1,0 +1,45 @@
+.header {
+    margin-bottom: var(--mantine-spacing-md);
+}
+
+/* EVE-HUD accent bar to the left of the title */
+.bar {
+    flex: 0 0 auto;
+    width: rem(4px);
+    height: rem(22px);
+    border-radius: rem(2px);
+    background: linear-gradient(
+            180deg,
+            var(--mantine-primary-color-filled),
+            color-mix(in srgb, var(--mantine-primary-color-filled) 15%, transparent)
+    );
+    box-shadow: 0 0 rem(10px) color-mix(in srgb, var(--mantine-primary-color-filled) 45%, transparent);
+}
+
+.title {
+    white-space: nowrap;
+}
+
+/* Monospace count chip, e.g. "2" pilots */
+.count {
+    flex: 0 0 auto;
+    font-family: var(--mantine-font-family-monospace);
+    font-size: var(--mantine-font-size-xs);
+    line-height: 1;
+    color: var(--mantine-color-dimmed);
+    border: rem(1px) solid color-mix(in srgb, var(--mantine-primary-color-filled) 28%, transparent);
+    border-radius: var(--mantine-radius-xs);
+    padding: rem(3px) rem(8px);
+}
+
+/* Thin gradient rule that fills the remaining width */
+.rule {
+    flex: 1 1 auto;
+    min-width: rem(24px);
+    height: rem(1px);
+    background: linear-gradient(
+            90deg,
+            color-mix(in srgb, var(--mantine-primary-color-filled) 30%, transparent),
+            transparent
+    );
+}

--- a/apps/web/components/Home/SectionHeader.tsx
+++ b/apps/web/components/Home/SectionHeader.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Group, Title } from "@mantine/core";
+
+import classes from "./SectionHeader.module.css";
+
+export interface SectionHeaderProps {
+  title: string;
+  /** Optional count rendered as a monospace chip next to the title. */
+  count?: number;
+  /** Optional control rendered on the far right (e.g. a button). */
+  action?: ReactNode;
+}
+
+export function SectionHeader({ title, count, action }: SectionHeaderProps) {
+  return (
+    <Group
+      justify="space-between"
+      align="center"
+      wrap="nowrap"
+      gap="md"
+      className={classes.header}
+    >
+      <Group
+        gap="sm"
+        align="center"
+        wrap="nowrap"
+        style={{ flex: 1, minWidth: 0 }}
+      >
+        <span className={classes.bar} aria-hidden />
+        <Title order={3} className={classes.title}>
+          {title}
+        </Title>
+        {count != null && <span className={classes.count}>{count}</span>}
+        <span className={classes.rule} aria-hidden />
+      </Group>
+      {action}
+    </Group>
+  );
+}

--- a/apps/web/components/Home/SectionHeader.tsx
+++ b/apps/web/components/Home/SectionHeader.tsx
@@ -13,7 +13,11 @@ export interface SectionHeaderProps {
   action?: ReactNode;
 }
 
-export function SectionHeader({ title, count, action }: SectionHeaderProps) {
+export function SectionHeader({
+  title,
+  count,
+  action,
+}: Readonly<SectionHeaderProps>) {
   return (
     <Group
       justify="space-between"

--- a/apps/web/components/Home/index.ts
+++ b/apps/web/components/Home/index.ts
@@ -1,0 +1,3 @@
+export { AddPilotCard } from "./AddPilotCard";
+export { AppCard } from "./AppCard";
+export { SectionHeader } from "./SectionHeader";

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -60,6 +60,15 @@ const server = z.object({
  * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
  */
 const client = z.object({
+  /**
+   * Next.js inlines `NODE_ENV` into the client bundle, so it must be part of
+   * the client schema as well. Without it, `env.NODE_ENV` is `undefined` in
+   * Client Components (the client proxy only carries vars from this schema),
+   * which silently breaks `NODE_ENV`-gated UI and causes dev-only SSR/CSR
+   * hydration mismatches.
+   */
+  NODE_ENV: z.enum(["development", "test", "production"]),
+
   NEXT_PUBLIC_UMAMI_WEBSITE_ID:
     process.env.NODE_ENV === "production"
       ? z.string().min(1)

--- a/apps/web/tests/homePage.test.tsx
+++ b/apps/web/tests/homePage.test.tsx
@@ -100,15 +100,15 @@ describe("home page corporations", () => {
       </MantineProvider>,
     );
 
-    expect(screen.getByText("Corporations:")).toBeInTheDocument();
+    expect(screen.getByText("Corporations")).toBeInTheDocument();
     expect(screen.getAllByText("Corporation 1")).toHaveLength(1);
     expect(screen.queryByText("Corporation 2")).not.toBeInTheDocument();
 
-    expect(screen.getByText("Alliances:")).toBeInTheDocument();
+    expect(screen.getByText("Alliances")).toBeInTheDocument();
     expect(screen.getAllByText("Alliance 10")).toHaveLength(1);
   });
 
-  it("renders no corporation or alliance cards when none are available", () => {
+  it("renders no corporation or alliance sections when none are available", () => {
     mockUseAuthenticatedCharacterIds.mockReturnValue([100]);
     mockUseAuthStore.mockImplementation((selector) =>
       selector({
@@ -125,9 +125,9 @@ describe("home page corporations", () => {
       </MantineProvider>,
     );
 
-    expect(screen.getByText("Corporations:")).toBeInTheDocument();
+    expect(screen.queryByText("Corporations")).not.toBeInTheDocument();
     expect(screen.queryByText("Corporation 100")).not.toBeInTheDocument();
-    expect(screen.getByText("Alliances:")).toBeInTheDocument();
+    expect(screen.queryByText("Alliances")).not.toBeInTheDocument();
     expect(screen.queryByText("Alliance 100")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Redesigns the `apps/web` homepage for a cleaner, denser, more polished layout while keeping all existing content. Driven by feedback that the page had room to improve on UX/design.

## What changed

**Consistent EVE-HUD section headers** — `components/Home/SectionHeader.tsx`
- One header style for every section: accent bar + uppercase title + a monospace count chip (e.g. "Pilots · 2") + a thin gradient rule.
- Replaces the inconsistent mix of `Title` headings and dimmed `Corporations:` / `Alliances:` text labels.
- Accents derive from `--mantine-primary-color-filled` + `color-mix`, so they adapt to the active theme (default blue, EVE-teal, or any faction theme).

**Compact, launcher-style app cards** — `components/Home/AppCard.tsx`
- Single-row cards (icon chip + title) in **up to 4 columns** (was sparse, tall, 3-up).
- Description moved into a hover **Tooltip**; the always-visible description is gone.
- Working hover/focus micro-interactions (lift, border + icon glow, sliding chevron) via CSS modules — the previous `&:hover` lived in a dead `styles`-prop comment that never applied under Mantine v7+.
- Beta tags are no longer rendered on the cards.

**"Add pilot" card** — `components/Home/AddPilotCard.tsx`
- A dashed CTA that trails the pilot grid (and is the login entry point when logged out), replacing the easy-to-miss "Add character" text link.

**Page structure** — `app/page.tsx`
- Sections wrapped in a `Stack` with consistent vertical rhythm; the Corporations/Alliances sections now render only when non-empty (logged-out users no longer see empty labels).

**Bonus fix — dev-only hydration mismatch** — `env.ts`
- `NODE_ENV` was only in the *server* env schema, so `env.NODE_ENV` was `undefined` in Client Components → the `DevelopmentModeAlert` rendered server-side only → a React hydration mismatch (the Next "1 Issue" overlay in dev). Added `NODE_ENV` to the *client* schema so it resolves consistently on both sides. (The ESLint `no-restricted-properties` rule bans `process.env`, so the fix belongs in the schema, not the call site.)

## Verification
- Rendered logged-out and logged-in (injected two real pilots) at desktop and mobile (375–1380px): all sections, count chips, the add-pilot card, and both 4-column tool grids render correctly; no horizontal overflow.
- Next dev overlay: **0 issues** (hydration mismatch resolved and confirmed).
- Tooltips confirmed rendering the app descriptions (multiline, positioned below the card) and hidden by default.
- `eslint` and `tsc --noEmit` clean for the changed files.

## Notes for reviewers
- **No changeset:** `@jitaspace/web` is `private`.
- `config/apps.tsx` `tags` were intentionally left in place (they may feed other UI such as the header mega-menu); the beta badges are simply not rendered on these cards.
- Tooltips are desktop-centric (on touch, tapping a card navigates). The grid is single-column on mobile — happy to keep descriptions inline on mobile if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
