### PR TITLE
refactor(db-history): adopt explicit immutable BuildDiff schema

### DIFF
--- a/apps/web/lib/history-actions.ts
+++ b/apps/web/lib/history-actions.ts
@@ -17,6 +17,10 @@ import type {
  * Client components invoke these (e.g. as React Query `queryFn`s); Next.js
  * keeps the Prisma client and the connection string server-side.
  *
+ * A change/file-change hangs off an immutable {@link BuildDiff} (an ordered
+ * build pair), not a single build — so "changes in build N" is the diff whose
+ * `toBuild` is N, and the build axis is recovered via `diff.toBuild`.
+ *
  * "Not found" resolves to `null` so callers can render an empty state.
  */
 
@@ -28,7 +32,7 @@ const opKey = (op: "added" | "modified" | "removed") =>
 /** The HistoryIndex (SDE collections only; localization strings live elsewhere). */
 export async function getHistoryIndex(): Promise<HistoryIndex> {
   const notStr = { name: { not: { startsWith: "strings:" } } };
-  const [builds, collections, grouped, entities] = await Promise.all([
+  const [builds, collections, grouped, entities, diffs] = await Promise.all([
     historyDb.build.findMany({
       orderBy: { buildNumber: "asc" },
       select: { buildNumber: true, releasedAt: true },
@@ -38,7 +42,7 @@ export async function getHistoryIndex(): Promise<HistoryIndex> {
       select: { id: true, name: true },
     }),
     historyDb.change.groupBy({
-      by: ["buildNumber", "collectionId"],
+      by: ["diffId", "collectionId"],
       where: { collection: notStr },
       _count: true,
     }),
@@ -46,16 +50,19 @@ export async function getHistoryIndex(): Promise<HistoryIndex> {
       where: { kind: { not: { startsWith: "string:" } } },
       select: { kind: true, eveId: true },
     }),
+    historyDb.buildDiff.findMany({ select: { id: true, toBuild: true } }),
   ]);
 
   const colName = new Map(collections.map((c) => [c.id, c.name]));
+  const toBuildOf = new Map(diffs.map((d) => [d.id, d.toBuild]));
   const perBuild = new Map<number, Record<string, number>>();
   for (const g of grouped) {
     const name = colName.get(g.collectionId);
-    if (!name) continue;
-    const m = perBuild.get(g.buildNumber) ?? {};
+    const toBuild = toBuildOf.get(g.diffId);
+    if (!name || toBuild === undefined) continue;
+    const m = perBuild.get(toBuild) ?? {};
     m[name] = g._count;
-    perBuild.set(g.buildNumber, m);
+    perBuild.set(toBuild, m);
   }
 
   const entityIdsByType: Record<string, number[]> = {};
@@ -93,7 +100,7 @@ export async function getBuildChanges(
 
   const rows = await historyDb.change.findMany({
     where: {
-      buildNumber: build,
+      diff: { toBuild: build },
       collection: { name: { not: { startsWith: "strings:" } } },
     },
     select: {
@@ -128,16 +135,18 @@ export async function getEntityTimeline(
     select: {
       op: true,
       data: true,
-      build: { select: { buildNumber: true, releasedAt: true } },
+      diff: {
+        select: { to: { select: { buildNumber: true, releasedAt: true } } },
+      },
       collection: { select: { name: true } },
     },
-    orderBy: { build: { buildNumber: "asc" } },
+    orderBy: { diff: { toBuild: "asc" } },
   });
   if (rows.length === 0) return null;
 
   const events = rows.map((r) => ({
-    build: r.build.buildNumber,
-    date: ymd(r.build.releasedAt),
+    build: r.diff.to.buildNumber,
+    date: ymd(r.diff.to.releasedAt),
     collection: r.collection.name,
     v: 1 as const,
     kind: r.op,
@@ -150,20 +159,21 @@ export async function getEntityTimeline(
 /** The ResourceIndex — file + localization-string change counts per build. */
 export async function getResourceIndex(): Promise<ResourceIndex> {
   const strFilter = { name: { startsWith: "strings:" } };
-  const [fileAgg, strColls, strAgg, builds] = await Promise.all([
-    historyDb.fileChange.groupBy({ by: ["buildNumber", "op"], _count: true }),
+  const [fileAgg, strColls, strAgg, builds, diffs] = await Promise.all([
+    historyDb.fileChange.groupBy({ by: ["diffId", "op"], _count: true }),
     historyDb.collection.findMany({
       where: strFilter,
       select: { id: true, name: true },
     }),
     historyDb.change.groupBy({
-      by: ["buildNumber", "collectionId", "op"],
+      by: ["diffId", "collectionId", "op"],
       where: { collection: strFilter },
       _count: true,
     }),
     historyDb.build.findMany({
       select: { buildNumber: true, releasedAt: true },
     }),
+    historyDb.buildDiff.findMany({ select: { id: true, toBuild: true } }),
   ]);
 
   const buildInfo = new Map(builds.map((b) => [b.buildNumber, b]));
@@ -171,6 +181,7 @@ export async function getResourceIndex(): Promise<ResourceIndex> {
     strColls.map((c) => [c.id, c.name.replace("strings:", "")]),
   );
   const languages = strColls.map((c) => c.name.replace("strings:", "")).sort();
+  const toBuildOf = new Map(diffs.map((d) => [d.id, d.toBuild]));
 
   const perBuild = new Map<
     number,
@@ -184,11 +195,15 @@ export async function getResourceIndex(): Promise<ResourceIndex> {
     }
     return a;
   };
-  for (const g of fileAgg) ensure(g.buildNumber).files[opKey(g.op)] += g._count;
+  for (const g of fileAgg) {
+    const toBuild = toBuildOf.get(g.diffId);
+    if (toBuild !== undefined) ensure(toBuild).files[opKey(g.op)] += g._count;
+  }
   for (const g of strAgg) {
     const lang = langOf.get(g.collectionId);
-    if (!lang) continue;
-    const a = ensure(g.buildNumber);
+    const toBuild = toBuildOf.get(g.diffId);
+    if (!lang || toBuild === undefined) continue;
+    const a = ensure(toBuild);
     (a.strings[lang] ??= { added: 0, changed: 0, removed: 0 })[opKey(g.op)] +=
       g._count;
   }
@@ -212,7 +227,7 @@ export async function getResourceIndex(): Promise<ResourceIndex> {
 /** Per-build raw-file diff (added / changed / removed paths). */
 export async function getFileDiff(build: number): Promise<FileDiff | null> {
   const rows = await historyDb.fileChange.findMany({
-    where: { build: { buildNumber: build } },
+    where: { diff: { toBuild: build } },
     select: { path: true, op: true },
   });
   if (rows.length === 0) return null;
@@ -231,7 +246,7 @@ export async function getStringChanges(
 ): Promise<StringChange[] | null> {
   const rows = await historyDb.change.findMany({
     where: {
-      build: { buildNumber: build },
+      diff: { toBuild: build },
       collection: { name: `strings:${lang}` },
     },
     select: { op: true, data: true, entity: { select: { eveId: true } } },

--- a/packages/db-history/prisma/schema.prisma
+++ b/packages/db-history/prisma/schema.prisma
@@ -1,5 +1,10 @@
 // Standalone change-history schema (isolated from @jitaspace/db).
-// Four tables: Build, Collection, Entity, Change — see the design discussion.
+// Tables: Build, BuildDiff, Collection, Entity, Change, FileChange.
+//
+// A diff between two builds is a first-class, IMMUTABLE BuildDiff row keyed by
+// its (fromBuild, toBuild) pair — never inferred from a build's baseline and
+// never mutated. Connecting two timelines (e.g. an SDE backfill onto the CDN
+// era) is an INSERT of a new BuildDiff, not an update of an existing build.
 
 generator client {
   provider = "prisma-client"
@@ -22,35 +27,52 @@ enum Server {
   singularity
 }
 
-/// One version of the game data. A build is server-independent content, and its
-/// build number is its natural identity — so the build number is the primary key.
+/// One version of the game data. Server-independent content; the build number is
+/// its natural identity (primary key). A build carries no diff of its own — the
+/// diff between two builds is an explicit {@link BuildDiff}.
 model Build {
   buildNumber Int          @id
   releasedAt  DateTime?
-  /// Which server's build pointer first surfaced this build (the diff's context).
+  /// Which server's build pointer first surfaced this build.
   server      Server?
-  /// The build this one's changes are computed against (the diff's "from" side).
-  /// null ⇒ genesis build (everything is "added"). Self-relation, so the baseline
-  /// is always a real Build row — see the monitor's per-server baseline rules.
-  baselineNumber Int?
-  baseline       Build?      @relation("baseline", fields: [baselineNumber], references: [buildNumber])
-  derivedBuilds  Build[]     @relation("baseline")
-  changes     Change[]
-  fileChanges FileChange[]
+  /// Diffs in which this build is the baseline ("from") / the target ("to").
+  diffsFrom BuildDiff[] @relation("diffFrom")
+  diffsTo   BuildDiff[] @relation("diffTo")
 
-  @@index([baselineNumber])
   @@index([server, buildNumber])
 }
 
-/// Raw resource-file changes (path-keyed, so they can't share Entity's integer key).
-model FileChange {
-  id          Int    @id @default(sequence())
-  build       Build  @relation(fields: [buildNumber], references: [buildNumber])
-  buildNumber Int
-  path        String
-  op          Op
+/// An explicit, immutable diff between an ordered pair of builds. Identity is the
+/// (fromBuild, toBuild) pair; once computed it is never updated. `fromBuild` null
+/// ⇒ genesis (the target is a full snapshot — every entity "added").
+model BuildDiff {
+  id        Int      @id @default(sequence())
+  /// Baseline ("from") build; null ⇒ genesis. A real Build row when set.
+  fromBuild Int?
+  from      Build?   @relation("diffFrom", fields: [fromBuild], references: [buildNumber])
+  /// Target ("to") build.
+  toBuild   Int
+  to        Build    @relation("diffTo", fields: [toBuild], references: [buildNumber])
+  createdAt   DateTime     @default(now())
+  changes     Change[]
+  fileChanges FileChange[]
 
-  @@index([buildNumber])
+  @@unique([fromBuild, toBuild])
+  @@index([toBuild])
+  @@index([fromBuild])
+}
+
+/// Raw resource-file changes for a diff (path-keyed, so they can't share Entity's
+/// integer key). Like Change, a file-change set is defined by the build PAIR, so
+/// it hangs off the BuildDiff (CDN-only; the SDE backfill produces no res files).
+model FileChange {
+  id     Int       @id @default(sequence())
+  diff   BuildDiff @relation(fields: [diffId], references: [id])
+  diffId Int
+  path   String
+  op     Op
+
+  @@index([diffId])
 }
 
 /// The registry of tracked datasets (≈ resource-server files). Add a row → track more.
@@ -81,11 +103,11 @@ model Entity {
   @@index([rootId])
 }
 
-/// The history: one row = "entity X changed in build B (from collection C)".
+/// The history: one row = "entity X changed in diff D (from collection C)".
 model Change {
   id           Int        @id @default(sequence())
-  build        Build      @relation(fields: [buildNumber], references: [buildNumber])
-  buildNumber  Int
+  diff         BuildDiff  @relation(fields: [diffId], references: [id])
+  diffId       Int
   collection   Collection @relation(fields: [collectionId], references: [id])
   collectionId Int
   entity       Entity     @relation(fields: [entityId], references: [id])
@@ -93,7 +115,7 @@ model Change {
   op           Op
   data         Json
 
-  @@index([buildNumber])
+  @@index([diffId])
   @@index([entityId])
   @@index([collectionId])
 }


### PR DESCRIPTION
## What

Synchronizes `@jitaspace/db-history` with the upstream change-history **writer** (jovespace): a change / file-change now hangs off an explicit, immutable **`BuildDiff(fromBuild, toBuild)`** row instead of a build's implicit `baselineNumber`.

- `Build` sheds `baselineNumber` (+ its self-relation); gains `diffsFrom` / `diffsTo`.
- `Change` and `FileChange` move from `buildNumber` → `diffId`.
- The schema is now **byte-identical** to the writer's.
- The viewer's server actions (`apps/web/lib/history-actions.ts`) query via the diff — group by `diffId`, recover the build axis through `BuildDiff.toBuild`, so "changes in build N" is the diff whose `toBuild` is N. **Output shapes are unchanged**, so the React components and tests are untouched.

## Why — preventing downtime

jitaspace and jovespace share one `eve-builds` CockroachDB. That DB is being migrated to the BuildDiff schema (the old `buildNumber` / `baselineNumber` columns get dropped). jitaspace's **deployed** reader currently queries `Change.buildNumber` — so dropping those columns without this change would break the history viewer in production.

**Order matters:** this must be merged and deployed **before** the destructive column drop runs against the shared DB. The migration is staged additively (BuildDiff + `diffId` added, old columns kept) precisely so both schemas coexist during this window.

## Verification

Type-checked the web app against the regenerated Prisma client:

- History code (`history-actions.ts`, `app/history/*`): **0 errors** ✅
- For contrast, the **pre-migration** queries produce **24 type errors** against the new client (`'buildNumber' does not exist in ChangeWhereInput`, `Property 'entity' does not exist`, …) — exactly the production breakage this PR avoids.

(The repo's other type-check errors — `background-jobs/*`, `eve-components/*`, and the jest-globals test collisions — are pre-existing and unrelated to this change.)

## Note for the author

There's unrelated WIP on `claude/build-type-history-viewer` adding `size` / `hash` to `FileChange` (stashed locally during this work). It'll want a trivial rebase onto this now-`diffId`-keyed `FileChange` once those columns also exist in the DB + writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
