### PR TITLE
fix(web): proxy Umami script via cloud.umami.is to stop CSP redirect violation

### DIFF
--- a/.changeset/fix-umami-script-proxy-redirect.md
+++ b/.changeset/fix-umami-script-proxy-redirect.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the privacy-friendly analytics script failing to load (and triggering Content Security Policy warnings) because the proxied Umami script host redirected to a different origin.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -153,8 +153,13 @@ const config = {
       destination: "https://gateway.umami.is/api/send", // Umami event gateway
     },
     {
+      // Must target `cloud.umami.is` (the canonical script host), NOT
+      // `analytics.umami.is` — the latter 301-redirects to `cloud.umami.is`,
+      // and Next.js forwards that redirect to the browser, which then loads a
+      // cross-origin script that `script-src 'self'` rejects (a CSP violation
+      // even though the proxied URL is same-origin). See JITASPACE-3T.
       source: "/analytics/:match*",
-      destination: "https://analytics.umami.is/:match*", // Proxy to Umami script
+      destination: "https://cloud.umami.is/:match*", // Proxy to Umami script
     },
     {
       // Serve a single static shell for every /market/<typeId> URL instead of


### PR DESCRIPTION
## What

Point the `/analytics/:match*` rewrite in `apps/web/next.config.mjs` at `cloud.umami.is` instead of `analytics.umami.is`.

## Why

Sentry [JITASPACE-3T](https://jitaspace.sentry.io/issues/128161833) — a `script-src-elem` CSP violation for `https://www.jita.space/analytics/script.js` (243 occurrences, 150 users, still firing).

The report was confusing because the blocked URL is **same-origin**, which `script-src 'self'` allows. The real cause is a redirect leaking through the proxy:

1. The rewrite proxied `/analytics/script.js` → `https://analytics.umami.is/script.js`.
2. `analytics.umami.is/script.js` returns **`301 → https://cloud.umami.is/script.js`** (verified with curl).
3. Next.js rewrites don't follow upstream redirects server-side — they forward the 301 to the browser.
4. The browser then loads the **cross-origin** `cloud.umami.is/script.js`, which isn't in `script-src`, so the CSP reports a violation. The blocked-uri is shown as the original same-origin URL per CSP's redirect-privacy rules, which is what made it look paradoxical.

Pointing the rewrite straight at `cloud.umami.is` (a `200`, no redirect) keeps the script same-origin end-to-end and eliminates the cross-origin hop.

## Notes for reviewers

- The event beacon path (`/analytics/api/send` → `gateway.umami.is`) was checked separately — it returns `400` to a bad body, no redirect — so it's untouched.
- The CSP is report-only, so the script was likely still loading after the browser followed the redirect; this removes the noise and the fragility.
- `Fixes JITASPACE-3T` will auto-close the Sentry issue on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)