### PR TITLE
fix(web): update DatabaseDashboard test after summary cards removed

### DIFF
--- a/apps/web/tests/databaseDashboard.test.tsx
+++ b/apps/web/tests/databaseDashboard.test.tsx
@@ -57,8 +57,8 @@ describe("DatabaseDashboard", () => {
 
     renderDashboard();
 
-    // Wait for data to load (the title renders even while loading). The largest
-    // table's label appears both in its row and in the "Largest Table" card.
+    // Wait for data to load (the title renders even while loading). Each table's
+    // humanized label appears in its table row.
     expect(
       (await screen.findAllByText("Killmail Victim")).length,
     ).toBeGreaterThanOrEqual(1);
@@ -67,12 +67,10 @@ describe("DatabaseDashboard", () => {
     // Physical table name is shown beneath the humanized label.
     expect(screen.getByText("KillmailVictim")).toBeInTheDocument();
 
-    // Largest-table count + total records (toLocaleString) appear.
+    // Total record count shows in the header badge; per-table counts in the rows
+    // (both via toLocaleString).
+    expect(screen.getByText("1,284,567 records")).toBeInTheDocument();
     expect(screen.getAllByText("1,234,567").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("1,284,567").length).toBeGreaterThanOrEqual(1);
-
-    // 2 of 3 tables have records.
-    expect(screen.getByText("2 with records")).toBeInTheDocument();
   });
 
   it("shows an empty state when no tables are reported", async () => {


### PR DESCRIPTION
## Problem

The SonarCloud **Run tests with coverage** step is failing on `main` (and therefore on every open PR, since PR CI tests the branch merged with `main`).

[#620](https://github.com/joaomlneto/jitaspace/pull/620) removed the three summary stat cards (Tables / Total Records / Largest Table) from the Database section of `/status`, but didn't update `apps/web/tests/databaseDashboard.test.tsx`. The test still asserted the removed **Total Records** value (`1,284,567`, a standalone element) and the **Tables** card's `2 with records` text, so it now fails:

```
TestingLibraryElementError: Unable to find an element with the text: 1,284,567
> 72 |     expect(screen.getAllByText("1,284,567").length).toBeGreaterThanOrEqual(1);
```

## Fix

`databaseDashboard.test.tsx` only — drop the two removed-card assertions, assert the total record count via the **surviving header badge** (`1,284,567 records`) instead, and keep the table-row assertions. No production code changes.

## Verification

Reproduced the failure and confirmed the fix against the current `main` (post-#620) component:

```
# before: Tests: 1 failed, 3 passed
# after:  Test Suites: 1 passed, Tests: 4 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)