### PR TITLE
fix(web): stop entity history timeline crashing on dangling BuildDiff FKs

### DIFF
--- a/apps/web/lib/history-actions.ts
+++ b/apps/web/lib/history-actions.ts
@@ -138,23 +138,42 @@ export async function getEntityTimeline(
     select: {
       op: true,
       data: true,
-      diff: {
-        select: { to: { select: { buildNumber: true, releasedAt: true } } },
-      },
+      diffId: true,
       collection: { select: { name: true } },
     },
     orderBy: { diff: { toBuild: "asc" } },
   });
   if (rows.length === 0) return null;
 
-  const events = rows.map((r) => ({
-    build: r.diff.to.buildNumber,
-    date: ymd(r.diff.to.releasedAt),
-    collection: r.collection.name,
-    v: 1 as const,
-    kind: r.op,
-    ...(r.op === "modified" ? { fields: r.data } : { values: r.data }),
-  })) as EntityTimeline["events"];
+  // Resolve the build axis via lookups instead of the change→diff→to→Build
+  // relation chain. Each hop can dangle while the shared eve-builds DB is
+  // mid-migration (a missing BuildDiff, or a BuildDiff whose toBuild has no
+  // Build row), and traversing a null relation crashed the timeline. A change
+  // whose diff is gone can't be placed on the axis (skip it); a missing Build
+  // row yields a null date.
+  const [diffs, builds] = await Promise.all([
+    historyDb.buildDiff.findMany({ select: { id: true, toBuild: true } }),
+    historyDb.build.findMany({
+      select: { buildNumber: true, releasedAt: true },
+    }),
+  ]);
+  const toBuildOf = new Map(diffs.map((d) => [d.id, d.toBuild]));
+  const releasedAtOf = new Map(builds.map((b) => [b.buildNumber, b.releasedAt]));
+
+  const events = rows.flatMap((r) => {
+    const build = toBuildOf.get(r.diffId);
+    if (build === undefined) return [];
+    return [
+      {
+        build,
+        date: ymd(releasedAtOf.get(build) ?? null),
+        collection: r.collection.name,
+        v: 1 as const,
+        kind: r.op,
+        ...(r.op === "modified" ? { fields: r.data } : { values: r.data }),
+      },
+    ];
+  }) as EntityTimeline["events"];
 
   return { entityType, entityId, events };
 }

--- a/apps/web/tests/historyActions.test.ts
+++ b/apps/web/tests/historyActions.test.ts
@@ -14,6 +14,12 @@ let mockCollections: { id: number; name: string }[] = [];
 let mockGrouped: { diffId: number; collectionId: number; _count: number }[] = [];
 let mockEntities: { kind: string; eveId: number }[] = [];
 let mockDiffs: { id: number; toBuild: number }[] = [];
+let mockChangeRows: {
+  op: "added" | "modified" | "removed";
+  data: unknown;
+  diffId: number;
+  collection: { name: string };
+}[] = [];
 
 jest.mock("@jitaspace/db-history", () => ({
   historyDb: {
@@ -24,7 +30,7 @@ jest.mock("@jitaspace/db-history", () => ({
     collection: { findMany: () => Promise.resolve(mockCollections) },
     change: {
       groupBy: () => Promise.resolve(mockGrouped),
-      findMany: () => Promise.resolve([]),
+      findMany: () => Promise.resolve(mockChangeRows),
     },
     entity: { findMany: () => Promise.resolve(mockEntities) },
     buildDiff: { findMany: () => Promise.resolve(mockDiffs) },
@@ -37,7 +43,7 @@ jest.mock("@jitaspace/db-history", () => ({
 
 // Lazy-require after jest.mock: next/jest (SWC) does not hoist jest.mock, so a
 // top-level import would load the real module before the stub is registered.
-const { getHistoryIndex } =
+const { getHistoryIndex, getEntityTimeline } =
   require("~/lib/history-actions") as typeof HistoryActions;
 
 describe("getHistoryIndex", () => {
@@ -85,5 +91,61 @@ describe("getHistoryIndex", () => {
     expect(build?.byCollection).toEqual({ types: 4, typeDogma: 1 });
     expect(build?.changeCount).toBe(5);
     expect(index.entityIdsByType).toEqual({ type: [587] });
+  });
+});
+
+describe("getEntityTimeline", () => {
+  it("survives dangling FKs: null date when the Build row is missing, skips changes with no diff", async () => {
+    // diff 10 → build 98 (present); diff 11 → build 99 (Build row missing);
+    // diff 999 is absent entirely (dangling Change.diffId).
+    mockDiffs = [
+      { id: 10, toBuild: 98 },
+      { id: 11, toBuild: 99 },
+    ];
+    mockBuilds = [{ buildNumber: 98, releasedAt: new Date("2024-01-01") }];
+    mockChangeRows = [
+      {
+        op: "added",
+        data: { typeName: "Rifter" },
+        diffId: 10,
+        collection: { name: "types" },
+      },
+      {
+        // BuildDiff resolves, but its toBuild (99) has no Build row → null date,
+        // yet the event must still render (build number comes from the diff map).
+        op: "modified",
+        data: { mass: { from: 1000, to: 1100 } },
+        diffId: 11,
+        collection: { name: "types" },
+      },
+      {
+        // The change's BuildDiff is gone entirely → can't place it; drop it.
+        op: "removed",
+        data: {},
+        diffId: 999,
+        collection: { name: "types" },
+      },
+    ];
+
+    const timeline = await getEntityTimeline("type", 587);
+
+    expect(timeline?.events).toEqual([
+      {
+        build: 98,
+        date: "2024-01-01",
+        collection: "types",
+        v: 1,
+        kind: "added",
+        values: { typeName: "Rifter" },
+      },
+      {
+        build: 99,
+        date: null,
+        collection: "types",
+        v: 1,
+        kind: "modified",
+        fields: { mass: { from: 1000, to: 1100 } },
+      },
+    ]);
   });
 });

--- a/apps/web/tests/historySchemaContract.test.ts
+++ b/apps/web/tests/historySchemaContract.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Schema-contract regression test for the change-history reader.
+ *
+ * The history pages read the shared `eve-builds` DB through
+ * `apps/web/lib/history-actions.ts`, whose Prisma queries assume a specific
+ * shape of `@jitaspace/db-history`'s schema. That schema mirrors the upstream
+ * writer (jovespace); when the writer changes it, this repo's
+ * `packages/db-history/prisma/schema.prisma` gets synced to match — and the
+ * reader can silently break (PR #619 moved `Change` off `buildNumber` onto
+ * `BuildDiff` + `diffId`; PR #627 fixed a crash that a changed relation caused).
+ *
+ * The unit tests in `historyActions.test.ts` mock the DB, so they cannot see
+ * schema drift. This test parses the committed schema and asserts the exact
+ * surface each reader depends on. If it fails, the db-history schema changed in
+ * a way that affects the reader: update `history-actions.ts` AND these
+ * assertions together, then run `pnpm db:generate` + `pnpm type-check` (the
+ * complementary code↔generated-client guard).
+ *
+ * Scope: this catches drift in the committed schema file. It cannot detect the
+ * live shared DB diverging from that file without a connection — that needs an
+ * integration test against HISTORY_DATABASE_URL, which CI does not run.
+ */
+
+interface Field {
+  type: string;
+  optional: boolean;
+  list: boolean;
+}
+type Models = Record<string, Record<string, Field>>;
+
+const SCHEMA_PATH = join(
+  __dirname,
+  "../../../packages/db-history/prisma/schema.prisma",
+);
+const schema = readFileSync(SCHEMA_PATH, "utf8");
+
+/** Minimal Prisma-schema parser: model → field → {type, optional, list}. */
+function parseModels(src: string): Models {
+  const models: Models = {};
+  for (const match of src.matchAll(/\bmodel\s+(\w+)\s*\{([\s\S]*?)\}/g)) {
+    const name = match[1];
+    const body = match[2];
+    if (!name || body === undefined) continue;
+    const fields: Record<string, Field> = {};
+    for (const rawLine of body.split("\n")) {
+      const line = rawLine.trim();
+      // Skip blank lines, block attributes (@@index/@@unique) and comments.
+      if (!line || line.startsWith("@@") || line.startsWith("//")) continue;
+      const [fname, ftype] = line.split(/\s+/);
+      if (!fname || !ftype) continue;
+      fields[fname] = {
+        type: ftype.replace(/[?[\]]/g, ""),
+        optional: ftype.endsWith("?"),
+        list: ftype.endsWith("[]"),
+      };
+    }
+    models[name] = fields;
+  }
+  return models;
+}
+
+function parseEnumValues(src: string, name: string): string[] {
+  const m = new RegExp(`enum\\s+${name}\\s*\\{([\\s\\S]*?)\\}`).exec(src);
+  if (!m?.[1]) return [];
+  return m[1]
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith("//"));
+}
+
+const models = parseModels(schema);
+
+/** Field descriptor, or null so a missing field fails `toEqual` with a clear diff. */
+const field = (model: string, name: string): Field | null =>
+  models[model]?.[name] ?? null;
+
+const scalar = (type: string, optional = false): Field => ({
+  type,
+  optional,
+  list: false,
+});
+const relation = (type: string): Field => ({ type, optional: false, list: false });
+
+describe("db-history schema ↔ history-actions reader contract", () => {
+  it("exposes exactly the expected models", () => {
+    expect(Object.keys(models).sort()).toEqual([
+      "Build",
+      "BuildDiff",
+      "Change",
+      "Collection",
+      "Entity",
+      "FileChange",
+    ]);
+  });
+
+  it("Op enum carries exactly the values the reader maps", () => {
+    // history-actions `opKey` maps modified→changed; added/removed pass through.
+    expect(parseEnumValues(schema, "Op").sort()).toEqual([
+      "added",
+      "modified",
+      "removed",
+    ]);
+  });
+
+  it("getHistoryIndex dependencies", () => {
+    expect(field("Build", "buildNumber")).toEqual(scalar("Int"));
+    expect(field("Build", "releasedAt")).toEqual(scalar("DateTime", true));
+    expect(field("Collection", "id")).toEqual(scalar("Int"));
+    expect(field("Collection", "name")).toEqual(scalar("String"));
+    expect(field("Change", "diffId")).toEqual(scalar("Int"));
+    expect(field("Change", "collectionId")).toEqual(scalar("Int"));
+    expect(field("Change", "collection")).toEqual(relation("Collection"));
+    expect(field("Entity", "kind")).toEqual(scalar("String"));
+    expect(field("Entity", "eveId")).toEqual(scalar("Int"));
+    expect(field("BuildDiff", "id")).toEqual(scalar("Int"));
+    expect(field("BuildDiff", "toBuild")).toEqual(scalar("Int"));
+  });
+
+  it("getBuildChanges dependencies", () => {
+    expect(field("Build", "buildNumber")).toEqual(scalar("Int"));
+    expect(field("Build", "releasedAt")).toEqual(scalar("DateTime", true));
+    expect(field("Change", "op")).toEqual(scalar("Op"));
+    expect(field("Change", "data")).toEqual(scalar("Json"));
+    expect(field("Change", "diff")).toEqual(relation("BuildDiff"));
+    expect(field("Change", "entity")).toEqual(relation("Entity"));
+    expect(field("Change", "collection")).toEqual(relation("Collection"));
+    expect(field("BuildDiff", "toBuild")).toEqual(scalar("Int")); // filtered via diff.toBuild
+    expect(field("Entity", "kind")).toEqual(scalar("String"));
+    expect(field("Entity", "eveId")).toEqual(scalar("Int"));
+    expect(field("Collection", "name")).toEqual(scalar("String"));
+  });
+
+  it("getEntityTimeline dependencies (the PR #627 crash site)", () => {
+    expect(field("Change", "diffId")).toEqual(scalar("Int"));
+    expect(field("Change", "op")).toEqual(scalar("Op"));
+    expect(field("Change", "data")).toEqual(scalar("Json"));
+    expect(field("Change", "entity")).toEqual(relation("Entity"));
+    expect(field("Change", "collection")).toEqual(relation("Collection"));
+    expect(field("Change", "diff")).toEqual(relation("BuildDiff")); // orderBy diff.toBuild
+    expect(field("BuildDiff", "id")).toEqual(scalar("Int"));
+    expect(field("BuildDiff", "toBuild")).toEqual(scalar("Int"));
+    expect(field("Build", "buildNumber")).toEqual(scalar("Int"));
+    expect(field("Build", "releasedAt")).toEqual(scalar("DateTime", true));
+    expect(field("Entity", "kind")).toEqual(scalar("String"));
+    expect(field("Entity", "eveId")).toEqual(scalar("Int"));
+    expect(field("Collection", "name")).toEqual(scalar("String"));
+  });
+
+  it("getResourceIndex dependencies", () => {
+    expect(field("FileChange", "diffId")).toEqual(scalar("Int"));
+    expect(field("FileChange", "op")).toEqual(scalar("Op"));
+    expect(field("Change", "diffId")).toEqual(scalar("Int"));
+    expect(field("Change", "collectionId")).toEqual(scalar("Int"));
+    expect(field("Change", "op")).toEqual(scalar("Op"));
+    expect(field("Change", "collection")).toEqual(relation("Collection"));
+    expect(field("Collection", "id")).toEqual(scalar("Int"));
+    expect(field("Collection", "name")).toEqual(scalar("String"));
+    expect(field("Build", "buildNumber")).toEqual(scalar("Int"));
+    expect(field("Build", "releasedAt")).toEqual(scalar("DateTime", true));
+    expect(field("BuildDiff", "id")).toEqual(scalar("Int"));
+    expect(field("BuildDiff", "toBuild")).toEqual(scalar("Int"));
+  });
+
+  it("getFileDiff dependencies", () => {
+    expect(field("FileChange", "diff")).toEqual(relation("BuildDiff"));
+    expect(field("FileChange", "path")).toEqual(scalar("String"));
+    expect(field("FileChange", "op")).toEqual(scalar("Op"));
+    expect(field("BuildDiff", "toBuild")).toEqual(scalar("Int"));
+  });
+
+  it("getStringChanges dependencies", () => {
+    expect(field("Change", "op")).toEqual(scalar("Op"));
+    expect(field("Change", "data")).toEqual(scalar("Json"));
+    expect(field("Change", "diff")).toEqual(relation("BuildDiff"));
+    expect(field("Change", "entity")).toEqual(relation("Entity"));
+    expect(field("Change", "collection")).toEqual(relation("Collection"));
+    expect(field("BuildDiff", "toBuild")).toEqual(scalar("Int"));
+    expect(field("Entity", "eveId")).toEqual(scalar("Int"));
+    expect(field("Collection", "name")).toEqual(scalar("String"));
+  });
+});


### PR DESCRIPTION
## What

Fixes a production crash on the `/type/{typeId}` history tab (and every other entity history tab — skin, group, etc.). From Vercel:

```
TypeError: Cannot read properties of null (reading 'buildNumber')
    at Array.map ... digest: '143643253'
```

Follow-up to #619 / #625.

## Why

`getEntityTimeline` read the build axis by walking the relation chain `change → diff → to → Build` (`r.diff.to.buildNumber`). While the shared `eve-builds` CockroachDB is **mid-migration** to the BuildDiff schema, a `BuildDiff.toBuild` can reference a `Build` row that doesn't exist yet, so Prisma returns `null` for the `to` relation **despite its non-null type** — and `r.diff.to.buildNumber` throws inside the `.map`.

## Fix

Resolve the build axis through lookup maps instead of relation traversal — the same `diffId → toBuild` / `toBuild → releasedAt` pattern `getHistoryIndex` and `getResourceIndex` already use:

- build number comes from `BuildDiff.toBuild` (a non-null scalar) via a map;
- a change whose `BuildDiff` is missing is **skipped** (can't be placed on the axis);
- a missing `Build` row yields a **null date** but the event still renders.

No relation chain is traversed, so the null-relation crash class is structurally gone. (`Map.get` returns `undefined`, never throws.)

## Tests

Extends `apps/web/tests/historyActions.test.ts` with a `getEntityTimeline` case covering both dangling-FK shapes (missing `Build` row → null date; missing `BuildDiff` → skipped). The existing history tests `jest.mock` the actions wholesale, so this is the only coverage of the real query logic.

Verified: test 3/3, lint clean, type-check clean (against the regenerated `@jitaspace/db-history` client). Browser verification isn't possible locally — the history pages need the shared prod `HISTORY_DATABASE_URL`.

## Note

The same dangling-FK exposure applies to the entity/collection relations in `getBuildChanges` / `getStringChanges` if those ever dangle, but this migration only affects the BuildDiff/Build axis, so I scoped the fix to the reported crash. Confined to `apps/web` (private package → no changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)