### PR TITLE
feat(web): show your loyalty points per corporation in the LP Store

### DIFF
--- a/.changeset/lp-store-character-loyalty-points.md
+++ b/.changeset/lp-store-character-loyalty-points.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+LP Store: when you're signed in, each corporation now shows how many loyalty points you currently have with it.

--- a/apps/web/app/lp-store/page.client.tsx
+++ b/apps/web/app/lp-store/page.client.tsx
@@ -6,13 +6,19 @@ import {
   Container,
   Group,
   SimpleGrid,
+  Skeleton,
   Stack,
   Text,
   Title,
+  useMantineTheme,
 } from "@mantine/core";
 import posthog from "posthog-js";
 
 import { LPStoreIcon } from "@jitaspace/eve-icons";
+import {
+  useCharacterLoyaltyPoints,
+  useSelectedCharacter,
+} from "@jitaspace/hooks";
 import { CorporationAvatar } from "@jitaspace/ui";
 
 export interface LPStorePageProps {
@@ -22,6 +28,12 @@ export interface LPStorePageProps {
 export default function LPStorePage({
   corporations,
 }: Readonly<LPStorePageProps>) {
+  const theme = useMantineTheme();
+  const character = useSelectedCharacter();
+  const { hasToken, loyaltyPointsMap, isLoading } = useCharacterLoyaltyPoints(
+    character?.characterId ?? 0,
+  );
+
   return (
     <Container size="xl">
       <Stack>
@@ -36,27 +48,45 @@ export default function LPStorePage({
           </Anchor>
         </Title>
         <SimpleGrid cols={{ base: 1, xs: 2, md: 3, lg: 4 }}>
-          {corporations.map((corporation) => (
-            <Anchor
-              component={Link}
-              href={`/lp-store/${corporation.name.replaceAll(" ", "_")}`}
-              key={corporation.corporationId}
-              onClick={() =>
-                posthog.capture("lp_store_corporation_selected", {
-                  corporation_id: corporation.corporationId,
-                  corporation_name: corporation.name,
-                })
-              }
-            >
-              <Group>
-                <CorporationAvatar
-                  corporationId={corporation.corporationId}
-                  size="sm"
-                />
-                <Text>{corporation.name}</Text>
-              </Group>
-            </Anchor>
-          ))}
+          {corporations.map((corporation) => {
+            const loyaltyPoints =
+              loyaltyPointsMap[corporation.corporationId] ?? 0;
+            return (
+              <Anchor
+                component={Link}
+                href={`/lp-store/${corporation.name.replaceAll(" ", "_")}`}
+                key={corporation.corporationId}
+                onClick={() =>
+                  posthog.capture("lp_store_corporation_selected", {
+                    corporation_id: corporation.corporationId,
+                    corporation_name: corporation.name,
+                  })
+                }
+              >
+                <Group wrap="nowrap">
+                  <CorporationAvatar
+                    corporationId={corporation.corporationId}
+                    size="sm"
+                  />
+                  <Stack gap={0}>
+                    <Text>{corporation.name}</Text>
+                    {hasToken &&
+                      (isLoading ? (
+                        <Skeleton height={12} mt={4} width={70} />
+                      ) : (
+                        <Text
+                          c={loyaltyPoints > 0 ? theme.primaryColor : "dimmed"}
+                          fw={loyaltyPoints > 0 ? 600 : undefined}
+                          size="xs"
+                        >
+                          {loyaltyPoints.toLocaleString()} LP
+                        </Text>
+                      ))}
+                  </Stack>
+                </Group>
+              </Anchor>
+            );
+          })}
         </SimpleGrid>
       </Stack>
     </Container>

--- a/apps/web/config/apps.tsx
+++ b/apps/web/config/apps.tsx
@@ -448,6 +448,10 @@ export const extraJitaFeatures: AppScopeSet[] = [
     scopes: ["esi-characters.read_standings.v1"],
   },
   {
+    reason: "Read character loyalty points",
+    scopes: ["esi-characters.read_loyalty.v1"],
+  },
+  {
     reason: "View your character assets (and active ship fitting)",
     scopes: ["esi-assets.read_assets.v1"],
   },

--- a/apps/web/tests/lpStoreIndexPage.test.tsx
+++ b/apps/web/tests/lpStoreIndexPage.test.tsx
@@ -9,10 +9,13 @@ import { captureMock } from "../__mocks__/posthogMocks";
 // ---------------------------------------------------------------------------
 // The LP Store index page client is presentational: it takes a list of
 // corporations and renders a header, an "all offers" link, and a grid of
-// per-corporation anchors. The route's page.tsx is an async Server Component
-// (Prisma fetch), so page.client carries the renderable UI and is exercised
-// here. next/link is stubbed to a plain anchor; @jitaspace/ui is a
-// pass-through Proxy so CorporationAvatar/Text wrappers don't drop children.
+// per-corporation anchors. When a character is signed in it also shows that
+// character's loyalty-point balance per corporation. The route's page.tsx is
+// an async Server Component (Prisma fetch), so page.client carries the
+// renderable UI and is exercised here. next/link is stubbed to a plain anchor;
+// @jitaspace/ui is a pass-through Proxy so CorporationAvatar/Text wrappers
+// don't drop children; @jitaspace/hooks is stubbed so we can drive the
+// signed-in / loyalty-points state.
 // ---------------------------------------------------------------------------
 
 jest.mock("next/link", () => ({
@@ -50,6 +53,15 @@ jest.mock(
     ),
 );
 
+const mockUseSelectedCharacter = jest.fn();
+const mockUseCharacterLoyaltyPoints = jest.fn();
+
+jest.mock("@jitaspace/hooks", () => ({
+  useSelectedCharacter: () => mockUseSelectedCharacter(),
+  useCharacterLoyaltyPoints: (...args: unknown[]) =>
+    mockUseCharacterLoyaltyPoints(...args),
+}));
+
 const CORPORATIONS = [
   { corporationId: 1000035, name: "Caldari Navy" },
   { corporationId: 1000125, name: "Federation Navy" },
@@ -68,6 +80,13 @@ function renderPage(props: Record<string, unknown> = {}) {
 describe("LP Store index page (client)", () => {
   beforeEach(() => {
     captureMock.mockClear();
+    // Default: signed out — no character, no loyalty points.
+    mockUseSelectedCharacter.mockReturnValue(null);
+    mockUseCharacterLoyaltyPoints.mockReturnValue({
+      hasToken: false,
+      loyaltyPointsMap: {},
+      isLoading: false,
+    });
   });
 
   it("captures lp_store_corporation_selected when a corporation is clicked", () => {
@@ -111,5 +130,41 @@ describe("LP Store index page (client)", () => {
     renderPage({ corporations: [] });
     expect(screen.getByText("LP Store")).toBeInTheDocument();
     expect(screen.queryByText("Caldari Navy")).not.toBeInTheDocument();
+  });
+
+  it("does not show loyalty points when signed out", () => {
+    renderPage();
+    expect(screen.queryByText("0 LP")).not.toBeInTheDocument();
+    expect(screen.queryByText("500 LP")).not.toBeInTheDocument();
+  });
+
+  it("shows the character's loyalty points per corporation when signed in", () => {
+    mockUseSelectedCharacter.mockReturnValue({ characterId: 90000001 });
+    mockUseCharacterLoyaltyPoints.mockReturnValue({
+      hasToken: true,
+      loyaltyPointsMap: { 1000035: 500 },
+      isLoading: false,
+    });
+
+    renderPage();
+
+    // A corporation the character has LP with shows the balance...
+    expect(screen.getByText("500 LP")).toBeInTheDocument();
+    // ...while corporations with no LP show a zero balance (ESI omits zeroes).
+    expect(screen.getByText("0 LP")).toBeInTheDocument();
+  });
+
+  it("shows nothing (not a zero balance) while loyalty points are loading", () => {
+    mockUseSelectedCharacter.mockReturnValue({ characterId: 90000001 });
+    mockUseCharacterLoyaltyPoints.mockReturnValue({
+      hasToken: true,
+      loyaltyPointsMap: {},
+      isLoading: true,
+    });
+
+    renderPage();
+
+    expect(screen.queryByText("0 LP")).not.toBeInTheDocument();
+    expect(screen.queryByText("500 LP")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What

On the **LP Store** landing page (`/lp-store`), each corporation card now shows the signed-in character's current loyalty point balance with that corporation.

- Non-zero balances are highlighted (theme primary color, semibold) so the corps you actually have LP with stand out; zero balances are dimmed.
- A skeleton is shown while loading; the line is hidden entirely when signed out.
- Reuses the existing `useCharacterLoyaltyPoints` hook (`@jitaspace/hooks`), keyed off `useSelectedCharacter()`.

## Why

The LP Store lets you browse what you can buy with LP, but never showed how much LP you actually have — so you had to alt-tab into the game to check. This surfaces it right where you pick a corporation.

## Notable for reviewers

- **Login scope plumbing (the non-obvious bit):** `esi-characters.read_loyalty.v1` was not in the app's requested scopes. The `LoginModal`'s default scope set (`allAppScopes`) is built **only** from `characterApps` + `extraJitaFeatures` — **not** from `universeApps` (where the LP Store lives). So the scope had to be added to `extraJitaFeatures` in `apps/web/config/apps.tsx`; adding it to the `lpstore` app entry would have been inert.
- **Graceful degradation:** the page stays fully public. If the character isn't signed in or hasn't granted the loyalty scope, the LP line is simply hidden — no `ScopeGuard` gate, no errors. Existing logged-in users will need to re-authenticate (grant the new permission) before their LP appears.
- ESI omits zero-balance corporations from the response, so corps you've never earned LP with correctly render a dimmed `0 LP`.

## Verification

- `pnpm exec prettier --check` ✓
- ESLint ✓ (`--flag unstable_native_nodejs_ts_config`) — 0 errors on the changed files; pre-commit `turbo lint` + `manypkg check` passed.
- `tsc --noEmit` for `@jitaspace/web` ✓ — 0 errors introduced (total unchanged at the pre-existing baseline).
- `LoginModal` unit tests ✓ (4 passed).

Not verified in a live browser: the balance only renders for an authenticated character holding the loyalty scope, which requires a real EVE SSO login plus the production database — neither is reachable in this environment.

## Possible follow-ups (not in this PR)

- Show the balance on the per-corporation detail page (`/lp-store/[corporationId]`) header, where you'd actually spend it.
- Add a "grant permission to see your LP" prompt for signed-in users missing the scope, for discoverability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
