### PR TITLE
Remove summary stat cards from /status dashboards

### DIFF
--- a/.changeset/status-remove-summary-cards.md
+++ b/.changeset/status-remove-summary-cards.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Removed the summary stat cards from the Status page's Background Jobs and Database sections (Active Jobs / Runs / Failed Runs, and Tables / Total Records / Largest Table), leaving the detailed tables and header badges.

--- a/apps/web/components/Status/DatabaseDashboard.tsx
+++ b/apps/web/components/Status/DatabaseDashboard.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
 import {
   Alert,
   Badge,
   Group,
   Loader,
-  Paper,
   ScrollArea,
-  SimpleGrid,
   Stack,
   Table,
   Text,
@@ -32,11 +29,6 @@ export function DatabaseDashboard() {
     refetchInterval: REFETCH_INTERVAL_MS,
     staleTime: REFETCH_INTERVAL_MS,
   });
-
-  const nonEmptyTables = useMemo(
-    () => data?.tables.filter((table) => table.rowCount > 0).length ?? 0,
-    [data],
-  );
 
   return (
     <Stack gap="md">
@@ -86,44 +78,6 @@ export function DatabaseDashboard() {
 
       {data && !data.error && (
         <>
-          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
-            <Paper withBorder p="md" shadow="xs">
-              <Text size="xs" c="dimmed">
-                Tables
-              </Text>
-              <Text size="xl" fw={700}>
-                {data.totals.tables.toLocaleString()}
-              </Text>
-              <Text size="xs" c="dimmed">
-                {nonEmptyTables.toLocaleString()} with records
-              </Text>
-            </Paper>
-
-            <Paper withBorder p="md" shadow="xs">
-              <Text size="xs" c="dimmed">
-                Total Records
-              </Text>
-              <Text size="xl" fw={700}>
-                {data.totals.rows.toLocaleString()}
-              </Text>
-              <Text size="xs" c="dimmed">
-                estimated across all tables
-              </Text>
-            </Paper>
-
-            <Paper withBorder p="md" shadow="xs">
-              <Text size="xs" c="dimmed">
-                Largest Table
-              </Text>
-              <Text size="xl" fw={700}>
-                {data.tables[0]?.rowCount.toLocaleString() ?? "0"}
-              </Text>
-              <Text size="xs" c="dimmed" truncate>
-                {data.tables[0]?.label ?? "-"}
-              </Text>
-            </Paper>
-          </SimpleGrid>
-
           {data.tables.length === 0 ? (
             <Alert
               icon={<IconAlertCircle size="1rem" />}

--- a/apps/web/components/Status/TriggerJobsDashboard.tsx
+++ b/apps/web/components/Status/TriggerJobsDashboard.tsx
@@ -7,9 +7,7 @@ import {
   ColorSwatch,
   Group,
   Loader,
-  Paper,
   ScrollArea,
-  SimpleGrid,
   Stack,
   Table,
   Text,
@@ -150,49 +148,6 @@ export function TriggerJobsDashboard() {
 
       {data && !data.error && (
         <>
-          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
-            <Paper withBorder p="md" shadow="xs">
-              <Text size="xs" c="dimmed">
-                Active Jobs
-              </Text>
-              <Text size="xl" fw={700}>
-                {data.totals.jobs.toLocaleString()}
-              </Text>
-              <Text size="xs" c="dimmed">
-                with runs in the window
-              </Text>
-            </Paper>
-
-            <Paper withBorder p="md" shadow="xs">
-              <Text size="xs" c="dimmed">
-                Runs
-              </Text>
-              <Text size="xl" fw={700}>
-                {data.totals.runs.toLocaleString()}
-              </Text>
-              <Text size="xs" c="dimmed">
-                {data.totals.completed.toLocaleString()} completed ·{" "}
-                {data.totals.running.toLocaleString()} running
-              </Text>
-            </Paper>
-
-            <Paper withBorder p="md" shadow="xs">
-              <Text size="xs" c="dimmed">
-                Failed Runs
-              </Text>
-              <Text
-                size="xl"
-                fw={700}
-                c={data.totals.failed > 0 ? "red" : "green"}
-              >
-                {data.totals.failed.toLocaleString()}
-              </Text>
-              <Text size="xs" c="dimmed">
-                {data.totals.cancelled.toLocaleString()} cancelled
-              </Text>
-            </Paper>
-          </SimpleGrid>
-
           {sortedJobs.length === 0 ? (
             <Alert
               icon={<IconAlertCircle size="1rem" />}


### PR DESCRIPTION
## What

Removes the 3-card summary grids from the top of two sections on the **/status** page:

- **Background Jobs (Trigger.dev)** — *Active Jobs*, *Runs*, *Failed Runs*
- **Database** — *Tables*, *Total Records*, *Largest Table*

Each section keeps its header, status badge (e.g. "All Jobs Healthy", "N records"), and detailed table — only the redundant top-of-section stat cards are gone.

## Why

The stat cards largely duplicated information already conveyed by the section header badges and the detail tables below them, adding visual noise to the page.

## Notes for reviewers

- Pure presentational deletion: **5 insertions, 91 deletions**, no logic changes.
- Cleaned up the imports left unused by the removal (`Paper`, `SimpleGrid` in both; `useMemo` in `DatabaseDashboard`) and the now-orphaned `nonEmptyTables` memo.
- The remaining `data.totals` reads still back the header badges, so the underlying server actions (`getTriggerStatus` / `getDatabaseStatus`) are unchanged.
- `tsc --noEmit` is clean for both changed files (the repo-wide type-check is RED at baseline, so this was scoped to the touched files).
- No live browser verification: this worktree has no `.env`, and the removed cards only render in each dashboard's success-data state, which needs live production CockroachDB + Trigger.dev credentials a preview can't supply.
- Includes a user-facing changeset (`@jitaspace/web`: patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)