### PR TITLE
perf(web): window the /history builds list

### DIFF
--- a/.changeset/history-builds-virtualized.md
+++ b/.changeset/history-builds-virtualized.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+The Change History page stays light and responsive with long histories. The builds list is now windowed — only the rows in view are rendered instead of mounting every build at once — so the initial load is lighter and scrolling and filter toggles stay smooth even across hundreds of builds.

--- a/apps/web/app/history/page.client.tsx
+++ b/apps/web/app/history/page.client.tsx
@@ -16,13 +16,143 @@ import {
   Stack,
   Switch,
   Text,
-  Timeline,
   Title,
 } from "@mantine/core";
 
 import type { HistoryIndex } from "~/lib/history";
 import { collectionMeta, entityTypeMeta } from "~/lib/history";
 import { HistoryTimelineChart } from "./_timeline-chart";
+
+type VisibleBuild = HistoryIndex["builds"][number] & { visibleCount: number };
+
+// Lightweight windowed list for the builds rail. With hundreds of changed
+// builds, rendering every Mantine `Timeline.Item` (and re-rendering them all on
+// each filter toggle) was the page's main weight. We render only the rows in (or
+// near) the viewport, absolutely positioned inside a full-height spacer.
+//
+// The viewport height used for the range math is a constant, NOT a measured one
+// — so there's no ResizeObserver dependency, it renders the first window on the
+// very first paint (incl. SSR / jsdom), and short lists still render in full.
+const ROW_HEIGHT = 60;
+const LIST_VIEWPORT = 600;
+const OVERSCAN = 8;
+
+function BuildRailRow({
+  b,
+  active,
+}: Readonly<{ b: VisibleBuild; active: string[] }>) {
+  return (
+    <Group wrap="nowrap" gap={0} style={{ height: ROW_HEIGHT }}>
+      <div
+        style={{
+          width: 22,
+          marginLeft: 6,
+          alignSelf: "stretch",
+          flexShrink: 0,
+          position: "relative",
+          borderLeft: "2px solid var(--mantine-color-default-border)",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            left: -6,
+            top: 7,
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            border: "2px solid var(--mantine-color-body)",
+            background:
+              b.visibleCount > 0
+                ? "var(--mantine-color-blue-6)"
+                : "var(--mantine-color-gray-5)",
+          }}
+        />
+      </div>
+      <Stack
+        gap={2}
+        style={{ flex: 1, minWidth: 0, paddingTop: 2, overflow: "hidden" }}
+      >
+        <Group gap="xs" wrap="nowrap">
+          <Anchor
+            component={Link}
+            href={`/history/build/${b.build}`}
+            c={b.visibleCount === 0 ? "dimmed" : undefined}
+            size="sm"
+          >
+            Build {b.build}
+          </Anchor>
+          <Badge
+            size="sm"
+            variant="light"
+            color={b.visibleCount > 0 ? "blue" : "gray"}
+          >
+            {b.changeCount === 0
+              ? "no changes"
+              : `${b.visibleCount.toLocaleString()} changes`}
+          </Badge>
+        </Group>
+        <Group gap="xs" wrap="nowrap" style={{ overflow: "hidden" }}>
+          <Text size="xs" c="dimmed" style={{ whiteSpace: "nowrap" }}>
+            {b.date ?? "date unknown"}
+          </Text>
+          {b.byCollection &&
+            Object.entries(b.byCollection)
+              .filter(([c]) => active.includes(c))
+              .map(([c, n]) => (
+                <Badge
+                  key={c}
+                  size="xs"
+                  variant="dot"
+                  color={collectionMeta(c).color}
+                  style={{ flexShrink: 0 }}
+                >
+                  {collectionMeta(c).label} {n}
+                </Badge>
+              ))}
+        </Group>
+      </Stack>
+    </Group>
+  );
+}
+
+function VirtualBuildList({
+  builds,
+  active,
+}: Readonly<{ builds: VisibleBuild[]; active: string[] }>) {
+  const [scrollTop, setScrollTop] = useState(0);
+  const total = builds.length * ROW_HEIGHT;
+  // Clamp so a stale scrollTop (e.g. after a filter shrinks the list) can't
+  // window past the end and render a blank viewport.
+  const top = Math.min(scrollTop, Math.max(0, total - LIST_VIEWPORT));
+  const start = Math.max(0, Math.floor(top / ROW_HEIGHT) - OVERSCAN);
+  const end = Math.min(
+    builds.length,
+    Math.ceil((top + LIST_VIEWPORT) / ROW_HEIGHT) + OVERSCAN,
+  );
+  return (
+    <div
+      onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+      style={{ height: Math.min(LIST_VIEWPORT, total), overflowY: "auto" }}
+    >
+      <div style={{ height: total, position: "relative" }}>
+        {builds.slice(start, end).map((b, i) => (
+          <div
+            key={b.build}
+            style={{
+              position: "absolute",
+              top: (start + i) * ROW_HEIGHT,
+              left: 0,
+              right: 0,
+            }}
+          >
+            <BuildRailRow b={b} active={active} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function HistoryIndexClient({
   initialIndex,
@@ -164,52 +294,9 @@ export default function HistoryIndexClient({
               No builds match the selected collections.
             </Text>
           )}
-          <Timeline active={-1} bulletSize={18} lineWidth={2}>
-            {builds.map((b) => (
-              <Timeline.Item
-                key={b.build}
-                title={
-                  <Group gap="xs">
-                    <Anchor
-                      component={Link}
-                      href={`/history/build/${b.build}`}
-                      c={b.visibleCount === 0 ? "dimmed" : undefined}
-                    >
-                      Build {b.build}
-                    </Anchor>
-                    <Badge
-                      size="sm"
-                      variant="light"
-                      color={b.visibleCount > 0 ? "blue" : "gray"}
-                    >
-                      {b.changeCount === 0
-                        ? "no changes"
-                        : `${b.visibleCount.toLocaleString()} changes`}
-                    </Badge>
-                  </Group>
-                }
-              >
-                <Group gap="xs">
-                  <Text size="xs" c="dimmed">
-                    {b.date ?? "date unknown"}
-                  </Text>
-                  {b.byCollection &&
-                    Object.entries(b.byCollection)
-                      .filter(([c]) => active.includes(c))
-                      .map(([c, n]) => (
-                        <Badge
-                          key={c}
-                          size="xs"
-                          variant="dot"
-                          color={collectionMeta(c).color}
-                        >
-                          {collectionMeta(c).label} {n}
-                        </Badge>
-                      ))}
-                </Group>
-              </Timeline.Item>
-            ))}
-          </Timeline>
+          {builds.length > 0 && (
+            <VirtualBuildList builds={builds} active={active} />
+          )}
         </div>
       </Stack>
     </Container>

--- a/apps/web/tests/historyRender.test.tsx
+++ b/apps/web/tests/historyRender.test.tsx
@@ -259,6 +259,32 @@ describe("HistoryIndexClient", () => {
     wrap(<HistoryIndexClient initialIndex={null} />);
     expect(screen.getByText(/No history has been generated/)).toBeTruthy();
   });
+
+  it("virtualizes the build list — renders only a window, not every build", async () => {
+    const { default: HistoryIndexClient } =
+      await import("~/app/history/page.client");
+    // 80 changed builds; the windowed list should mount only ~one viewport.
+    const builds = Array.from({ length: 80 }, (_, i) => ({
+      build: 1000 + i,
+      date: "2024-01-01",
+      changeCount: 3,
+      byCollection: { types: 3 },
+    }));
+    wrap(
+      <HistoryIndexClient
+        initialIndex={{
+          generatedAt: "x",
+          collections: ["types"],
+          entityTypes: ["type"],
+          entityCountsByType: { type: 1 },
+          builds,
+        }}
+      />,
+    );
+    const rows = screen.getAllByText(/^Build \d+$/);
+    expect(rows.length).toBeGreaterThan(5); // a window did render
+    expect(rows.length).toBeLessThan(40); // but nowhere near all 80
+  });
 });
 
 describe("EntityHistory", () => {


### PR DESCRIPTION
## What

The `/history` builds list is now **windowed** — only the rows in/near the viewport are rendered, instead of mounting a Mantine `Timeline.Item` for every changed build (hundreds) and re-rendering them all on each filter toggle. That list was the page's main client-side weight.

## How

A small hand-rolled windowed list — **no new dependency**:
- Renders only ~one viewport + overscan of rows, absolutely positioned inside a full-height spacer.
- The range math uses a **constant** viewport height, not a measured one — so there's no `ResizeObserver` dependency, it renders the first window on the very first paint (SSR / jsdom included), and short lists still render in full.
- Keeps the timeline look — left rail line + bullet dots, same Build / changes / date / collection-badge content.

## Tests

New test renders 80 changed builds and asserts only ~a window (`<40`, not all 80) actually mounts — proving the windowing. Full history suite green (64). Lint / prettier / type-check clean.

## Notes for the reviewer

- **Not visually verified** — `/history` needs the `db-history` connection, which isn't wired up locally, so the windowing is proven by tests but the rail/bullet styling is best-effort. Please eyeball it on the preview deploy; happy to fine-tune.
- Rows are fixed-height + `nowrap`, so a build touching *many* collections clips its extra badges (full list is on the build page). Trivial to switch to wrapping if you'd prefer.
- Pairs with the index speedup (the DB index that took `/history` from ~9s → ~0.5s) — that fixed the server side; this trims the client side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)