### PR TITLE
feat(web): add change-history tab to item pages

### DIFF
--- a/.changeset/type-page-history-tab.md
+++ b/.changeset/type-page-history-tab.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+Add a History tab to item pages. Each item page (`/type/{id}`) now has a History tab showing how that item has changed across EVE client builds — the same per-build change timeline as the dedicated `/history/type/{id}` page, with the collection filters and links to each build.

--- a/apps/web/app/history/EntityHistory.tsx
+++ b/apps/web/app/history/EntityHistory.tsx
@@ -29,15 +29,21 @@ import { EventContent } from "./_event";
  * Fetches the entity's timeline, renders the collection-filter chips and the
  * per-build timeline. `renderHeader` lets each route supply its own heading
  * (icon, name, links), optionally using the loaded timeline for a label.
+ *
+ * `embedded` renders without the outer page `Container` (and typically without
+ * a header) so the timeline can sit inside a host that already provides one —
+ * e.g. the History tab on the type page.
  */
 export function EntityHistory({
   entityType,
   entityId,
   renderHeader,
+  embedded = false,
 }: Readonly<{
   entityType: string;
   entityId: number;
-  renderHeader: (timeline: EntityTimeline | null) => ReactNode;
+  renderHeader?: (timeline: EntityTimeline | null) => ReactNode;
+  embedded?: boolean;
 }>) {
   const { data, isLoading } = useQuery({
     queryKey: ["history-entity", entityType, entityId],
@@ -49,21 +55,30 @@ export function EntityHistory({
 
   if (isLoading) return <Loader />;
 
-  const header = renderHeader(data ?? null);
+  const header = renderHeader?.(data ?? null) ?? null;
+
+  // When embedded the host supplies the page Container, so render bare to avoid
+  // nesting containers (which would mis-constrain the timeline's width).
+  const wrap = (children: ReactNode) =>
+    embedded ? (
+      children
+    ) : (
+      <Container size="md" py="xl">
+        {children}
+      </Container>
+    );
 
   if (!data || data.events.length === 0) {
-    return (
-      <Container size="md" py="xl">
-        <Stack gap="lg">
-          {header}
-          <Alert color="gray">
-            No recorded changes for this entity across the tracked builds.{" "}
-            <Anchor component={Link} href="/history">
-              Back to history
-            </Anchor>
-          </Alert>
-        </Stack>
-      </Container>
+    return wrap(
+      <Stack gap="lg">
+        {header}
+        <Alert color="gray">
+          No recorded changes for this entity across the tracked builds.{" "}
+          <Anchor component={Link} href="/history">
+            Back to history
+          </Anchor>
+        </Alert>
+      </Stack>,
     );
   }
 
@@ -97,85 +112,83 @@ export function EntityHistory({
     else buildGroups.push({ build: e.build, date: e.date, events: [e] });
   }
 
-  return (
-    <Container size="md" py="xl">
-      <Stack gap="lg">
-        {header}
-        <Group gap="xs">
-          <Badge variant="light">{visibleEvents.length} events</Badge>
-          {seenCollections.length > 1 && (
-            <Chip.Group multiple value={active} onChange={setSelected}>
-              <Group gap={6}>
-                {seenCollections.map((c) => (
-                  <Chip
-                    key={c}
-                    value={c}
-                    size="xs"
-                    color={collectionMeta(c).color}
-                  >
-                    {collectionMeta(c).label}
-                  </Chip>
-                ))}
-              </Group>
-            </Chip.Group>
-          )}
-          <Anchor component={Link} href="/history" size="sm">
-            All history
-          </Anchor>
-        </Group>
+  return wrap(
+    <Stack gap="lg">
+      {header}
+      <Group gap="xs">
+        <Badge variant="light">{visibleEvents.length} events</Badge>
+        {seenCollections.length > 1 && (
+          <Chip.Group multiple value={active} onChange={setSelected}>
+            <Group gap={6}>
+              {seenCollections.map((c) => (
+                <Chip
+                  key={c}
+                  value={c}
+                  size="xs"
+                  color={collectionMeta(c).color}
+                >
+                  {collectionMeta(c).label}
+                </Chip>
+              ))}
+            </Group>
+          </Chip.Group>
+        )}
+        <Anchor component={Link} href="/history" size="sm">
+          All history
+        </Anchor>
+      </Group>
 
-        <Paper withBorder p="lg" radius="md">
-          {buildGroups.length === 0 && (
-            <Text size="sm" c="dimmed">
-              No changes match the selected collections.
-            </Text>
-          )}
-          <Timeline active={buildGroups.length} bulletSize={20} lineWidth={2}>
-            {buildGroups.map((group) => (
-              <Timeline.Item
-                key={group.build}
-                title={
-                  <Group gap="xs">
-                    <Anchor
-                      component={Link}
-                      href={`/history/build/${group.build}`}
-                      fw={500}
-                    >
-                      {group.date ?? `Build ${group.build}`}
-                    </Anchor>
-                    <Text size="xs" c="dimmed">
-                      build {group.build}
-                    </Text>
-                  </Group>
-                }
-              >
-                <Stack gap="sm" mt={2}>
-                  {group.events.map((event) => {
-                    const meta = collectionMeta(event.collection);
-                    return (
-                      <div key={event.collection ?? "types"}>
-                        <Group gap="xs">
-                          <Badge size="sm" variant="dot" color={meta.color}>
-                            {meta.label}
-                          </Badge>
-                          <Badge
-                            size="sm"
-                            variant="light"
-                            color={KIND_COLOR[event.kind]}
-                          >
-                            {event.kind}
-                          </Badge>
-                        </Group>
-                        <EventContent event={event} entityType={entityType} />
-                      </div>
-                    );
-                  })}
-                </Stack>
-              </Timeline.Item>
-            ))}
-          </Timeline>
-        </Paper>
-      </Stack>
-    </Container>
+      <Paper withBorder p="lg" radius="md">
+        {buildGroups.length === 0 && (
+          <Text size="sm" c="dimmed">
+            No changes match the selected collections.
+          </Text>
+        )}
+        <Timeline active={buildGroups.length} bulletSize={20} lineWidth={2}>
+          {buildGroups.map((group) => (
+            <Timeline.Item
+              key={group.build}
+              title={
+                <Group gap="xs">
+                  <Anchor
+                    component={Link}
+                    href={`/history/build/${group.build}`}
+                    fw={500}
+                  >
+                    {group.date ?? `Build ${group.build}`}
+                  </Anchor>
+                  <Text size="xs" c="dimmed">
+                    build {group.build}
+                  </Text>
+                </Group>
+              }
+            >
+              <Stack gap="sm" mt={2}>
+                {group.events.map((event) => {
+                  const meta = collectionMeta(event.collection);
+                  return (
+                    <div key={event.collection ?? "types"}>
+                      <Group gap="xs">
+                        <Badge size="sm" variant="dot" color={meta.color}>
+                          {meta.label}
+                        </Badge>
+                        <Badge
+                          size="sm"
+                          variant="light"
+                          color={KIND_COLOR[event.kind]}
+                        >
+                          {event.kind}
+                        </Badge>
+                      </Group>
+                      <EventContent event={event} entityType={entityType} />
+                    </div>
+                  );
+                })}
+              </Stack>
+            </Timeline.Item>
+          ))}
+        </Timeline>
+      </Paper>
+    </Stack>,
   );
 }

--- a/apps/web/app/type/[typeId]/page.client.tsx
+++ b/apps/web/app/type/[typeId]/page.client.tsx
@@ -25,6 +25,7 @@ import {
   IconCoin,
   IconExternalLink,
   IconFileText,
+  IconHistory,
   IconInfoCircle,
   IconListDetails,
 } from "@tabler/icons-react";
@@ -67,6 +68,7 @@ import {
   GroupName,
   MarketGroupName,
 } from "~/components/Text";
+import { EntityHistory } from "../../history/EntityHistory";
 
 export interface PageProps {
   typeId: number;
@@ -637,6 +639,9 @@ export default function TypePage({
                 Description
               </Tabs.Tab>
             )}
+            <Tabs.Tab value="history" leftSection={<IconHistory size={16} />}>
+              History
+            </Tabs.Tab>
           </Tabs.List>
 
           {/* Overview */}
@@ -909,6 +914,11 @@ export default function TypePage({
               </Paper>
             </Tabs.Panel>
           )}
+
+          {/* History — per-build change timeline (loaded on demand) */}
+          <Tabs.Panel value="history" pt="lg">
+            <EntityHistory entityType="type" entityId={typeId} embedded />
+          </Tabs.Panel>
         </Tabs>
       </Stack>
     </Container>


### PR DESCRIPTION
## What

Adds a **History** tab to item pages (`/type/{typeId}`). It presents the same per-build change timeline as the dedicated `/history/type/{typeId}` page — events count, collection filter chips (Dogma, Type, …), per-build entries with change details, and links to each build and to the full history.

The timeline loads **lazily**, only when the user opens the History tab (`keepMounted={false}`), so it adds no cost to the initial item-page render.

## Why

The change history already existed at a separate `/history/type/{id}` URL, but it wasn't discoverable from the item itself. Surfacing it as a tab puts "how has this item changed across EVE client builds" right where users are already looking at the item.

## How

- **`apps/web/app/type/[typeId]/page.client.tsx`** — new `History` tab (`IconHistory`) + a panel rendering `<EntityHistory entityType="type" entityId={typeId} embedded />`.
- **`apps/web/app/history/EntityHistory.tsx`** — the shared timeline component gains an optional `embedded` mode: `renderHeader` is now optional and `embedded` skips the outer page `Container` so it nests cleanly inside the type page's `lg` container (no double-wrapping / mis-constrained width). Fully backward-compatible — the standalone `/history/type/{id}` route still passes `renderHeader` and renders its own container + header.

## Verification

Ran the dev server against live (read-only) data and exercised the feature in-browser:

- **Rifter (587)** → History tab loads the populated timeline (4 events; Dogma/Type chips; e.g. Heat Attenuation `0.63 → 0.5` in build 2420589). No nested container.
- **Tritanium (34)** → embedded empty state renders correctly ("No recorded changes" + "Back to history").
- **Regression** — standalone `/history/type/587` unchanged: header "Rifter #587", "View item page →" link, and timeline all intact.
- `type-check` clean on both files; `lint` clean; no server or console errors.

## Reviewer notes

- The large line count on `EntityHistory.tsx` is mostly re-indentation: the `Container` was lifted into a small `wrap()` helper so both the empty and populated branches share the embedded/standalone decision.
- Changeset: `@jitaspace/web: minor` (new user-facing feature surface). Happy to drop to `patch` if preferred.