### PR TITLE
fix(web): restore /status Database dashboard (CockroachDB v26 crdb_internal restriction)

### DIFF
--- a/.changeset/status-database-show-tables.md
+++ b/.changeset/status-database-show-tables.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the Database panel on the status page showing "Database status is currently unavailable" — it now reads table row estimates via `SHOW TABLES` instead of restricted internal tables, so the dashboard works again on CockroachDB v26 and CockroachDB Cloud.

--- a/apps/web/app/status/actions.ts
+++ b/apps/web/app/status/actions.ts
@@ -125,8 +125,9 @@ const DATABASE_CACHE_TTL_MS = DATABASE_STATUS_STALE_MINUTES * 60 * 1000;
 interface TableRowStatistic {
   table_name: string;
   // The pg adapter returns CockroachDB INT8 as a string to avoid precision
-  // loss; bigint/number are tolerated too, and the LEFT JOIN yields null for a
-  // table with no statistics yet. `Number(... ?? 0)` normalizes all of these.
+  // loss; bigint/number are tolerated too, and a table with no statistics yet
+  // reports 0 (null is tolerated defensively). `Number(... ?? 0)` normalizes
+  // all of these.
   estimated_row_count: string | number | bigint | null;
 }
 
@@ -146,17 +147,23 @@ const computeDatabaseStatus = async (): Promise<DatabaseStatusResponse> => {
     // cache miss. The estimates are refreshed automatically and are plenty for
     // a status dashboard (this is what CockroachDB's own DB Console shows).
     //
-    // `crdb_internal.table_row_statistics` is cluster-wide, so we join against
-    // `crdb_internal.tables` and scope to the connected database's public
-    // schema to list exactly our application's tables. The LEFT JOIN keeps
-    // tables that have no statistics yet (estimate comes back null → 0).
+    // We read them via `SHOW TABLES`, whose `estimated_row_count` column comes
+    // from those same statistics. We deliberately do NOT query
+    // `crdb_internal.table_row_statistics` directly: as of CockroachDB v26 (and
+    // on CockroachDB Cloud Basic/Standard) direct access to `crdb_internal` and
+    // `system` is restricted for non-admin roles and fails with error 42501
+    // ("Access to crdb_internal and system is restricted") unless the unsafe
+    // `allow_unsafe_internals` session var is set. `SHOW` statements are
+    // explicitly exempt from that gate, so they keep working in production.
+    //
+    // `SHOW TABLES` (no `FROM`) scopes to the connection's current database. We
+    // wrap it as a table expression (`[SHOW TABLES]`) so we can keep only base
+    // tables in the public schema (dropping views/sequences); `estimated_row_count`
+    // is 0 for tables whose statistics have not been computed yet.
     const rows = await prisma.$queryRaw<TableRowStatistic[]>`
-      SELECT t.name AS table_name, s.estimated_row_count AS estimated_row_count
-      FROM crdb_internal.tables AS t
-      LEFT JOIN crdb_internal.table_row_statistics AS s ON s.table_id = t.table_id
-      WHERE t.database_name = current_database()
-        AND t.schema_name = 'public'
-        AND t.state = 'PUBLIC'
+      SELECT table_name, estimated_row_count
+      FROM [SHOW TABLES]
+      WHERE type = 'table' AND schema_name = 'public'
     `;
 
     return buildDatabaseStatusResponse({

--- a/apps/web/lib/databaseStatus.ts
+++ b/apps/web/lib/databaseStatus.ts
@@ -3,7 +3,7 @@
  * (`app/status/actions.ts`) and the status-page dashboard.
  *
  * The counts are CockroachDB's estimated row counts (read from the latest
- * table statistics via `crdb_internal.table_row_statistics`), not exact
+ * table statistics via `SHOW TABLES`' `estimated_row_count`), not exact
  * `count(*)` results — see `getDatabaseStatus` for why. This module only
  * shapes/aggregates the rows; the actual query lives in the server function.
  *


### PR DESCRIPTION
## Problem

The **Database** panel on `/status` was showing:

> Database status is currently unavailable: Invalid `prisma.$queryRaw()` invocation: Raw query failed. Code: `42501`. Message: `Access to crdb_internal and system is restricted.`

The dashboard read estimated row counts by querying `crdb_internal.tables` + `crdb_internal.table_row_statistics`. As of **CockroachDB v26** (and on CockroachDB Cloud Basic/Standard), non-admin roles can no longer read `crdb_internal`/`system` directly — those reads fail with error `42501` unless the unsafe `allow_unsafe_internals` session var is set. Production hit v26, so the query started throwing and the panel fell into its error state. This is a platform-permissions change, not a bug in the aggregation code.

## Fix

Read the same estimates through **`SHOW TABLES`**, which is explicitly exempt from the restriction gate:

```sql
SELECT table_name, estimated_row_count
FROM [SHOW TABLES]
WHERE type = 'table' AND schema_name = 'public'
```

- `estimated_row_count` comes from the **same table statistics**, so counts are identical to before.
- The `[SHOW TABLES]` table-expression form lets us wrap it in a `SELECT`; no `FROM` scopes it to the connection's current database (matching the previous `current_database()` behavior).
- `type = 'table'` drops views/sequences; PascalCase Prisma model names are preserved.
- No aggregation/normalization changes: `estimated_row_count` still arrives as a string and `Number(x ?? 0)` handles it.

## Verification

No `.env`/DB is reachable from the worktree, so I spun up a throwaway **CockroachDB v26.2.3** node in Docker (which reproduces the `allow_unsafe_internals`-off default) and, through the **pg extended/prepared protocol** (exactly what Prisma `$queryRaw` uses):

- Old query → `42501 Access to crdb_internal and system is restricted.` (reproduces the reported error exactly)
- New query → correct estimates (e.g. `{"table_name":"KillmailVictimItems","estimated_row_count":"42"}`)
- Also confirmed `pg_class.reltuples` is NULL in CockroachDB (a dead end), and that `SHOW TABLES` estimates settle after the usual auto-stats propagation lag the dashboard already labels "approximate".

## Notes for reviewers

- The existing unit tests only cover the pure aggregation helpers in `lib/databaseStatus.ts` (not the SQL), so they're unaffected.
- `/status` was the only place under `apps/web` reading `crdb_internal`/`system` directly.
- Includes a user-facing changeset for `@jitaspace/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)