### PR TITLE
fix(web): sum change counts across BuildDiffs sharing a build in history index

### DIFF
--- a/apps/web/lib/history-actions.ts
+++ b/apps/web/lib/history-actions.ts
@@ -61,7 +61,10 @@ export async function getHistoryIndex(): Promise<HistoryIndex> {
     const toBuild = toBuildOf.get(g.diffId);
     if (!name || toBuild === undefined) continue;
     const m = perBuild.get(toBuild) ?? {};
-    m[name] = g._count;
+    // Multiple diffs can target the same build (e.g. connecting an SDE backfill
+    // onto the CDN era), so accumulate across them rather than overwrite — same
+    // diffId→toBuild collapse as getResourceIndex.
+    m[name] = (m[name] ?? 0) + g._count;
     perBuild.set(toBuild, m);
   }
 

--- a/apps/web/tests/historyActions.test.ts
+++ b/apps/web/tests/historyActions.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+// Type-only import: erased at runtime, so it does NOT load the real (Prisma-
+// backed) module; used only to type the lazy require() below.
+import type * as HistoryActions from "~/lib/history-actions";
+
+// Exercises the query logic in ~/lib/history-actions (the change-history server
+// functions) by stubbing @jitaspace/db-history so the real Prisma client is
+// never loaded. Mutable fixtures are reassigned per-test; the stub closes over
+// them by reference (mock-prefixed so the jest factory accepts them).
+
+let mockBuilds: { buildNumber: number; releasedAt: Date | null }[] = [];
+let mockCollections: { id: number; name: string }[] = [];
+let mockGrouped: { diffId: number; collectionId: number; _count: number }[] = [];
+let mockEntities: { kind: string; eveId: number }[] = [];
+let mockDiffs: { id: number; toBuild: number }[] = [];
+
+jest.mock("@jitaspace/db-history", () => ({
+  historyDb: {
+    build: {
+      findMany: () => Promise.resolve(mockBuilds),
+      findUnique: () => Promise.resolve(null),
+    },
+    collection: { findMany: () => Promise.resolve(mockCollections) },
+    change: {
+      groupBy: () => Promise.resolve(mockGrouped),
+      findMany: () => Promise.resolve([]),
+    },
+    entity: { findMany: () => Promise.resolve(mockEntities) },
+    buildDiff: { findMany: () => Promise.resolve(mockDiffs) },
+    fileChange: {
+      groupBy: () => Promise.resolve([]),
+      findMany: () => Promise.resolve([]),
+    },
+  },
+}));
+
+// Lazy-require after jest.mock: next/jest (SWC) does not hoist jest.mock, so a
+// top-level import would load the real module before the stub is registered.
+const { getHistoryIndex } =
+  require("~/lib/history-actions") as typeof HistoryActions;
+
+describe("getHistoryIndex", () => {
+  beforeEach(() => {
+    mockBuilds = [{ buildNumber: 100, releasedAt: new Date("2025-01-15") }];
+    mockCollections = [
+      { id: 1, name: "types" },
+      { id: 2, name: "typeDogma" },
+    ];
+    mockEntities = [{ kind: "type", eveId: 587 }];
+  });
+
+  it("accumulates change counts across multiple diffs targeting the same build", async () => {
+    // Two diffs both end at build 100 (e.g. an SDE backfill connected onto the
+    // CDN era) and both touch the `types` collection.
+    mockDiffs = [
+      { id: 10, toBuild: 100 },
+      { id: 11, toBuild: 100 },
+    ];
+    mockGrouped = [
+      { diffId: 10, collectionId: 1, _count: 5 }, // types via diff 10
+      { diffId: 11, collectionId: 1, _count: 3 }, // types via diff 11
+      { diffId: 10, collectionId: 2, _count: 2 }, // typeDogma via diff 10
+    ];
+
+    const index = await getHistoryIndex();
+    const build = index.builds.find((b) => b.build === 100);
+
+    // 5 + 3 must be summed, not overwritten to 3.
+    expect(build?.byCollection).toEqual({ types: 8, typeDogma: 2 });
+    expect(build?.changeCount).toBe(10);
+    expect(build?.date).toBe("2025-01-15");
+  });
+
+  it("reports the per-collection counts for the single-diff case", async () => {
+    mockDiffs = [{ id: 10, toBuild: 100 }];
+    mockGrouped = [
+      { diffId: 10, collectionId: 1, _count: 4 },
+      { diffId: 10, collectionId: 2, _count: 1 },
+    ];
+
+    const index = await getHistoryIndex();
+    const build = index.builds.find((b) => b.build === 100);
+
+    expect(build?.byCollection).toEqual({ types: 4, typeDogma: 1 });
+    expect(build?.changeCount).toBe(5);
+    expect(index.entityIdsByType).toEqual({ type: [587] });
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #619. `getHistoryIndex` (the `/history` index page's data source) undercounts changes when a build is the target of **more than one `BuildDiff`**.

#619 moved a `Change` from a build's `buildNumber` onto an immutable `BuildDiff(fromBuild, toBuild)`, so every "changes in build N" reader now collapses `diffId → toBuild`. The new schema deliberately allows **multiple diffs to share one `toBuild`** (connecting an SDE backfill onto the CDN era is an *insert* of a new `BuildDiff`). `getHistoryIndex` collapsed the diffs but assigned per-collection counts with `m[name] = g._count` — **overwriting** earlier diffs that target the same build instead of summing them:

```js
- m[name] = g._count;
+ m[name] = (m[name] ?? 0) + g._count;
```

Its sibling `getResourceIndex` already accumulates with `+=` for the identical collapse, so the rewrite was internally inconsistent. Effect: the index page's activity bar chart, per-build `changeCount`, and per-collection breakdown all undercount once any build has >1 diff.

## Why it wasn't caught

- It's a pure logic bug — the output types are unchanged, so `type-check` passes.
- The history tests `jest.mock("~/lib/history-actions")` **wholesale**, so the query logic had **zero** test coverage.

## Tests

Adds `apps/web/tests/historyActions.test.ts` — the first test to exercise `history-actions` query logic. It stubs `@jitaspace/db-history` and lazy-`require`s the module (next/jest doesn't hoist `jest.mock`). Verified it **fails on the old code** (multi-diff case) and **passes on the fix**; lint + type-check clean.

## Reviewer note (not changed here)

The **list** readers — `getBuildChanges`, `getFileDiff`, `getStringChanges`, `getEntityTimeline` — also union across all diffs ending at a build, so if the writer (jovespace) ever emits >1 diff per `toBuild` with overlapping entities/paths/strings, the build-detail page would render **duplicate rows**. Not deduped here because the correct precedence depends on the writer's semantics. Worth a follow-up if that scenario is real.

Scope is confined to `apps/web` (private package → no changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)