### PR TITLE
chore(turbo): declare TRIGGER_VERSION in globalPassThroughEnv

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,7 @@
     "CI",
     "VERCEL",
     "VERCEL_URL",
+    "TRIGGER_VERSION",
     "npm_lifecycle_event"
   ],
   "tasks": {


### PR DESCRIPTION
## What

Declare `TRIGGER_VERSION` in `turbo.json`'s `globalPassThroughEnv`.

## Why

Vercel builds emit this warning for every build/codegen task:

> Warning - the following environment variables are set on your Vercel project, but missing from "turbo.json". These variables WILL NOT be available to your application and may cause your build to fail.
> - `TRIGGER_VERSION`

The Trigger.dev ↔ Vercel integration injects `TRIGGER_VERSION` into the Vercel project, but it was never declared in `turbo.json`. Turborepo's strict-env mode therefore strips it from the build-task environment and warns about it. The sibling `TRIGGER_*` vars that the app actually consumes (`TRIGGER_SECRET_KEY`, `TRIGGER_API_URL`, `TRIGGER_PROJECT_REF`) are already declared in `globalEnv`.

## Why `globalPassThroughEnv` (not `globalEnv`)

- Nothing in the codebase reads `TRIGGER_VERSION` at build time (`grep` across the repo returns no references).
- Its value changes on every Trigger.dev deploy. Adding it to `globalEnv` would fold it into the Turbo cache hash and needlessly bust the build cache on each deploy.
- `globalPassThroughEnv` makes the var available to tasks without affecting the cache hash — which silences the warning at zero cache cost.

## Notes for reviewer

- No changeset: this is a root build-config tweak with no published-package or user-facing effect.
- If we ever start consuming `TRIGGER_VERSION` during the build, it should move to `globalEnv` so value changes invalidate the cache correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)