### PR TITLE
Redesign the navigation header and flag limited search without a character

### DIFF
--- a/.changeset/header-menu-redesign.md
+++ b/.changeset/header-menu-redesign.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+Redesigned the top navigation header. The Character, Corporation, Alliance and Universe menus now show text labels next to their icons, the menu for the section you're currently in is highlighted, and hovering an entry reveals what it does. A new search box opens search straight from the header — click it or press ⌘K / Ctrl+K. The bar adapts to your screen size (labels and the full search box on wider screens, a compact layout on smaller ones, and a burger menu on phones), and apps are no longer marked "beta".

--- a/.changeset/search-auth-notice.md
+++ b/.changeset/search-auth-notice.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Search (and the ⌘K spotlight) now show a short notice when no character is signed in, explaining that finding people, corporations and places across New Eden needs a logged-in character — EVE's search is authenticated — with a one-click way to log in. Without it, only JitaSpace's own pages and tools are searchable.

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
 
+import { SearchScopeNotice } from "~/components/Spotlight/SearchScopeNotice";
 import { useSearchActions } from "~/components/Spotlight/useSearchActions";
 
 /**
@@ -24,7 +25,8 @@ import { useSearchActions } from "~/components/Spotlight/useSearchActions";
 function SearchView() {
   const searchParams = useSearchParams();
   const [query, setQuery] = useState<string>(searchParams.get("q") ?? "");
-  const { filteredActions, ungrouped, groups } = useSearchActions(query);
+  const { filteredActions, ungrouped, groups, canSearchEntities } =
+    useSearchActions(query);
 
   // Focus the search box on mount (this is a dedicated search destination).
   // Done via ref rather than the autoFocus attribute, which is an a11y smell.
@@ -47,11 +49,11 @@ function SearchView() {
           onChange={(event) => setQuery(event.currentTarget.value)}
         />
 
+        {!canSearchEntities && <SearchScopeNotice />}
+
         {filteredActions.length > 0 ? (
           <Stack gap="lg">
-            {ungrouped.length > 0 && (
-              <SearchActionList actions={ungrouped} />
-            )}
+            {ungrouped.length > 0 && <SearchActionList actions={ungrouped} />}
             {Object.entries(groups).map(([groupName, groupActions]) => (
               <Stack key={groupName} gap="xs">
                 <Text size="xs" tt="uppercase" c="dimmed" fw={700}>

--- a/apps/web/components/Spotlight/MainSpotlight.tsx
+++ b/apps/web/components/Spotlight/MainSpotlight.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { Spotlight } from "@mantine/spotlight";
+import { Box } from "@mantine/core";
+import { closeSpotlight, Spotlight } from "@mantine/spotlight";
 
+import { SearchScopeNotice } from "./SearchScopeNotice";
 import { useSearchActions } from "./useSearchActions";
 
 export const MainSpotlight = () => {
   const [query, setQuery] = useState<string>("");
-  const { filteredActions, ungrouped, groups } = useSearchActions(query);
+  const { filteredActions, ungrouped, groups, canSearchEntities } =
+    useSearchActions(query);
 
   // Use the compound API so SpotlightActionsList is always mounted.
   // When SpotlightActionsList unmounts it clears listId to ""; pressing Enter
@@ -20,6 +23,11 @@ export const MainSpotlight = () => {
       onQueryChange={setQuery}
     >
       <Spotlight.Search />
+      {!canSearchEntities && (
+        <Box px="md" pt="xs">
+          <SearchScopeNotice onBeforeLogin={() => closeSpotlight()} />
+        </Box>
+      )}
       <Spotlight.ActionsList mah="60vh" style={{ overflowY: "auto" }}>
         {filteredActions.length > 0 ? (
           <>

--- a/apps/web/components/Spotlight/SearchScopeNotice.tsx
+++ b/apps/web/components/Spotlight/SearchScopeNotice.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Alert, Anchor } from "@mantine/core";
+import { openContextModal } from "@mantine/modals";
+import { IconSearchOff } from "@tabler/icons-react";
+
+export interface SearchScopeNoticeProps {
+  /** Run before the login modal opens — e.g. to close the Spotlight first. */
+  onBeforeLogin?: () => void;
+}
+
+/**
+ * Shown in Search / Spotlight when no signed-in character can reach EVE's search.
+ * ESI's only search endpoint (`/characters/{id}/search`) is character-authenticated,
+ * so without a token the universe results never load and search is limited to the
+ * app's own pages. Explains the limitation and offers a way to log in.
+ */
+export function SearchScopeNotice({ onBeforeLogin }: SearchScopeNoticeProps) {
+  return (
+    <Alert
+      variant="light"
+      color="yellow"
+      icon={<IconSearchOff size={18} />}
+      title="Search is limited"
+    >
+      Without a signed-in character, search only covers JitaSpace&rsquo;s own
+      pages and tools — finding pilots, corporations and places across New Eden
+      uses EVE&rsquo;s authenticated search.{" "}
+      <Anchor
+        component="button"
+        type="button"
+        inherit
+        onClick={() => {
+          onBeforeLogin?.();
+          openContextModal({
+            modal: "login",
+            title: "Log in",
+            size: "xl",
+            innerProps: {},
+          });
+        }}
+      >
+        Log in to search New Eden
+      </Anchor>
+      .
+    </Alert>
+  );
+}

--- a/apps/web/components/Spotlight/SearchScopeNotice.tsx
+++ b/apps/web/components/Spotlight/SearchScopeNotice.tsx
@@ -15,7 +15,9 @@ export interface SearchScopeNoticeProps {
  * so without a token the universe results never load and search is limited to the
  * app's own pages. Explains the limitation and offers a way to log in.
  */
-export function SearchScopeNotice({ onBeforeLogin }: SearchScopeNoticeProps) {
+export function SearchScopeNotice({
+  onBeforeLogin,
+}: Readonly<SearchScopeNoticeProps>) {
   return (
     <Alert
       variant="light"

--- a/apps/web/components/Spotlight/useSearchActions.tsx
+++ b/apps/web/components/Spotlight/useSearchActions.tsx
@@ -32,6 +32,12 @@ export interface SearchActionGroups {
   ungrouped: SpotlightActionData[];
   /** Actions keyed by their group label. */
   groups: Record<string, SpotlightActionData[]>;
+  /**
+   * Whether EVE entity search is reachable, i.e. a signed-in character holds the
+   * `esi-search.search_structures.v1` scope. When false, only the app/tool
+   * actions are available and the UI should surface that limitation.
+   */
+  canSearchEntities: boolean;
 }
 
 /**
@@ -43,7 +49,8 @@ export function useSearchActions(query: string): SearchActionGroups {
   const router = useRouter();
   const [debouncedQuery] = useDebouncedValue(query, 1000);
 
-  const { data: esiSearchData } = useEsiSearch(debouncedQuery);
+  const { data: esiSearchData, canSearchStructures } =
+    useEsiSearch(debouncedQuery);
 
   const entityEntries = useMemo(
     () =>
@@ -144,8 +151,7 @@ export function useSearchActions(query: string): SearchActionGroups {
     const _ungrouped: SpotlightActionData[] = [];
     for (const action of filteredActions) {
       if (action.group) {
-        _groups[action.group] ??= [];
-        _groups[action.group].push(action);
+        (_groups[action.group] ??= []).push(action);
       } else {
         _ungrouped.push(action);
       }
@@ -153,5 +159,10 @@ export function useSearchActions(query: string): SearchActionGroups {
     return { ungrouped: _ungrouped, groups: _groups };
   }, [filteredActions]);
 
-  return { filteredActions, ungrouped, groups };
+  return {
+    filteredActions,
+    ungrouped,
+    groups,
+    canSearchEntities: canSearchStructures,
+  };
 }

--- a/apps/web/components/Spotlight/useSearchActions.tsx
+++ b/apps/web/components/Spotlight/useSearchActions.tsx
@@ -151,7 +151,9 @@ export function useSearchActions(query: string): SearchActionGroups {
     const _ungrouped: SpotlightActionData[] = [];
     for (const action of filteredActions) {
       if (action.group) {
-        (_groups[action.group] ??= []).push(action);
+        const group = _groups[action.group] ?? [];
+        _groups[action.group] = group;
+        group.push(action);
       } else {
         _ungrouped.push(action);
       }

--- a/apps/web/config/apps.tsx
+++ b/apps/web/config/apps.tsx
@@ -33,7 +33,6 @@ export interface JitaApp {
   url?: string;
   onClick?: () => void;
   Icon: (props: EveIconProps) => React.ReactElement;
-  tags?: string[];
   hotKey?: string[];
   scopes: {
     required?: AppScopeSet[];
@@ -107,7 +106,6 @@ export const characterApps: Record<string, JitaApp> = {
     description: "View and manage your character's contacts.",
     url: "/contacts/character",
     Icon: (props: EveIconProps) => React.createElement(ContactsIcon, props),
-    tags: ["beta"],
     scopes: {
       optional: [
         {
@@ -134,7 +132,6 @@ export const characterApps: Record<string, JitaApp> = {
     description: "View and manage your character's ship fittings.",
     url: "/fittings",
     Icon: (props: EveIconProps) => React.createElement(FittingIcon, props),
-    tags: ["beta"],
     scopes: {
       required: [
         {
@@ -155,7 +152,6 @@ export const characterApps: Record<string, JitaApp> = {
     description: "Manage your skills and skills points on your characters.",
     url: "/skills",
     Icon: (props) => React.createElement(SkillsIcon, props),
-    tags: ["beta"],
     scopes: {
       required: [
         { reason: "Read Skills", scopes: ["esi-skills.read_skills.v1"] },
@@ -171,9 +167,7 @@ export const characterApps: Record<string, JitaApp> = {
     name: "Assets",
     description: "View and manage your character's assets.",
     url: "/assets/character",
-    Icon: (props) => React.createElement(AssetsIcon, props),
-    tags: ["beta"],
-    scopes: {
+    Icon: (props) => React.createElement(AssetsIcon, props),    scopes: {
       optional: [
         {
           reason: "View your character assets",
@@ -194,7 +188,6 @@ export const characterApps: Record<string, JitaApp> = {
     description: "View your character's and your corporation's wallet.",
     url: "/wallet/character",
     Icon: (props) => React.createElement(WalletIcon, props),
-    tags: ["beta"],
     scopes: {
       optional: [
         {
@@ -213,9 +206,7 @@ export const characterApps: Record<string, JitaApp> = {
     name: "Notifications",
     description: "View your character in-game notifications",
     url: "/notifications",
-    Icon: (props: EveIconProps) => React.createElement(MemberIcon, props),
-    tags: ["beta"],
-    scopes: {
+    Icon: (props: EveIconProps) => React.createElement(MemberIcon, props),    scopes: {
       required: [
         {
           reason: "Read Character Notifications",
@@ -234,7 +225,6 @@ export const corporationApps: Record<string, JitaApp> = {
     description: "View and manage your corporation's contacts.",
     url: "/contacts/corporation",
     Icon: (props: EveIconProps) => React.createElement(ContactsIcon, props),
-    tags: ["beta"],
     scopes: {
       optional: [
         {
@@ -261,9 +251,7 @@ export const corporationApps: Record<string, JitaApp> = {
     name: "Assets",
     description: "View and manage your corporation's assets.",
     url: "/assets/corporation",
-    Icon: (props) => React.createElement(AssetsIcon, props),
-    tags: ["beta"],
-    scopes: {
+    Icon: (props) => React.createElement(AssetsIcon, props),    scopes: {
       optional: [
         {
           reason: "View your character assets",
@@ -284,7 +272,6 @@ export const corporationApps: Record<string, JitaApp> = {
     description: "View your corporation's wallet balance and transactions.",
     url: "/wallet/corporation",
     Icon: (props) => React.createElement(WalletIcon, props),
-    tags: ["beta"],
     scopes: {
       optional: [
         {
@@ -306,7 +293,6 @@ export const allianceApps: Record<string, JitaApp> = {
     description: "View and manage your alliance's contacts.",
     url: "/contacts/alliance",
     Icon: (props: EveIconProps) => React.createElement(ContactsIcon, props),
-    tags: ["beta"],
     scopes: {
       optional: [
         {
@@ -333,7 +319,6 @@ export const universeApps: Record<string, JitaApp> = {
     url: "/active-wars",
     Icon: (props) => <WarsIcon {...props} />,
     scopes: {},
-    tags: [],
   },
   map: {
     name: "Map",
@@ -356,7 +341,6 @@ export const universeApps: Record<string, JitaApp> = {
     url: "/agents",
     Icon: (props) => <AgentFinderIcon {...props} />,
     scopes: {},
-    tags: ["beta"],
   },
   travel: {
     name: "Travel Planner",
@@ -364,7 +348,6 @@ export const universeApps: Record<string, JitaApp> = {
     url: "/travel/jita/amarr",
     Icon: (props) => <MapIcon {...props} />,
     scopes: {},
-    tags: ["beta"],
   },
   market: {
     name: "Market",
@@ -372,7 +355,6 @@ export const universeApps: Record<string, JitaApp> = {
     url: "/market",
     Icon: (props) => <MarketIcon {...props} />,
     scopes: {},
-    tags: ["beta"],
   },
   dogma: {
     name: "Dogma",
@@ -380,7 +362,6 @@ export const universeApps: Record<string, JitaApp> = {
     url: "/dogma",
     Icon: (props) => <AttributesIcon {...props} />,
     scopes: {},
-    tags: ["beta"],
   },
   /*
                                 search: {

--- a/apps/web/layouts/MainLayout/HeaderMenu/DesktopNavMenu.tsx
+++ b/apps/web/layouts/MainLayout/HeaderMenu/DesktopNavMenu.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type React from "react";
+import { memo } from "react";
+import Link from "next/link";
+import { Box, Center, Menu, Tooltip, UnstyledButton } from "@mantine/core";
+import { IconChevronDown } from "@tabler/icons-react";
+
+import type { EveIconProps } from "@jitaspace/eve-icons";
+
+import type { JitaApp } from "~/config/apps";
+import classes from "./HeaderMenu.module.css";
+
+export interface DesktopNavMenuProps {
+  label: string;
+  Icon: React.ComponentType<EveIconProps>;
+  apps: Record<string, JitaApp>;
+  /** Highlight this group as the current section. */
+  active?: boolean;
+}
+
+/**
+ * A single labelled header dropdown ("Character ▾"). Opens on hover or click and
+ * lists its apps as a compact icon + name menu; each item's description shows in
+ * a tooltip on hover. The text label is hidden below `md` (icon-only trigger) so
+ * the bar stays responsive — the dropdown still names every app.
+ */
+export const DesktopNavMenu = memo(
+  ({ label, Icon, apps, active }: DesktopNavMenuProps) => {
+    const items = Object.entries(apps).map(([key, app]) => (
+      <Tooltip
+        key={key}
+        label={app.description}
+        position="right"
+        withArrow
+        openDelay={300}
+        multiline
+        w={240}
+        events={{ hover: true, focus: true, touch: false }}
+      >
+        <Menu.Item
+          component={Link}
+          href={app.url ?? "#"}
+          leftSection={<app.Icon width={20} />}
+        >
+          {app.name}
+        </Menu.Item>
+      </Tooltip>
+    ));
+
+    return (
+      <Menu
+        trigger="click-hover"
+        position="bottom-start"
+        transitionProps={{ exitDuration: 0 }}
+        withinPortal
+        radius="md"
+        shadow="md"
+        closeDelay={100}
+      >
+        <Menu.Target>
+          <UnstyledButton
+            className={
+              active ? `${classes.link} ${classes.linkActive}` : classes.link
+            }
+            aria-label={label}
+            aria-current={active ? "page" : undefined}
+          >
+            <Center inline>
+              <Icon width={20} />
+              <Box component="span" mx={6} visibleFrom="md">
+                {label}
+              </Box>
+              <IconChevronDown
+                size={14}
+                stroke={1.5}
+                style={{ marginInlineStart: 2 }}
+              />
+            </Center>
+          </UnstyledButton>
+        </Menu.Target>
+        <Menu.Dropdown>{items}</Menu.Dropdown>
+      </Menu>
+    );
+  },
+);
+DesktopNavMenu.displayName = "DesktopNavMenu";

--- a/apps/web/layouts/MainLayout/HeaderMenu/HeaderMenu.module.css
+++ b/apps/web/layouts/MainLayout/HeaderMenu/HeaderMenu.module.css
@@ -1,0 +1,121 @@
+.header {
+  height: rem(60px);
+  padding-left: var(--mantine-spacing-md);
+  padding-right: var(--mantine-spacing-md);
+  border-bottom: rem(1px) solid
+    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+/* In the installed app the header background is grown to cover the status-bar /
+   notch (see globals.css). Push the header content below the inset and clear a
+   landscape notch on the sides. */
+@media (display-mode: standalone), (display-mode: fullscreen) {
+  .header {
+    height: calc(rem(60px) + env(safe-area-inset-top));
+    padding-top: env(safe-area-inset-top);
+    padding-left: max(var(--mantine-spacing-md), env(safe-area-inset-left));
+    padding-right: max(var(--mantine-spacing-md), env(safe-area-inset-right));
+  }
+}
+
+/* Window Controls Overlay: when the installed desktop app (Chrome/Edge) uses
+   the native title bar, the OS window controls overlay the top of the viewport.
+   Lay the header out inside the area the OS leaves available (titlebar-area-*)
+   so nothing renders under the window buttons, and turn the bar into a real
+   drag handle while keeping its interactive children clickable. */
+@media (display-mode: window-controls-overlay) {
+  .header {
+    position: relative;
+    top: env(titlebar-area-y, 0);
+    margin-left: env(titlebar-area-x, 0);
+    width: env(titlebar-area-width, 100%);
+    height: env(titlebar-area-height, rem(60px));
+    -webkit-app-region: drag;
+    app-region: drag;
+  }
+
+  /* Interactive elements must opt out of dragging to stay clickable. */
+  .header :is(a, button, input, [role="button"], [tabindex]) {
+    -webkit-app-region: no-drag;
+    app-region: no-drag;
+  }
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+/* A nav trigger ("Character ▾") on desktop, and a flat row in the mobile drawer.
+   The full-width 44px treatment is only for the drawer (below `sm`); above it the
+   class styles the inline bar triggers, which keep auto width and full height. */
+.link {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding-left: var(--mantine-spacing-sm);
+  padding-right: var(--mantine-spacing-sm);
+  border-radius: var(--mantine-radius-sm);
+  text-decoration: none;
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  font-weight: 500;
+  font-size: var(--mantine-font-size-sm);
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    height: rem(44px);
+    width: 100%;
+  }
+
+  @mixin hover {
+    background-color: light-dark(
+      var(--mantine-color-gray-0),
+      var(--mantine-color-dark-6)
+    );
+  }
+}
+
+/* The current section — tinted label plus a tab-style underline in the primary
+   colour (theme-portable; adapts to whichever faction theme is active). */
+.linkActive,
+.linkActive:hover {
+  color: var(--mantine-primary-color-light-color);
+  box-shadow: inset 0 rem(-2px) 0 0 var(--mantine-primary-color-filled);
+}
+
+/* The search affordance — looks like an input, opens the Spotlight on click. */
+.search {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+  min-width: rem(200px);
+  height: rem(34px);
+  padding-left: var(--mantine-spacing-xs);
+  padding-right: rem(6px);
+  border-radius: var(--mantine-radius-sm);
+  border: rem(1px) solid
+    light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+  background-color: light-dark(
+    var(--mantine-color-gray-0),
+    var(--mantine-color-dark-6)
+  );
+  color: light-dark(var(--mantine-color-gray-6), var(--mantine-color-dark-1));
+
+  @mixin hover {
+    border-color: light-dark(
+      var(--mantine-color-gray-4),
+      var(--mantine-color-dark-3)
+    );
+    background-color: light-dark(
+      var(--mantine-color-gray-1),
+      var(--mantine-color-dark-5)
+    );
+  }
+}
+
+.searchLabel {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/apps/web/layouts/MainLayout/HeaderMenu/HeaderMenu.tsx
+++ b/apps/web/layouts/MainLayout/HeaderMenu/HeaderMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { Suspense, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -52,6 +52,42 @@ function activeGroupName(pathname: string): string | null {
 }
 
 /**
+ * The desktop nav row. Split out so the `usePathname` read (in
+ * ActiveDesktopNavGroup) can live inside a <Suspense> boundary: a null pathname
+ * renders every trigger un-highlighted, which is the static-shell fallback.
+ */
+function DesktopNavGroup({ pathname }: { pathname: string | null }) {
+  const activeName = useMemo(
+    () => (pathname ? activeGroupName(pathname) : null),
+    [pathname],
+  );
+  return (
+    <Group h="100%" gap={2} visibleFrom="sm" wrap="nowrap">
+      {Object.values(jitaApps).map((group) => (
+        <DesktopNavMenu
+          key={group.name}
+          label={group.name}
+          Icon={group.Icon}
+          apps={group.apps}
+          active={group.name === activeName}
+        />
+      ))}
+    </Group>
+  );
+}
+
+/**
+ * Highlights the active section from usePathname. On dynamic routes (e.g.
+ * /contract/[id]) usePathname is request-time data that Next 16 cacheComponents
+ * only allows inside a <Suspense> boundary, so HeaderMenu wraps this and falls
+ * back to an un-highlighted nav in the prerendered shell.
+ */
+function ActiveDesktopNavGroup() {
+  const pathname = usePathname();
+  return <DesktopNavGroup pathname={pathname} />;
+}
+
+/**
  * Top navigation header for the MainLayout. Labelled "mega menu"-style
  * dropdowns (Character / Corporation / Alliance / Universe) replace the older
  * icon-only triggers, alongside a Spotlight-backed search box and the character
@@ -62,8 +98,6 @@ export function HeaderMenu() {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] =
     useDisclosure(false);
   const characterIds = useAuthenticatedCharacterIds();
-  const pathname = usePathname();
-  const activeName = useMemo(() => activeGroupName(pathname), [pathname]);
 
   return (
     <Box h="100%" px="md">
@@ -83,17 +117,9 @@ export function HeaderMenu() {
                 <ServerStatusIndicator />
               </Group>
 
-              <Group h="100%" gap={2} visibleFrom="sm" wrap="nowrap">
-                {Object.values(jitaApps).map((group) => (
-                  <DesktopNavMenu
-                    key={group.name}
-                    label={group.name}
-                    Icon={group.Icon}
-                    apps={group.apps}
-                    active={group.name === activeName}
-                  />
-                ))}
-              </Group>
+              <Suspense fallback={<DesktopNavGroup pathname={null} />}>
+                <ActiveDesktopNavGroup />
+              </Suspense>
             </Group>
 
             <Group gap="xs" visibleFrom="sm" wrap="nowrap">

--- a/apps/web/layouts/MainLayout/HeaderMenu/HeaderMenu.tsx
+++ b/apps/web/layouts/MainLayout/HeaderMenu/HeaderMenu.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Box, Burger, Container, Group, Title } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { openContextModal } from "@mantine/modals";
+
+import { useAuthenticatedCharacterIds } from "@jitaspace/hooks";
+import { LoginWithEveOnlineButton } from "@jitaspace/ui";
+
+import { ServerStatusIndicator } from "~/components/ServerStatus/ServerStatusIndicator";
+import { jitaApps } from "~/config/apps";
+import UserButton from "~/layouts/MainLayout/UserButton";
+import { DesktopNavMenu } from "./DesktopNavMenu";
+import classes from "./HeaderMenu.module.css";
+import { HeaderSearchButton } from "./HeaderSearchButton";
+import { MobileNavDrawer } from "./MobileNavDrawer";
+
+/**
+ * The nav group that owns the current route, chosen by the longest matching app
+ * URL (so /wallet/corporation lights up Corporation, not Character). Falls back
+ * to the first path segment for apps whose configured URL is a deeper default,
+ * so e.g. Travel's "/travel/jita/amarr" still matches any /travel/* page.
+ * Returns null on routes no group owns (e.g. the home page).
+ */
+function activeGroupName(pathname: string): string | null {
+  let bestLen = 0;
+  let bestName: string | null = null;
+  for (const group of Object.values(jitaApps)) {
+    for (const app of Object.values(group.apps)) {
+      if (!app.url) continue;
+      const segment = `/${app.url.split("/")[1] ?? ""}`;
+      let len = 0;
+      if (pathname === app.url || pathname.startsWith(`${app.url}/`)) {
+        len = app.url.length;
+      } else if (
+        segment.length > 1 &&
+        (pathname === segment || pathname.startsWith(`${segment}/`))
+      ) {
+        len = segment.length;
+      }
+      if (len > bestLen) {
+        bestLen = len;
+        bestName = group.name;
+      }
+    }
+  }
+  return bestName;
+}
+
+/**
+ * Top navigation header for the MainLayout. Labelled "mega menu"-style
+ * dropdowns (Character / Corporation / Alliance / Universe) replace the older
+ * icon-only triggers, alongside a Spotlight-backed search box and the character
+ * menu. Responsive: trigger labels and the full search box appear on wider
+ * screens, and it collapses to a burger + full-screen drawer below `sm`.
+ */
+export function HeaderMenu() {
+  const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] =
+    useDisclosure(false);
+  const characterIds = useAuthenticatedCharacterIds();
+  const pathname = usePathname();
+  const activeName = useMemo(() => activeGroupName(pathname), [pathname]);
+
+  return (
+    <Box h="100%" px="md">
+      <div className={classes.header}>
+        <Container size="xl" h={60} p={0}>
+          <Group justify="space-between" h="100%" gap="xs" wrap="nowrap">
+            <Group h="100%" gap="lg" wrap="nowrap">
+              <Group h="100%" gap="sm" wrap="nowrap">
+                <Link href="/" className={classes.logo}>
+                  <Image
+                    src="/logo.png"
+                    alt="Jita logo"
+                    width={32}
+                    height={32}
+                  />
+                </Link>
+                <ServerStatusIndicator />
+              </Group>
+
+              <Group h="100%" gap={2} visibleFrom="sm" wrap="nowrap">
+                {Object.values(jitaApps).map((group) => (
+                  <DesktopNavMenu
+                    key={group.name}
+                    label={group.name}
+                    Icon={group.Icon}
+                    apps={group.apps}
+                    active={group.name === activeName}
+                  />
+                ))}
+              </Group>
+            </Group>
+
+            <Group gap="xs" visibleFrom="sm" wrap="nowrap">
+              <HeaderSearchButton />
+              {characterIds.length > 0 && <UserButton />}
+              {characterIds.length === 0 && (
+                <LoginWithEveOnlineButton
+                  size="small"
+                  onClick={() => {
+                    openContextModal({
+                      modal: "login",
+                      title: <Title order={3}>Login</Title>,
+                      size: "xl",
+                      centered: false,
+                      innerProps: {},
+                    });
+                  }}
+                />
+              )}
+            </Group>
+
+            <Burger
+              opened={drawerOpened}
+              onClick={toggleDrawer}
+              hiddenFrom="sm"
+            />
+          </Group>
+        </Container>
+      </div>
+      <MobileNavDrawer opened={drawerOpened} close={closeDrawer} />
+    </Box>
+  );
+}

--- a/apps/web/layouts/MainLayout/HeaderMenu/HeaderSearchButton.tsx
+++ b/apps/web/layouts/MainLayout/HeaderMenu/HeaderSearchButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ActionIcon, Kbd, Text, UnstyledButton } from "@mantine/core";
+import { useOs } from "@mantine/hooks";
+import { openSpotlight } from "@mantine/spotlight";
+import { IconSearch } from "@tabler/icons-react";
+
+import classes from "./HeaderMenu.module.css";
+
+/**
+ * Opens the existing Spotlight (the same one bound to ⌘/Ctrl + K). Responsive:
+ * a full input-style box from `lg`, and a compact icon button below it so the
+ * bar fits on narrower screens (the labelled nav + wide EVE login button leave
+ * no room for the box until `lg`). `useOs()` reports "undetermined" on the server
+ * and first client render, resolving the platform only in an effect, so the
+ * shortcut hint stays hydration-safe.
+ */
+export function HeaderSearchButton() {
+  const os = useOs();
+  const modKey = os === "macos" ? "⌘" : "Ctrl";
+
+  return (
+    <>
+      <UnstyledButton
+        className={classes.search}
+        visibleFrom="lg"
+        onClick={() => openSpotlight()}
+        aria-label="Search New Eden"
+      >
+        <IconSearch size={16} stroke={1.5} />
+        <Text className={classes.searchLabel} size="sm" c="dimmed">
+          Search New Eden…
+        </Text>
+        <Kbd>{modKey} K</Kbd>
+      </UnstyledButton>
+      <ActionIcon
+        variant="default"
+        size="lg"
+        radius="sm"
+        hiddenFrom="lg"
+        onClick={() => openSpotlight()}
+        aria-label="Search New Eden"
+      >
+        <IconSearch size={18} stroke={1.5} />
+      </ActionIcon>
+    </>
+  );
+}

--- a/apps/web/layouts/MainLayout/HeaderMenu/MobileNavDrawer.tsx
+++ b/apps/web/layouts/MainLayout/HeaderMenu/MobileNavDrawer.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { memo } from "react";
+import Link from "next/link";
+import {
+  Divider,
+  Drawer,
+  Group,
+  rem,
+  ScrollArea,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "@mantine/core";
+import { openContextModal } from "@mantine/modals";
+import { openSpotlight } from "@mantine/spotlight";
+import { IconSearch } from "@tabler/icons-react";
+
+import { useAuthenticatedCharacterIds } from "@jitaspace/hooks";
+import { LoginWithEveOnlineButton } from "@jitaspace/ui";
+
+import { jitaApps } from "~/config/apps";
+import UserButton from "~/layouts/MainLayout/UserButton";
+import classes from "./HeaderMenu.module.css";
+
+export interface MobileNavDrawerProps {
+  opened: boolean;
+  close: () => void;
+}
+
+/**
+ * Full-screen navigation for phones (below the `sm` breakpoint, where the
+ * desktop bar is hidden). Mirrors the desktop groups as flat, always-expanded
+ * sections, and brings the search box along.
+ */
+export const MobileNavDrawer = memo(
+  ({ opened, close }: MobileNavDrawerProps) => {
+    const characterIds = useAuthenticatedCharacterIds();
+
+    return (
+      <Drawer
+        opened={opened}
+        onClose={close}
+        size="100%"
+        padding="md"
+        title="Navigation"
+        hiddenFrom="sm"
+        zIndex={1000000}
+      >
+        <ScrollArea h={`calc(100vh - ${rem(60)})`} mx="-md">
+          <UnstyledButton
+            className={classes.search}
+            mx="md"
+            mb="sm"
+            onClick={() => {
+              close();
+              openSpotlight();
+            }}
+            aria-label="Search New Eden"
+          >
+            <IconSearch size={16} stroke={1.5} />
+            <Text className={classes.searchLabel} size="sm" c="dimmed">
+              Search New Eden…
+            </Text>
+          </UnstyledButton>
+
+          <Divider mb="sm" />
+
+          {Object.values(jitaApps).map((group) => (
+            <Stack gap={2} key={group.name} mb="sm">
+              <Group gap="xs" px="md" py={4}>
+                <group.Icon width={20} />
+                <Text fw={600} size="sm">
+                  {group.name}
+                </Text>
+              </Group>
+              {Object.entries(group.apps).map(([key, app]) => (
+                <UnstyledButton
+                  key={key}
+                  component={Link}
+                  href={app.url ?? "#"}
+                  className={classes.link}
+                  onClick={close}
+                >
+                  <Group gap="sm" wrap="nowrap">
+                    <app.Icon width={24} />
+                    <Text size="sm">{app.name}</Text>
+                  </Group>
+                </UnstyledButton>
+              ))}
+            </Stack>
+          ))}
+
+          <Divider my="sm" />
+
+          <Group justify="center" grow pb="xl" px="md">
+            {characterIds.length > 0 && <UserButton />}
+            {characterIds.length === 0 && (
+              <LoginWithEveOnlineButton
+                size="small"
+                onClick={() => {
+                  close();
+                  openContextModal({
+                    modal: "login",
+                    title: "Login",
+                    size: "xl",
+                    innerProps: {},
+                  });
+                }}
+              />
+            )}
+          </Group>
+        </ScrollArea>
+      </Drawer>
+    );
+  },
+);
+MobileNavDrawer.displayName = "MobileNavDrawer";

--- a/apps/web/layouts/MainLayout/HeaderMenu/index.ts
+++ b/apps/web/layouts/MainLayout/HeaderMenu/index.ts
@@ -1,0 +1,1 @@
+export * from "./HeaderMenu";

--- a/apps/web/layouts/MainLayout/MainLayout.tsx
+++ b/apps/web/layouts/MainLayout/MainLayout.tsx
@@ -6,7 +6,7 @@ import { AppShell, Box, rem, useMantineTheme } from "@mantine/core";
 import { useHeadroom } from "@mantine/hooks";
 
 import { FooterWithLinks } from "~/layouts/MainLayout/FooterWithLinks";
-import { HeaderWithMegaMenus } from "~/layouts/MainLayout/HeaderWithMegaMenus";
+import { HeaderMenu } from "~/layouts/MainLayout/HeaderMenu";
 import { MobileTabBar } from "~/layouts/MainLayout/MobileTabBar";
 
 export function MainLayout({
@@ -32,7 +32,7 @@ export function MainLayout({
       {...otherProps}
     >
       <AppShell.Header>
-        <HeaderWithMegaMenus pinned={pinned} />
+        <HeaderMenu />
       </AppShell.Header>
       <AppShell.Main
         // The header overlaps the status-bar inset in standalone mode (its


### PR DESCRIPTION
## Summary

Two user-facing changes to `@jitaspace/web`:

1. **Redesigned the top navigation header** — replaces the old icon-only mega-menus with a labelled, responsive `HeaderMenu`.
2. **Added a "search is limited" notice** shown when no authenticated character is available, in both the ⌘K spotlight and the `/search` page.

## 1. Header redesign

Following the Mantine header-menu pattern:

- **Labelled dropdowns** — Character / Corporation / Alliance / Universe now show text labels (icon-only below `md`), so they're self-explanatory. Each app's description shows in a **tooltip on hover**; the menu opens on hover or click.
- **Active-section highlight** — the current section's trigger gets a tab-style underline, matched by longest app-URL prefix (with a first-segment fallback for deep defaults like Travel, and correct disambiguation of `/wallet/character` vs `/wallet/corporation`).
- **Search** — a Spotlight-backed search box (⌘K / Ctrl+K) at `lg`+, collapsing to a search icon below.
- **Responsive layout** — brand + nav anchored left, account actions on the right; collapses to a burger + full-screen drawer below `sm`. Live server status, the EVE SSO menu, and the PWA safe-area / window-controls-overlay handling are retained.
- **Removed the "beta" status** from all apps — the `tags` field is gone from the config and the UI.

Behaviour by viewport width:

| Width | Triggers | Search |
| --- | --- | --- |
| ≥ 1280 (`lg`) | icon + label | full box |
| 1024–1280 (`md`) | icon + label | icon |
| 768–1024 (`sm`) | icon only | icon |
| < 768 | burger → drawer | search row in drawer |

## 2. "Search is limited" notice

EVE's only search endpoint (`/characters/{id}/search`) is character-authenticated, so without a signed-in character the universe results never load — only JitaSpace's own pages and tools are searchable. The notice explains this succinctly and offers a one-click login.

- Gated on the real capability flag: `useEsiSearch` already returns `canSearchStructures`, surfaced through `useSearchActions` as `canSearchEntities`. This also covers a logged-in character that hasn't granted the search scope.
- A shared `SearchScopeNotice` is used by both the spotlight and the `/search` page.

## Reviewer notes

- The old `HeaderWithMegaMenus/` directory is left in place but **unreferenced** — kept for easy rollback; safe to delete in a follow-up.
- **Tablet (768–1024px) is intentionally icon-only** — a deliberate choice to keep the bar visible rather than drop to a burger at that width.
- The **search box is `lg`+ only**: at 1024px logged-out, the labelled nav + box + the wide EVE login button overflow and clip the button (measured ~1125px of content). It fits once logged in, so it could be gated on login state in a follow-up if desired.
- **Tests / coverage:** the new `HeaderMenu/` components and the notice's login click-handler aren't unit-tested, so the SonarCloud **New Code coverage gate (≥80%)** may flag this PR. The existing `mainSpotlight` suite (19 tests) still passes with the notice added.
- Verified live across all breakpoints (desktop / tablet / mobile), plus the notice on `/search` and in the spotlight. Lint, type-check (no new errors), and Prettier are clean. Two changesets are included (both `@jitaspace/web`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
