### PR TITLE
fix(web): resolve CSP violations for Umami, GTM beacon, and unsafe-eval

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -62,12 +62,12 @@ const contentSecurityPolicy = [
   // 'none'` shuts off legacy plugin embedding vectors.
   "base-uri 'self'",
   "object-src 'none'",
-  "img-src 'self' https://images.evetech.net https://web.ccpgamescdn.com https://iec.jita.space data:",
+  "img-src 'self' https://images.evetech.net https://web.ccpgamescdn.com https://iec.jita.space https://www.googletagmanager.com data:",
   // FUTURE WORK: `'unsafe-inline'` is unavoidable here until we emit a
   // per-request nonce (Next.js injects inline bootstrap scripts; GTM is loaded
   // from googletagmanager.com). Removing it is the goal of the nonce migration
   // described above.
-  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com",
   // Mantine emits inline styles; same per-request-nonce caveat as script-src.
   "style-src 'self' 'unsafe-inline'",
   // Sentry Session Replay (enabled in instrumentation-client.ts) compresses
@@ -81,7 +81,7 @@ const contentSecurityPolicy = [
   // and so needs connect-src in addition to img-src. Then Google Analytics
   // (incl. regional `*.google-analytics.com` collectors) and the same-origin
   // Sentry/Umami proxies.
-  "connect-src 'self' https://esi.evetech.net https://sde.jita.space https://eve-kill.com https://evetycoon.com https://market.fuzzwork.co.uk https://images.evetech.net https://zkillboard.com https://www.google-analytics.com https://*.google-analytics.com /monitoring /analytics /ingest",
+  "connect-src 'self' https://esi.evetech.net https://sde.jita.space https://eve-kill.com https://evetycoon.com https://market.fuzzwork.co.uk https://images.evetech.net https://zkillboard.com https://www.google-analytics.com https://*.google-analytics.com https://gateway.umami.is https://www.google.com /monitoring /analytics /ingest",
   "frame-ancestors 'none'",
   // Sentry Security (CSP) endpoint derived from the browser DSN — see the note
   // above on why this is NOT the `/monitoring` tunnel. TODO: `report-uri` is


### PR DESCRIPTION
## What

Adds the missing origins/keywords to the Content-Security-Policy in `apps/web/next.config.mjs` so the browser stops reporting violations:

| Directive | Added | Why |
|-----------|-------|-----|
| `connect-src` | `https://gateway.umami.is` | Umami analytics ingest |
| `connect-src` | `https://www.google.com` | Google network calls (e.g. reCAPTCHA) |
| `img-src` | `https://www.googletagmanager.com` | GTM image/pixel beacon |
| `script-src` | `'unsafe-eval'` | required by a bundled script that evaluates dynamic code |

## Why

These resources were being blocked / reported by the CSP, producing console violations. The change just widens the allow-list to match what the app already loads.

## Notes for reviewers

- The CSP lives in **a single place** — `apps/web/next.config.mjs` (the `contentSecurityPolicy` array consumed by `headers()`). A repo-wide grep for `connect-src` / `Content-Security-Policy` confirms there is no other definition to keep in sync.
- The header is currently emitted as `Content-Security-Policy-Report-Only`, so these directives govern violation **reports** rather than active enforcement until the policy is switched to enforcing mode. The additions are still correct for when that migration happens.
- No changeset added: `@jitaspace/web` is a private package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)