### PR TITLE
fix(web): run OpenGraph image route on the edge runtime

### DIFF
--- a/.changeset/opengraph-edge-runtime.md
+++ b/.changeset/opengraph-edge-runtime.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed broken social-media preview (OpenGraph) images, which were failing to generate in production.

--- a/apps/web/app/api/opengraph/image/route.tsx
+++ b/apps/web/app/api/opengraph/image/route.tsx
@@ -3,6 +3,13 @@ import { ImageResponse } from "@vercel/og";
 
 /* eslint-disable @next/next/no-img-element */
 
+// `@vercel/og`'s `ImageResponse` is designed for the Edge runtime. Pinning the
+// route to `edge` avoids the Node serverless bundle missing the native
+// `@vercel/og` module on Vercel (which produced a runtime
+// "Cannot find module .../@vercel/og/index.node.js" 500). The handler only uses
+// `URL` + `ImageResponse` — no Node-only APIs — so it is edge-safe.
+export const runtime = "edge";
+
 export function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);


### PR DESCRIPTION
## What

Pin the `GET /api/opengraph/image` route to the **edge runtime** (`export const runtime = "edge"`).

## Why

In production on Vercel the route was throwing a 500:

```
Cannot find module '/var/task/node_modules/next/dist/compiled/@vercel/og/index.node.js'
```

This is a packaging issue — under the default Node serverless runtime, the native `@vercel/og/index.node.js` module wasn't being traced into the function bundle, so social-media preview (OpenGraph) images failed to generate.

`@vercel/og`'s `ImageResponse` is designed for the edge runtime, which is the most reliable fix and avoids the Node bundling problem entirely.

## Edge-safety

The handler only uses `URL`, `ImageResponse`, and `console.error` — all edge-compatible. No `fs`, no `node:crypto`, no DB/Redis/auth imports, so it's safe to move to edge.

## Notes for reviewers

- This bug only reproduces in Vercel's serverless *bundler*; locally the route already worked under the Node runtime, so it can't be reproduced on a local dev server. Verified edge-safety by inspection.
- Includes a user-facing changeset (`@jitaspace/web: patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)