### PR TITLE
perf(db-history): mirror the /history aggregation indexes

### DIFF
--- a/packages/db-history/prisma/schema.prisma
+++ b/packages/db-history/prisma/schema.prisma
@@ -73,6 +73,10 @@ model FileChange {
   op     Op
 
   @@index([diffId])
+  // Covering index for the build-page file-change count (getResourceIndex):
+  // COUNT(*) GROUP BY (diffId, op). `@@index([diffId])` above is now a redundant
+  // prefix. Owned by the upstream ingestion pipeline; mirrored here for parity.
+  @@index([diffId, op])
 }
 
 /// The registry of tracked datasets (≈ resource-server files). Add a row → track more.
@@ -118,4 +122,12 @@ model Change {
   @@index([diffId])
   @@index([entityId])
   @@index([collectionId])
+  // Covering index for the change-count aggregations the `/history` readers run:
+  //   • index page  (getCachedHistoryIndex): COUNT(*) GROUP BY (collectionId, diffId)
+  //   • build pages (getResourceIndex):      COUNT(*) GROUP BY (collectionId, diffId, op)
+  // Without it the first groups the whole Change table via a full scan (~9s); the
+  // index makes both index-only counts. `@@index([collectionId])` above is now a
+  // redundant prefix. Owned by the upstream ingestion pipeline; mirrored here for
+  // parity (this package never pushes the schema).
+  @@index([collectionId, diffId, op])
 }


### PR DESCRIPTION
Read-side mirror of [jovespace#81](https://github.com/joaomlneto/jovespace/pull/81) — documentation parity for the covering indexes that fix the ~9s `/history` aggregation.

`@jitaspace/db-history` is read-only (its `db:push` is a no-op guard), so this changes **no runtime behavior here** — and the indexes are **already live** on the eve-builds DB (applied directly via `CREATE INDEX`). `EXPLAIN ANALYZE` confirms the index-page count dropped **~9s → 510ms**, now using `Change@Change_collectionId_diffId_op_idx`.

- `Change(collectionId, diffId, op)` — index page (`getCachedHistoryIndex`) + build-page string counts (`getResourceIndex`)
- `FileChange(diffId, op)` — build-page file counts

> Note: applying these to the DB was done with targeted `CREATE INDEX`, **not** `prisma db push` — the live `FileChange` table has `size`/`hash` columns this schema doesn't declare, so a push would drop them. See jovespace#81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)