### PR TITLE
fix(web): proxy Umami event beacon to keep analytics ad-blocker- & CSP-safe

### DIFF
--- a/.changeset/proxy-umami-beacon.md
+++ b/.changeset/proxy-umami-beacon.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Route site analytics through a first-party path so visitors with ad blockers or strict browser privacy settings no longer have their analytics requests blocked.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -125,8 +125,12 @@ export default function RootLayout({
           strategy="afterInteractive"
           async
           defer
-          // /analytics is a proxy to the umami server - set in next.config.mjs
+          // /analytics is a proxy to the umami server - set in next.config.mjs.
+          // data-host-url routes the event beacon (`<host-url>/api/send`)
+          // back through the same-origin proxy too, so it stays off the CSP
+          // third-party allow-list and survives ad blockers that block umami.is.
           src={"/analytics/script.js"}
+          data-host-url="/analytics"
           data-website-id={env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
           data-domains="www.jita.space"
         ></Script>

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -142,8 +142,19 @@ const config = {
 
   rewrites: async () => [
     {
+      // Umami's tracker sends events to `<data-host-url>/api/send`, which
+      // defaults to the cloud collection gateway. The layout sets
+      // `data-host-url="/analytics"` so the beacon is same-origin (kept off
+      // `connect-src`'s third-party list and invisible to ad blockers that
+      // block `*.umami.is`); this rewrite forwards it to the gateway. Must
+      // come BEFORE the catch-all below — that one targets the script host,
+      // which does not serve `/api/send`.
+      source: "/analytics/api/send",
+      destination: "https://gateway.umami.is/api/send", // Umami event gateway
+    },
+    {
       source: "/analytics/:match*",
-      destination: "https://analytics.umami.is/:match*", // Proxy to Umami
+      destination: "https://analytics.umami.is/:match*", // Proxy to Umami script
     },
     {
       // Serve a single static shell for every /market/<typeId> URL instead of


### PR DESCRIPTION
## What

Routes the Umami analytics **event beacon** through the existing same-origin `/analytics` proxy instead of letting it post directly to `gateway.umami.is`.

- [apps/web/app/layout.tsx](apps/web/app/layout.tsx) — add `data-host-url="/analytics"` to the tracker `<Script>`, so the beacon targets `/analytics/api/send` (same-origin).
- [apps/web/next.config.mjs](apps/web/next.config.mjs) — add a rewrite `/analytics/api/send` → `https://gateway.umami.is/api/send`, ordered **before** the existing catch-all (which proxies the *script* host `analytics.umami.is`, not the ingestion gateway).
- Changeset (`@jitaspace/web` patch).

## Why

The tracker script was already loaded same-origin (`/analytics/script.js`), but its beacon went **straight to `gateway.umami.is/api/send`**, which:

1. **Tripped the report-only CSP** `connect-src` directive — Sentry [`JITASPACE-3S`](https://jitaspace.sentry.io/issues/128152120/), ~2.4k reports / 537 users. When the policy is eventually enforced, this would have **blocked analytics outright**.
2. **Was visible to ad blockers** that block `*.umami.is`, so those visitors weren't tracked.

With the beacon now same-origin, it's covered by CSP `'self'` (no `connect-src` change needed) and invisible to umami.is block rules.

## How it works

The cloud tracker builds its endpoint as `` `${(data-host-url || "https://gateway.umami.is").replace(/\/$/,"")}/api/send` `` — a plain string concat (no `new URL()`), verified against the live `script.js`. So a **relative** `data-host-url="/analytics"` resolves same-origin on every environment, and the existing `data-domains="www.jita.space"` guard keeps it from firing on dev/preview hostnames.

## Notes for reviewers

- Rewrite **ordering matters**: the specific `/analytics/api/send` must precede `/analytics/:match*`, because the catch-all targets the script host (`analytics.umami.is`), not the gateway.
- No browser preview was run: the `data-domains` guard disables the beacon on localhost, so there's nothing a dev preview could exercise. Verified instead by (a) reading the live tracker's endpoint logic and (b) confirming `gateway.umami.is/api/send` is the live ingestion endpoint.
- Merging with `Fixes JITASPACE-3S` will auto-close the Sentry issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)