### PR TITLE
Fix watch-sde OOM by removing the micro machine override

### DIFF
--- a/packages/background-jobs-triggerdev/trigger.config.ts
+++ b/packages/background-jobs-triggerdev/trigger.config.ts
@@ -21,6 +21,13 @@ export default defineConfig({
   project: process.env.TRIGGER_PROJECT_REF ?? "proj_REPLACE_ME",
   dirs: ["./src/trigger"],
   runtime: "node-22",
+  // Default machine for every task. Each worker loads the whole task bundle
+  // (Prisma + the full ESI/SDE generated clients + Bull) regardless of which
+  // task it runs, and that baseline RSS exceeds micro's 0.25 GB — so "micro"
+  // OOM-kills even a trivial task (it bit watch-sde). small-1x (0.5 GB, also
+  // Trigger's own default) is the proven floor; heavy jobs opt UP per-task
+  // (e.g. ingest-sde-all → medium-2x).
+  machine: "small-1x",
   // Generous default; long jobs (solar systems, killmail backfill) set their own.
   maxDuration: 600,
   retries: {

--- a/packages/background-jobs/jobs/scrape/sde/watchSde.ts
+++ b/packages/background-jobs/jobs/scrape/sde/watchSde.ts
@@ -33,8 +33,10 @@ export const watchSde = defineJob<WatchSdeEventPayload["data"]>({
     "Hourly HEAD on the SDE archive; triggers ingest-sde-all when its Last-Modified changes.",
   trigger: { type: "cron", cron: "TZ=UTC 0 * * * *" },
   singleton: true,
-  // One HEAD request + one Redis op — the smallest machine is plenty.
-  machine: "micro",
+  // No per-task machine: inherit the project default (small-1x). The handler is
+  // trivial (one HEAD + one Redis op), but every worker loads the full task
+  // bundle, whose baseline RSS exceeds micro's 0.25 GB — micro OOM-killed this
+  // job. See the `machine` default in trigger.config.ts.
   handler: async (ctx) => {
     const lastModified = (await latestSdeLastModified()).toISOString();
     const redis = await getRedis();


### PR DESCRIPTION
## What

- **`watchSde.ts`**: removed `machine: "micro"` so the `watch-sde` task inherits the project-default machine.
- **`trigger.config.ts`**: pinned `machine: "small-1x"` as the explicit project-wide default. This is behavior-neutral (`small-1x` is already Trigger's default) — it documents the deployment's memory floor and prevents future tasks from opting down to `micro`.

## Why

`watch-sde` fails intermittently with `TASK_PROCESS_OOM_KILLED`, which is surprising given its handler is trivial — one `HEAD` request for the SDE archive's `Last-Modified` plus a Redis `get`/`set`.

The OOM is about the **process footprint, not the handler logic**. The Trigger entrypoint imports the full job registry, and `jobs/index.ts` statically imports all ~110 job modules. That transitively loads the entire task bundle into *every* worker — the Prisma 7 client, the full Kubb-generated ESI **and** SDE clients, Bull, Sentry — regardless of which single task the process runs. That baseline resident memory exceeds `micro`'s 0.25 GB, so `micro` OOM-kills even a do-nothing handler. It fired intermittently because RSS sat right at the 256 MB edge and tipped over depending on GC/heap timing.

`watch-sde` was the **only** job opting *down* to `micro`. The other ~108 jobs set no machine and run the exact same heavy bundle on the default `small-1x` (0.5 GB) without OOM, which is the direct evidence that 0.5 GB clears the baseline.

(Minor aggravator, not changed here: `watch-sde`'s `getRedis()` also spins up the four Bull queues in `@jitaspace/kv` just to do one `get`/`set` — extra memory/sockets on top of the module baseline.)

## Reviewer notes

- No changeset: both `@jitaspace/background-jobs` and `@jitaspace/background-jobs-triggerdev` are `private: true`, and there's no web-app behavior change.
- `ingest-sde-all` keeps its per-task `machine: "medium-2x"` — a per-task machine still overrides the new default.
- **Takes effect only after the Trigger deployment is rebuilt _and promoted_** — main builds land as a pending version and don't auto-promote, so scheduled runs keep using the old machine size until promoted in the Trigger console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)