### PR TITLE
fix(hooks): show character descriptions instead of "No description"

### DIFF
--- a/.changeset/fix-character-description.md
+++ b/.changeset/fix-character-description.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/hooks": patch
+"@jitaspace/web": patch
+---
+
+Fixed character pages always showing "No description". A character's biography and security status are now read from EVE Online and displayed correctly. Previously the `useCharacter` hook fetched these fields but never passed them through, so every character appeared to have no description.

--- a/packages/hooks/src/hooks/character/useCharacter.ts
+++ b/packages/hooks/src/hooks/character/useCharacter.ts
@@ -159,6 +159,10 @@ export const useCharacter = (
             locationId: agent.data.data.locationID,
             name: esiCharacter.data.data.name,
             raceId: esiCharacter.data.data.race_id,
+            description: esiCharacter.data.data.description,
+            factionId: esiCharacter.data.data.faction_id,
+            securityStatus: esiCharacter.data.data.security_status,
+            title: esiCharacter.data.data.title,
             ...researchAgentData,
             ...agentInSpaceData,
           }
@@ -188,6 +192,10 @@ export const useCharacter = (
             gender: esiCharacter.data.data.gender,
             name: esiCharacter.data.data.name,
             raceId: esiCharacter.data.data.race_id,
+            description: esiCharacter.data.data.description,
+            factionId: esiCharacter.data.data.faction_id,
+            securityStatus: esiCharacter.data.data.security_status,
+            title: esiCharacter.data.data.title,
           }
         : null,
     [esiCharacter.data, isNpc],

--- a/packages/hooks/tests/useCharacter.test.tsx
+++ b/packages/hooks/tests/useCharacter.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { renderHook } from "@testing-library/react";
+
+// useCharacter merges the public ESI character record with SDE agent data. The
+// generated @jitaspace/esi-client and @jitaspace/sde-client clients aren't built
+// in this workspace, and @swc/jest does not hoist jest.mock above imports, so
+// every dependency is mocked here and the hook under test is required lazily.
+
+const mockUseEsiCharacter = jest.fn();
+const mockUseSdeAgent = jest.fn();
+const mockUseGetAllNpcCharacterIds = jest.fn();
+const mockUseGetAllAgentInSpaceIds = jest.fn();
+const mockUseGetAgentInSpaceById = jest.fn();
+
+jest.mock("@jitaspace/esi-client", () => ({
+  __esModule: true,
+  CharactersDetailGenderEnum: { male: "male", female: "female" },
+}));
+
+jest.mock("@jitaspace/esi-metadata", () => ({
+  __esModule: true,
+  isIdInRanges: () => false,
+  npcCharacterIdRanges: [],
+}));
+
+jest.mock("@jitaspace/sde-client", () => ({
+  __esModule: true,
+  useGetAllNpcCharacterIds: (...args: unknown[]) =>
+    mockUseGetAllNpcCharacterIds(...args),
+  useGetAllAgentInSpaceIds: (...args: unknown[]) =>
+    mockUseGetAllAgentInSpaceIds(...args),
+  useGetAgentInSpaceById: (...args: unknown[]) =>
+    mockUseGetAgentInSpaceById(...args),
+}));
+
+jest.mock("../src/hooks/character/useEsiCharacter", () => ({
+  __esModule: true,
+  useEsiCharacter: (...args: unknown[]) => mockUseEsiCharacter(...args),
+}));
+
+jest.mock("../src/hooks/character/useSdeAgent", () => ({
+  __esModule: true,
+  useSdeAgent: (...args: unknown[]) => mockUseSdeAgent(...args),
+}));
+
+const { useCharacter } =
+  require("../src/hooks/character/useCharacter") as typeof import("../src/hooks/character/useCharacter");
+
+const CHARACTER_ID = 30000142;
+
+// A public ESI character record carrying every optional biography field.
+const esiCharacterDetail = {
+  bloodline_id: 1,
+  corporation_id: 1000035,
+  alliance_id: 99000001,
+  gender: "male",
+  name: "Test Character",
+  race_id: 1,
+  birthday: "2003-05-06T00:00:00Z",
+  description: "A short biography",
+  faction_id: 500001,
+  security_status: 4.2,
+  title: "Fleet Commander",
+};
+
+function querySuccess<T>(data: T) {
+  return { data, error: null, isError: false, isLoading: false };
+}
+
+function queryIdle() {
+  return { data: undefined, error: null, isError: false, isLoading: false };
+}
+
+describe("useCharacter", () => {
+  it("propagates the ESI description, faction, security status and title for a player", () => {
+    mockUseEsiCharacter.mockReturnValue(
+      querySuccess({ data: esiCharacterDetail }),
+    );
+    mockUseGetAllNpcCharacterIds.mockReturnValue(querySuccess({ data: [] }));
+    mockUseSdeAgent.mockReturnValue(queryIdle());
+    mockUseGetAllAgentInSpaceIds.mockReturnValue(querySuccess({ data: [] }));
+    mockUseGetAgentInSpaceById.mockReturnValue(queryIdle());
+
+    const { result } = renderHook(() => useCharacter(CHARACTER_ID));
+
+    expect(result.current.data?.type).toBe("player");
+    expect(result.current.data?.description).toBe("A short biography");
+    expect(result.current.data?.factionId).toBe(500001);
+    expect(result.current.data?.securityStatus).toBe(4.2);
+    expect(result.current.data?.title).toBe("Fleet Commander");
+  });
+
+  it("propagates the ESI biography fields for an agent", () => {
+    mockUseEsiCharacter.mockReturnValue(
+      querySuccess({ data: esiCharacterDetail }),
+    );
+    // The character id is a known NPC agent -> the agent branch is taken.
+    mockUseGetAllNpcCharacterIds.mockReturnValue(
+      querySuccess({ data: [CHARACTER_ID] }),
+    );
+    mockUseSdeAgent.mockReturnValue(
+      querySuccess({
+        data: {
+          agent: {
+            agentTypeID: 3,
+            divisionID: 22,
+            isLocator: true,
+            level: 4,
+          },
+          corporationID: 1000035,
+          locationID: 60000001,
+          skills: [],
+        },
+      }),
+    );
+    mockUseGetAllAgentInSpaceIds.mockReturnValue(querySuccess({ data: [] }));
+    mockUseGetAgentInSpaceById.mockReturnValue(queryIdle());
+
+    const { result } = renderHook(() => useCharacter(CHARACTER_ID));
+
+    expect(result.current.data?.type).toBe("agent");
+    expect(result.current.data?.description).toBe("A short biography");
+    expect(result.current.data?.factionId).toBe(500001);
+    expect(result.current.data?.securityStatus).toBe(4.2);
+    expect(result.current.data?.title).toBe("Fleet Commander");
+  });
+
+  it("leaves the biography fields undefined when ESI omits them", () => {
+    // A record without any of the optional biography fields.
+    const minimal = {
+      bloodline_id: esiCharacterDetail.bloodline_id,
+      corporation_id: esiCharacterDetail.corporation_id,
+      alliance_id: esiCharacterDetail.alliance_id,
+      gender: esiCharacterDetail.gender,
+      name: esiCharacterDetail.name,
+      race_id: esiCharacterDetail.race_id,
+      birthday: esiCharacterDetail.birthday,
+    };
+    mockUseEsiCharacter.mockReturnValue(querySuccess({ data: minimal }));
+    mockUseGetAllNpcCharacterIds.mockReturnValue(querySuccess({ data: [] }));
+    mockUseSdeAgent.mockReturnValue(queryIdle());
+    mockUseGetAllAgentInSpaceIds.mockReturnValue(querySuccess({ data: [] }));
+    mockUseGetAgentInSpaceById.mockReturnValue(queryIdle());
+
+    const { result } = renderHook(() => useCharacter(CHARACTER_ID));
+
+    expect(result.current.data?.type).toBe("player");
+    expect(result.current.data?.description).toBeUndefined();
+    expect(result.current.data?.factionId).toBeUndefined();
+    expect(result.current.data?.securityStatus).toBeUndefined();
+    expect(result.current.data?.title).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Fixes character pages always showing **"No description"** for every character.

## Why

The character page renders the bio via `useCharacter(...).data?.description`, falling back to `"No description"` when it's absent. The [`useCharacter`](https://github.com/joaomlneto/jitaspace/blob/main/packages/hooks/src/hooks/character/useCharacter.ts) hook declares `description?: string` on its `PlayerCharacter` type and fetches the full ESI character record (which **does** include `description`) — but it never copied that field into the object it returns. So `character.description` was always `undefined`, and every character showed "No description".

The same omission also silently dropped `securityStatus`, `factionId`, and `title` — all declared on the type and provided by ESI, all lost in the merge.

## Changes

- Populate `description`, `factionId`, `securityStatus`, and `title` from the ESI record in **both** the player and agent merge branches of `useCharacter`.
- Add a `useCharacter` regression test (player / agent / ESI-omits-the-fields paths).
- Changeset (`@jitaspace/hooks` + `@jitaspace/web`, user-facing).

## Reviewer notes

- **User-visible effect:** `description` and `securityStatus` are both displayed on the character page — the "Security Status" row was also always hidden due to the same bug. `factionId` and `title` aren't rendered on this page today; they're populated so the hook honors its own type contract and future consumers get correct data.
- **Why the existing test missed it:** [`characterPage.test.tsx`](https://github.com/joaomlneto/jitaspace/blob/main/apps/web/tests/characterPage.test.tsx) mocks `useCharacter` with a `description` already present, so it could never catch a hook that drops the field. The new test exercises the real merge logic — all passing, covering all new lines (97% file coverage).
- **Verification:** unit test passes; types are correct by construction (all four fields exist on the ESI `CharactersDetail` type and the merge targets already declare them as optional). A live browser check wasn't possible in this worktree (generated ESI client not built locally), but the unit test exercises exactly the merge path that was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)