### PR TITLE
feat(web): redesign the character page

### DIFF
--- a/.changeset/character-page-redesign.md
+++ b/.changeset/character-page-redesign.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+Redesigned the character page with a richer, more attractive layout: a portrait hero showing corporation, alliance and faction militia, a details sidebar (security status, age, race, bloodline and more), a formatted biography, and a full employment-history timeline with the dates and durations spent at each corporation. When you view one of your own characters it also surfaces live wallet balance, skill points, current location and skill training. Race and bloodline now display reliably instead of occasionally getting stuck loading.

--- a/.changeset/fix-race-bloodline-memo.md
+++ b/.changeset/fix-race-bloodline-memo.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/hooks": patch
+---
+
+Fix `useRace` and `useBloodline` returning a stale result when the requested id changes after the reference dataset has already loaded. The lookup `useMemo` omitted the id from its dependency array, so a component that mounted with an unresolved id (e.g. `0`) and received the real id afterwards would keep resolving to `undefined`.

--- a/apps/web/app/character/[characterId]/page.client.tsx
+++ b/apps/web/app/character/[characterId]/page.client.tsx
@@ -1,23 +1,40 @@
 "use client";
 
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import {
   Anchor,
   Badge,
+  Box,
   Button,
+  Card,
   Container,
+  Divider,
+  Grid,
   Group,
+  Skeleton,
   Stack,
   Text,
+  Timeline,
   Title,
 } from "@mantine/core";
-import { IconExternalLink } from "@tabler/icons-react";
+import {
+  IconBriefcase,
+  IconExternalLink,
+  IconId,
+  IconUserCircle,
+} from "@tabler/icons-react";
+import { format, formatDistanceStrict } from "date-fns";
 
+import { useGetCharactersCharacterIdCorporationhistory } from "@jitaspace/esi-client";
 import {
   AllianceName,
   CharacterName,
+  CharacterOnlineIndicator,
   CorporationName,
+  FactionName,
   SolarSystemAnchor,
   SolarSystemName,
   StationAnchor,
@@ -25,7 +42,13 @@ import {
   TypeAnchor,
   TypeName,
 } from "@jitaspace/eve-components";
-import { useCharacter, useSelectedCharacter } from "@jitaspace/hooks";
+import {
+  useAuthenticatedCharacter,
+  useCharacter,
+  useCharacterSkills,
+  useSelectedCharacter,
+} from "@jitaspace/hooks";
+import { useCharacterWalletBalance } from "@jitaspace/hooks/src/hooks/character/useCharacterWalletBalance";
 import { useGetNpcCorporationDivisionById } from "@jitaspace/sde-client";
 import { sanitizeFormattedEveString } from "@jitaspace/tiptap-eve";
 import {
@@ -33,14 +56,164 @@ import {
   CharacterAvatar,
   CorporationAvatar,
   DateHoverCard,
+  FactionAvatar,
   FormattedDateText,
+  ISKAmount,
   TypeAvatar,
 } from "@jitaspace/ui";
 
 import { OpenInformationWindowActionIcon } from "~/components/ActionIcon";
 import { StationAvatar } from "~/components/Avatar";
+import {
+  CharacterLocationCard,
+  CharacterSkillTrainingCard,
+} from "~/components/Card";
 import { MailMessageViewer } from "~/components/EveMail";
 import { BloodlineName, RaceName } from "~/components/Text";
+
+/** Map an EVE security status (-10 … +10) to a theme-safe Mantine color. */
+function securityStatusColor(sec: number): string {
+  if (sec >= 5) return "teal";
+  if (sec > 0) return "green";
+  if (sec === 0) return "gray";
+  if (sec > -5) return "orange";
+  return "red";
+}
+
+/** A dimmed uppercase eyebrow that sits above a section's content. */
+function SectionTitle({
+  icon,
+  children,
+}: {
+  icon?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <Group gap="xs" mb="md" wrap="nowrap">
+      {icon}
+      <Title order={4} style={{ letterSpacing: "0.08em" }}>
+        {children}
+      </Title>
+    </Group>
+  );
+}
+
+/** A single label / value row used inside the Details card. */
+function InfoRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Group justify="space-between" wrap="nowrap" gap="xl" align="center">
+      <Text size="sm" c="dimmed" style={{ whiteSpace: "nowrap" }}>
+        {label}
+      </Text>
+      <Box style={{ textAlign: "right", minWidth: 0 }}>{children}</Box>
+    </Group>
+  );
+}
+
+/**
+ * Renders a capsuleer's age. The birthday row only mounts once character data
+ * has loaded client-side, so a per-mount `now` is safe (no SSR/hydration gap).
+ */
+function CharacterAge({ birthday }: { birthday: Date }) {
+  const [now] = useState(() => new Date());
+  return <>{formatDistanceStrict(birthday, now)}</>;
+}
+
+/** Public employment history — the corporations a character has belonged to. */
+function CharacterEmploymentHistory({ characterId }: { characterId: number }) {
+  const { data, isLoading } =
+    useGetCharactersCharacterIdCorporationhistory(characterId);
+
+  const entries = useMemo(() => {
+    const history = data?.data;
+    if (!history) return [];
+    // Newest first. Each record ends when the next-newer record begins.
+    const sorted = [...history].sort((a, b) => b.record_id - a.record_id);
+    return sorted.map((entry, index) => ({
+      ...entry,
+      endDate: index === 0 ? undefined : sorted[index - 1]?.start_date,
+      isCurrent: index === 0,
+    }));
+  }, [data?.data]);
+
+  if (isLoading) {
+    return (
+      <Stack gap="lg">
+        {[0, 1, 2].map((i) => (
+          <Group key={i} gap="sm" wrap="nowrap">
+            <Skeleton height={32} circle />
+            <Stack gap={6} style={{ flex: 1 }}>
+              <Skeleton height={14} width="45%" />
+              <Skeleton height={10} width="70%" />
+            </Stack>
+          </Group>
+        ))}
+      </Stack>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        No employment history available.
+      </Text>
+    );
+  }
+
+  return (
+    <Timeline active={-1} bulletSize={32} lineWidth={2}>
+      {entries.map((entry) => (
+        <Timeline.Item
+          key={entry.record_id}
+          bullet={
+            <CorporationAvatar corporationId={entry.corporation_id} size={28} />
+          }
+          title={
+            <Group gap="xs">
+              <Anchor
+                component={Link}
+                href={`/corporation/${entry.corporation_id}`}
+              >
+                <CorporationName
+                  span
+                  corporationId={entry.corporation_id}
+                  fw={500}
+                />
+              </Anchor>
+              {entry.isCurrent && (
+                <Badge size="xs" color="teal" variant="light">
+                  Current
+                </Badge>
+              )}
+              {entry.is_deleted && (
+                <Badge size="xs" color="red" variant="light">
+                  Closed
+                </Badge>
+              )}
+            </Group>
+          }
+        >
+          <Text size="xs" c="dimmed" mt={4}>
+            {format(new Date(entry.start_date), "yyyy-MM-dd")}
+            {entry.endDate ? (
+              <>
+                {" → "}
+                {format(new Date(entry.endDate), "yyyy-MM-dd")}
+                {" · "}
+                {formatDistanceStrict(
+                  new Date(entry.start_date),
+                  new Date(entry.endDate),
+                )}
+              </>
+            ) : (
+              <> · present</>
+            )}
+          </Text>
+        </Timeline.Item>
+      ))}
+    </Timeline>
+  );
+}
 
 export default function Page() {
   const params = useParams();
@@ -50,217 +223,389 @@ export default function Page() {
   );
 
   const selectedCharacter = useSelectedCharacter();
-
   const { data: character } = useCharacter(characterId);
+
+  // Authenticated enrichment — only resolves when the viewer has a live token
+  // for this exact character (i.e. viewing one of their own characters).
+  const authenticatedCharacter = useAuthenticatedCharacter(characterId);
+  const { data: walletBalance, isAllowed: canReadWallet } =
+    useCharacterWalletBalance(characterId);
+  const { data: skills, hasToken: canReadSkills } =
+    useCharacterSkills(characterId);
 
   const { data: agentDivision } = useGetNpcCorporationDivisionById(
     character?.type === "agent" ? character.agentDivisionId : 0,
     { query: { enabled: character?.type === "agent" } },
   );
+
   if (!Number.isFinite(characterId)) {
     return null;
   }
 
-  let npcBadgeLabel: string;
+  const cleanTitle = character?.title
+    ? character.title.replace(/<[^>]*>/g, "").trim()
+    : undefined;
+
+  let npcBadgeLabel: string | undefined;
   if (character?.type === "agent") {
     npcBadgeLabel = character.isResearchAgent ? "Research Agent" : "Agent";
-  } else {
+  } else if (character?.isNpc) {
     npcBadgeLabel = "NPC";
   }
 
+  const showCapsuleerStatus =
+    !!authenticatedCharacter && !authenticatedCharacter.sessionExpired;
+
   return (
-    <Container size="sm">
-      <Stack>
-        <Group gap="xl">
-          <CharacterAvatar characterId={characterId} size="lg" />
-          <Title order={3}>
-            <CharacterName span characterId={characterId} />
-          </Title>
-          {character?.isNpc && <Badge>{npcBadgeLabel}</Badge>}
-          {selectedCharacter && (
-            <OpenInformationWindowActionIcon
-              characterId={selectedCharacter.characterId}
-              entityId={characterId}
-            />
-          )}
-        </Group>
-        <Group>
-          <Link
-            href={`https://evewho.com/character/${characterId}`}
-            target="_blank"
-          >
-            <Button>
-              <Group gap="xs">
-                <IconExternalLink size={14} />
-                EveWho
-              </Group>
-            </Button>
-          </Link>
-          <Link
-            href={`https://zkillboard.com/character/${characterId}`}
-            target="_blank"
-          >
-            <Button>
-              <Group gap="xs">
-                <IconExternalLink size={14} />
-                zKillboard
-              </Group>
-            </Button>
-          </Link>
-        </Group>
-        {character?.corporationId && (
-          <Group justify="space-between">
-            <Text>Corporation</Text>
-            <Group>
-              <CorporationAvatar
-                corporationId={character.corporationId}
-                size="sm"
+    <Container size="lg" py="md">
+      <Stack gap="xl">
+        {/* ---- Hero ---------------------------------------------------- */}
+        <Card padding="xl">
+          <Group align="flex-start" gap="xl" wrap="wrap">
+            <CharacterOnlineIndicator
+              characterId={characterId}
+              position="bottom-end"
+              offset={14}
+              size={16}
+              withBorder
+            >
+              <CharacterAvatar
+                characterId={characterId}
+                size={128}
+                radius="md"
               />
-              <Anchor
-                component={Link}
-                href={`/corporation/${character.corporationId}`}
-              >
-                <CorporationName span corporationId={character.corporationId} />
-              </Anchor>
-            </Group>
-          </Group>
-        )}
-        {character?.allianceId && (
-          <Group justify="space-between">
-            <Text>Alliance</Text>
-            <Group>
-              <AllianceAvatar allianceId={character.allianceId} size="sm" />
-              <Anchor
-                component={Link}
-                href={`/alliance/${character.allianceId}`}
-              >
-                <AllianceName span allianceId={character.allianceId} />
-              </Anchor>
-            </Group>
-          </Group>
-        )}
-        {character?.gender && (
-          <Group justify="space-between">
-            <Text>Gender</Text>
-            <Text>{character.gender === "male" ? "Male" : "Female"}</Text>
-          </Group>
-        )}
-        {character?.securityStatus !== undefined && (
-          <Group justify="space-between">
-            <Text>Security Status</Text>
-            <Text>{character.securityStatus}</Text>
-          </Group>
-        )}
-        {character?.birthday && (
-          <Group justify="space-between">
-            <Text>Birthday</Text>
-            <DateHoverCard date={character.birthday}>
-              <FormattedDateText date={character.birthday} />
-            </DateHoverCard>
-          </Group>
-        )}
-        <Group justify="space-between">
-          <Text>Bloodline</Text>
-          <Anchor
-            component={Link}
-            href={`/bloodline/${character?.bloodlineId}`}
-          >
-            <BloodlineName bloodlineId={character?.bloodlineId} />
-          </Anchor>
-        </Group>
-        <Group justify="space-between">
-          <Text>Race</Text>
-          <Anchor component={Link} href={`/race/${character?.raceId}`}>
-            <RaceName span raceId={character?.raceId} />
-          </Anchor>
-        </Group>
-        {character?.type === "agent" && (
-          <>
-            <Group justify="space-between">
-              <Text>Agent Division</Text>
-              <Text>{agentDivision?.data.name.en}</Text>
-            </Group>
-            <Group justify="space-between">
-              <Text>Agent Type</Text>
-              <Text>{character.agentTypeId}</Text>
-            </Group>
-            <Group justify="space-between">
-              <Text>Is Locator Agent?</Text>
-              <Text>{character.isLocator ? "Yes" : "No"}</Text>
-            </Group>
-            <Group justify="space-between">
-              <Text>Agent Level</Text>
-              <Text>{character.level}</Text>
-            </Group>
-            <Group justify="space-between">
-              <Text>Agent Station</Text>
-              <Group wrap="nowrap" gap="xs">
-                <StationAvatar stationId={character.locationId} size="xs" />
-                <StationAnchor stationId={character.locationId} target="_blank">
-                  <StationName stationId={character.locationId} />
-                </StationAnchor>
-              </Group>
-            </Group>
-            {character.isResearchAgent && (
-              <Group justify="space-between">
-                <Text>Research Agent Skills</Text>
-                <Stack gap="xs">
-                  {character.researchSkills?.map((typeId) => (
-                    <Group wrap="nowrap" gap="xs" key={typeId}>
-                      <TypeAvatar typeId={typeId} size="xs" />
-                      <TypeAnchor typeId={typeId} target="_blank">
-                        <TypeName typeId={typeId} />
-                      </TypeAnchor>
-                    </Group>
-                  ))}
-                </Stack>
-              </Group>
-            )}
-            {character.isInSpace && (
-              <>
-                <Group justify="space-between">
-                  <Text>Dungeon</Text>
-                  <Text>{character.dungeonId}</Text>
-                </Group>
-                <Group justify="space-between">
-                  <Text>Spawn Point</Text>
-                  <Text>{character.spawnPointId}</Text>
-                </Group>
-                <Group justify="space-between">
-                  <Text>Solar System</Text>
-                  <Group>
-                    <SolarSystemAnchor
-                      solarSystemId={character.solarSystemId}
-                      target="_blank"
+            </CharacterOnlineIndicator>
+
+            <Stack gap="sm" style={{ flex: 1, minWidth: 240 }}>
+              <div>
+                {cleanTitle && (
+                  <Text size="xs" c="dimmed" tt="uppercase" fw={600} mb={2}>
+                    {cleanTitle}
+                  </Text>
+                )}
+                <Group gap="sm" align="center">
+                  <Title order={2}>
+                    <CharacterName span characterId={characterId} />
+                  </Title>
+                  {npcBadgeLabel && (
+                    <Badge variant="light">{npcBadgeLabel}</Badge>
+                  )}
+                  {character?.securityStatus !== undefined && (
+                    <Badge
+                      variant="light"
+                      color={securityStatusColor(character.securityStatus)}
                     >
-                      <SolarSystemName
-                        solarSystemId={character.solarSystemId}
+                      {character.securityStatus.toFixed(1)}
+                    </Badge>
+                  )}
+                  {selectedCharacter && (
+                    <OpenInformationWindowActionIcon
+                      characterId={selectedCharacter.characterId}
+                      entityId={characterId}
+                    />
+                  )}
+                </Group>
+              </div>
+
+              {/* Affiliations */}
+              <Stack gap={6}>
+                {character?.corporationId && (
+                  <Group gap="xs" wrap="nowrap">
+                    <CorporationAvatar
+                      corporationId={character.corporationId}
+                      size="sm"
+                    />
+                    <Anchor
+                      component={Link}
+                      href={`/corporation/${character.corporationId}`}
+                    >
+                      <CorporationName
+                        span
+                        corporationId={character.corporationId}
+                        size="sm"
                       />
-                    </SolarSystemAnchor>
+                    </Anchor>
                   </Group>
-                </Group>
-                <Group justify="space-between">
-                  <Text>Type</Text>
-                  <Group>
-                    <TypeAvatar typeId={character.typeId} size="xs" />
-                    <TypeAnchor typeId={character.typeId} target="_blank">
-                      <TypeName typeId={character.typeId} />
-                    </TypeAnchor>
+                )}
+                {character?.allianceId && (
+                  <Group gap="xs" wrap="nowrap">
+                    <AllianceAvatar
+                      allianceId={character.allianceId}
+                      size="sm"
+                    />
+                    <Anchor
+                      component={Link}
+                      href={`/alliance/${character.allianceId}`}
+                    >
+                      <AllianceName
+                        span
+                        allianceId={character.allianceId}
+                        size="sm"
+                      />
+                    </Anchor>
                   </Group>
-                </Group>
-              </>
-            )}
-          </>
-        )}
-        {character && (
-          <MailMessageViewer
-            content={
-              character.description
-                ? sanitizeFormattedEveString(character.description)
-                : "No description"
-            }
-          />
-        )}
+                )}
+                {character?.factionId && (
+                  <Group gap="xs" wrap="nowrap">
+                    <FactionAvatar factionId={character.factionId} size="sm" />
+                    <Anchor
+                      component={Link}
+                      href={`/faction/${character.factionId}`}
+                    >
+                      <FactionName
+                        span
+                        factionId={character.factionId}
+                        size="sm"
+                      />
+                    </Anchor>
+                  </Group>
+                )}
+              </Stack>
+
+              {/* External resources */}
+              <Group gap="xs" mt={4}>
+                <Button
+                  component={Link}
+                  href={`https://evewho.com/character/${characterId}`}
+                  target="_blank"
+                  size="xs"
+                  leftSection={<IconExternalLink size={14} />}
+                >
+                  EveWho
+                </Button>
+                <Button
+                  component={Link}
+                  href={`https://zkillboard.com/character/${characterId}`}
+                  target="_blank"
+                  size="xs"
+                  leftSection={<IconExternalLink size={14} />}
+                >
+                  zKillboard
+                </Button>
+              </Group>
+            </Stack>
+          </Group>
+        </Card>
+
+        {/* ---- Body --------------------------------------------------- */}
+        <Grid gap="xl">
+          {/* Main column — biography + employment history */}
+          <Grid.Col span={{ base: 12, md: 8 }}>
+            <Stack gap="xl">
+              <Card padding="xl">
+                <SectionTitle icon={<IconUserCircle size={18} />}>
+                  Biography
+                </SectionTitle>
+                {character ? (
+                  <MailMessageViewer
+                    content={
+                      character.description
+                        ? sanitizeFormattedEveString(character.description)
+                        : "No biography."
+                    }
+                  />
+                ) : (
+                  <Skeleton height={80} />
+                )}
+              </Card>
+
+              <Card padding="xl">
+                <SectionTitle icon={<IconBriefcase size={18} />}>
+                  Employment History
+                </SectionTitle>
+                <CharacterEmploymentHistory characterId={characterId} />
+              </Card>
+            </Stack>
+          </Grid.Col>
+
+          {/* Aside column — the facts sidebar */}
+          <Grid.Col span={{ base: 12, md: 4 }}>
+            <Stack gap="xl">
+              <Card padding="xl">
+                <SectionTitle icon={<IconId size={18} />}>Details</SectionTitle>
+                <Stack gap="sm">
+                  {character?.securityStatus !== undefined && (
+                    <>
+                      <InfoRow label="Security Status">
+                        <Text
+                          span
+                          fw={600}
+                          c={securityStatusColor(character.securityStatus)}
+                        >
+                          {character.securityStatus.toFixed(2)}
+                        </Text>
+                      </InfoRow>
+                      <Divider />
+                    </>
+                  )}
+                  {character?.birthday && (
+                    <>
+                      <InfoRow label="Born">
+                        <DateHoverCard date={character.birthday}>
+                          <FormattedDateText
+                            date={character.birthday}
+                            format="d MMM yyyy"
+                          />
+                        </DateHoverCard>
+                      </InfoRow>
+                      <InfoRow label="Age">
+                        <Text span>
+                          <CharacterAge birthday={character.birthday} />
+                        </Text>
+                      </InfoRow>
+                      <Divider />
+                    </>
+                  )}
+                  {character?.gender && (
+                    <InfoRow label="Gender">
+                      <Text span tt="capitalize">
+                        {character.gender}
+                      </Text>
+                    </InfoRow>
+                  )}
+                  <InfoRow label="Race">
+                    <Anchor
+                      component={Link}
+                      href={`/race/${character?.raceId}`}
+                    >
+                      <RaceName span raceId={character?.raceId} />
+                    </Anchor>
+                  </InfoRow>
+                  <InfoRow label="Bloodline">
+                    <Anchor
+                      component={Link}
+                      href={`/bloodline/${character?.bloodlineId}`}
+                    >
+                      <BloodlineName bloodlineId={character?.bloodlineId} />
+                    </Anchor>
+                  </InfoRow>
+                  {character?.factionId && (
+                    <InfoRow label="Faction">
+                      <Anchor
+                        component={Link}
+                        href={`/faction/${character.factionId}`}
+                      >
+                        <FactionName span factionId={character.factionId} />
+                      </Anchor>
+                    </InfoRow>
+                  )}
+                </Stack>
+              </Card>
+
+              {/* NPC agent specifics */}
+              {character?.type === "agent" && (
+                <Card padding="xl">
+                  <SectionTitle icon={<IconId size={18} />}>
+                    Agent Details
+                  </SectionTitle>
+                  <Stack gap="sm">
+                    <InfoRow label="Division">
+                      <Text span>{agentDivision?.data.name.en ?? "—"}</Text>
+                    </InfoRow>
+                    <InfoRow label="Agent Type">
+                      <Text span>{character.agentTypeId}</Text>
+                    </InfoRow>
+                    <InfoRow label="Level">
+                      <Text span>{character.level}</Text>
+                    </InfoRow>
+                    <InfoRow label="Locator Agent">
+                      <Text span>{character.isLocator ? "Yes" : "No"}</Text>
+                    </InfoRow>
+                    <InfoRow label="Station">
+                      <Group wrap="nowrap" gap="xs" justify="flex-end">
+                        <StationAvatar
+                          stationId={character.locationId}
+                          size="xs"
+                        />
+                        <StationAnchor
+                          stationId={character.locationId}
+                          target="_blank"
+                        >
+                          <StationName stationId={character.locationId} />
+                        </StationAnchor>
+                      </Group>
+                    </InfoRow>
+                    {character.isResearchAgent &&
+                      character.researchSkills &&
+                      character.researchSkills.length > 0 && (
+                        <InfoRow label="Research Skills">
+                          <Stack gap="xs">
+                            {character.researchSkills.map((typeId) => (
+                              <Group
+                                wrap="nowrap"
+                                gap="xs"
+                                justify="flex-end"
+                                key={typeId}
+                              >
+                                <TypeAvatar typeId={typeId} size="xs" />
+                                <TypeAnchor typeId={typeId} target="_blank">
+                                  <TypeName typeId={typeId} />
+                                </TypeAnchor>
+                              </Group>
+                            ))}
+                          </Stack>
+                        </InfoRow>
+                      )}
+                    {character.isInSpace && (
+                      <>
+                        <Divider />
+                        <InfoRow label="Solar System">
+                          <SolarSystemAnchor
+                            solarSystemId={character.solarSystemId}
+                            target="_blank"
+                          >
+                            <SolarSystemName
+                              solarSystemId={character.solarSystemId}
+                            />
+                          </SolarSystemAnchor>
+                        </InfoRow>
+                        <InfoRow label="Ship">
+                          <Group wrap="nowrap" gap="xs" justify="flex-end">
+                            <TypeAvatar typeId={character.typeId} size="xs" />
+                            <TypeAnchor
+                              typeId={character.typeId}
+                              target="_blank"
+                            >
+                              <TypeName typeId={character.typeId} />
+                            </TypeAnchor>
+                          </Group>
+                        </InfoRow>
+                      </>
+                    )}
+                  </Stack>
+                </Card>
+              )}
+
+              {/* Authenticated (own character) live data */}
+              {showCapsuleerStatus && (
+                <Card padding="xl">
+                  <SectionTitle icon={<IconUserCircle size={18} />}>
+                    Capsuleer Status
+                  </SectionTitle>
+                  <Stack gap="md">
+                    {canReadWallet && (
+                      <InfoRow label="Wallet">
+                        <ISKAmount span fw={600} amount={walletBalance?.data} />
+                      </InfoRow>
+                    )}
+                    {canReadSkills && (
+                      <InfoRow label="Skill Points">
+                        <Group gap={6} wrap="nowrap" justify="flex-end">
+                          <TypeAvatar typeId={19430} size={16} />
+                          <Text span fw={600}>
+                            {skills?.data.total_sp.toLocaleString() ?? "—"} SP
+                          </Text>
+                        </Group>
+                      </InfoRow>
+                    )}
+                    <CharacterLocationCard characterId={characterId} />
+                    <CharacterSkillTrainingCard characterId={characterId} />
+                  </Stack>
+                </Card>
+              )}
+            </Stack>
+          </Grid.Col>
+        </Grid>
       </Stack>
     </Container>
   );

--- a/apps/web/app/character/[characterId]/page.client.tsx
+++ b/apps/web/app/character/[characterId]/page.client.tsx
@@ -84,10 +84,10 @@ function securityStatusColor(sec: number): string {
 function SectionTitle({
   icon,
   children,
-}: {
+}: Readonly<{
   icon?: ReactNode;
   children: ReactNode;
-}) {
+}>) {
   return (
     <Group gap="xs" mb="md" wrap="nowrap">
       {icon}
@@ -99,7 +99,10 @@ function SectionTitle({
 }
 
 /** A single label / value row used inside the Details card. */
-function InfoRow({ label, children }: { label: string; children: ReactNode }) {
+function InfoRow({
+  label,
+  children,
+}: Readonly<{ label: string; children: ReactNode }>) {
   return (
     <Group justify="space-between" wrap="nowrap" gap="xl" align="center">
       <Text size="sm" c="dimmed" style={{ whiteSpace: "nowrap" }}>
@@ -114,13 +117,15 @@ function InfoRow({ label, children }: { label: string; children: ReactNode }) {
  * Renders a capsuleer's age. The birthday row only mounts once character data
  * has loaded client-side, so a per-mount `now` is safe (no SSR/hydration gap).
  */
-function CharacterAge({ birthday }: { birthday: Date }) {
+function CharacterAge({ birthday }: Readonly<{ birthday: Date }>) {
   const [now] = useState(() => new Date());
   return <>{formatDistanceStrict(birthday, now)}</>;
 }
 
 /** Public employment history — the corporations a character has belonged to. */
-function CharacterEmploymentHistory({ characterId }: { characterId: number }) {
+function CharacterEmploymentHistory({
+  characterId,
+}: Readonly<{ characterId: number }>) {
   const { data, isLoading } =
     useGetCharactersCharacterIdCorporationhistory(characterId);
 
@@ -243,7 +248,7 @@ export default function Page() {
   }
 
   const cleanTitle = character?.title
-    ? character.title.replace(/<[^>]*>/g, "").trim()
+    ? character.title.replace(/<[^<>]*>/g, "").trim()
     : undefined;
 
   let npcBadgeLabel: string | undefined;

--- a/apps/web/tests/characterPage.test.tsx
+++ b/apps/web/tests/characterPage.test.tsx
@@ -10,12 +10,19 @@ const CHARACTER_ID = 30000142;
 const mockUseCharacter = jest.fn();
 const mockUseSelectedCharacter = jest.fn();
 const mockUseGetNpcCorporationDivisionById = jest.fn();
+const mockUseAuthenticatedCharacter = jest.fn();
+const mockUseCharacterSkills = jest.fn();
+const mockUseCharacterWalletBalance = jest.fn();
+const mockUseCorporationHistory = jest.fn();
 
-// character/[characterId]/page.tsx imports getCharactersCharacterId for generateMetadata
+// page.tsx imports getCharactersCharacterId for generateMetadata; page.client
+// imports useGetCharactersCharacterIdCorporationhistory for the timeline.
 jest.mock("@jitaspace/esi-client", () => ({
   getCharactersCharacterId: jest
     .fn()
     .mockResolvedValue({ data: { name: "Test" } }),
+  useGetCharactersCharacterIdCorporationhistory: (...args: unknown[]) =>
+    mockUseCorporationHistory(...args),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -27,7 +34,19 @@ jest.mock("next/navigation", () => ({
 jest.mock("@jitaspace/hooks", () => ({
   useCharacter: (...args: unknown[]) => mockUseCharacter(...args),
   useSelectedCharacter: () => mockUseSelectedCharacter(),
+  useAuthenticatedCharacter: (...args: unknown[]) =>
+    mockUseAuthenticatedCharacter(...args),
+  useCharacterSkills: (...args: unknown[]) => mockUseCharacterSkills(...args),
 }));
+
+// Imported via its deep path (not re-exported from the package root).
+jest.mock(
+  "@jitaspace/hooks/src/hooks/character/useCharacterWalletBalance",
+  () => ({
+    useCharacterWalletBalance: (...args: unknown[]) =>
+      mockUseCharacterWalletBalance(...args),
+  }),
+);
 
 jest.mock("@jitaspace/sde-client", () => ({
   useGetNpcCorporationDivisionById: (...args: unknown[]) =>
@@ -46,6 +65,11 @@ jest.mock("~/components/ActionIcon", () => ({
 
 jest.mock("~/components/Avatar", () => ({
   StationAvatar: () => null,
+}));
+
+jest.mock("~/components/Card", () => ({
+  CharacterLocationCard: () => <div data-testid="location-card" />,
+  CharacterSkillTrainingCard: () => <div data-testid="skill-training-card" />,
 }));
 
 jest.mock("~/components/Text", () => ({
@@ -88,8 +112,21 @@ describe("Character page", () => {
     mockUseCharacter.mockReset();
     mockUseSelectedCharacter.mockReset();
     mockUseGetNpcCorporationDivisionById.mockReset();
+    mockUseAuthenticatedCharacter.mockReset();
+    mockUseCharacterSkills.mockReset();
+    mockUseCharacterWalletBalance.mockReset();
+    mockUseCorporationHistory.mockReset();
+
+    // Sensible defaults — individual tests override as needed.
     mockUseGetNpcCorporationDivisionById.mockReturnValue({
       data: { data: { name: { en: "Distribution" } } },
+    });
+    mockUseAuthenticatedCharacter.mockReturnValue(null);
+    mockUseCharacterSkills.mockReturnValue({ hasToken: false });
+    mockUseCharacterWalletBalance.mockReturnValue({ isAllowed: false });
+    mockUseCorporationHistory.mockReturnValue({
+      data: { data: [] },
+      isLoading: false,
     });
   });
 
@@ -110,23 +147,43 @@ describe("Character page", () => {
         level: 4,
         locationId: 60000001,
         isInSpace: true,
-        dungeonId: 111,
-        spawnPointId: 222,
         solarSystemId: 30000142,
         typeId: 587,
         researchSkills: [11442, 11443],
         corporationId: 1000035,
         allianceId: 99000001,
+        factionId: 500001,
         gender: "male",
         securityStatus: 1.5,
         birthday: new Date("2003-05-06T00:00:00Z"),
         bloodlineId: 1,
         raceId: 1,
+        title: "<b>The</b> Agent",
         description: "An EVE agent",
       },
     });
+    mockUseCorporationHistory.mockReturnValue({
+      data: {
+        data: [
+          {
+            corporation_id: 1000035,
+            record_id: 3,
+            start_date: "2010-01-01T00:00:00Z",
+            is_deleted: false,
+          },
+          {
+            corporation_id: 2000,
+            record_id: 2,
+            start_date: "2008-01-01T00:00:00Z",
+            is_deleted: true,
+          },
+          { corporation_id: 3000, record_id: 1, start_date: "2005-01-01T00:00:00Z" },
+        ],
+      },
+      isLoading: false,
+    });
 
-    renderPage();
+    const { container } = renderPage();
 
     expect(mockUseCharacter).toHaveBeenCalledWith(CHARACTER_ID);
     // agent division hook called with the division id, query enabled
@@ -138,6 +195,9 @@ describe("Character page", () => {
     expect(screen.getAllByTestId("info-window").length).toBeGreaterThanOrEqual(
       1,
     );
+
+    // Title has its EVE-HTML tags stripped
+    expect(screen.getByText("The Agent")).toBeInTheDocument();
 
     // NPC research agent badge
     expect(screen.getByText("Research Agent")).toBeInTheDocument();
@@ -152,53 +212,79 @@ describe("Character page", () => {
       `https://zkillboard.com/character/${CHARACTER_ID}`,
     );
 
-    // Optional relationship rows
-    expect(screen.getByText("Corporation")).toBeInTheDocument();
-    expect(screen.getByText("Alliance")).toBeInTheDocument();
-    expect(screen.getByText("Gender")).toBeInTheDocument();
-    expect(screen.getByText("Male")).toBeInTheDocument();
-    expect(screen.getByText("Security Status")).toBeInTheDocument();
-    expect(screen.getByText("1.5")).toBeInTheDocument();
-    expect(screen.getByText("Birthday")).toBeInTheDocument();
-    expect(screen.getByText("Bloodline")).toBeInTheDocument();
-    expect(screen.getByText("Race")).toBeInTheDocument();
+    // Affiliations render as links in the hero
+    expect(
+      container.querySelector('a[href="/corporation/1000035"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('a[href="/alliance/99000001"]'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('a[href="/faction/500001"]'),
+    ).toBeInTheDocument();
 
-    // Agent-specific rows
-    expect(screen.getByText("Agent Division")).toBeInTheDocument();
+    // Details sidebar
+    expect(screen.getByText("Details")).toBeInTheDocument();
+    expect(screen.getByText("Security Status")).toBeInTheDocument();
+    expect(screen.getByText("1.50")).toBeInTheDocument();
+    expect(screen.getByText("Born")).toBeInTheDocument();
+    expect(screen.getByText("Age")).toBeInTheDocument();
+    expect(screen.getByText("Gender")).toBeInTheDocument();
+    expect(screen.getByText("male")).toBeInTheDocument();
+    expect(screen.getByText("Race")).toBeInTheDocument();
+    expect(screen.getByText("Race#1")).toBeInTheDocument();
+    expect(screen.getByText("Bloodline")).toBeInTheDocument();
+    expect(screen.getByText("Faction")).toBeInTheDocument();
+
+    // Agent-specific rows (relabelled from the old page)
+    expect(screen.getByText("Agent Details")).toBeInTheDocument();
+    expect(screen.getByText("Division")).toBeInTheDocument();
     expect(screen.getByText("Distribution")).toBeInTheDocument();
     expect(screen.getByText("Agent Type")).toBeInTheDocument();
-    expect(screen.getByText("Is Locator Agent?")).toBeInTheDocument();
-    expect(screen.getByText("Agent Level")).toBeInTheDocument();
-    expect(screen.getByText("Agent Station")).toBeInTheDocument();
-    expect(screen.getByText("Research Agent Skills")).toBeInTheDocument();
+    expect(screen.getByText("Level")).toBeInTheDocument();
+    expect(screen.getByText("Locator Agent")).toBeInTheDocument();
+    expect(screen.getByText("Station")).toBeInTheDocument();
+    expect(screen.getByText("Research Skills")).toBeInTheDocument();
 
     // isInSpace branch rows
-    expect(screen.getByText("Dungeon")).toBeInTheDocument();
-    expect(screen.getByText("Spawn Point")).toBeInTheDocument();
     expect(screen.getByText("Solar System")).toBeInTheDocument();
-    expect(screen.getByText("Type")).toBeInTheDocument();
+    expect(screen.getByText("Ship")).toBeInTheDocument();
+    // Rows dropped in the redesign
+    expect(screen.queryByText("Dungeon")).not.toBeInTheDocument();
+    expect(screen.queryByText("Spawn Point")).not.toBeInTheDocument();
 
     // Description sanitized through tiptap-eve and shown in the mail viewer
     expect(screen.getByTestId("mail-viewer")).toHaveTextContent(
       "sanitized:An EVE agent",
     );
+
+    // Employment history timeline
+    expect(screen.getByText("Employment History")).toBeInTheDocument();
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    expect(screen.getByText("Closed")).toBeInTheDocument();
+    expect(
+      container.querySelector('a[href="/corporation/3000"]'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("No employment history available."),
+    ).not.toBeInTheDocument();
   });
 
-  it("renders a plain non-agent NPC badge and skips agent rows", () => {
+  it("renders a plain non-agent NPC and skips the optional rows", () => {
     mockUseSelectedCharacter.mockReturnValue(undefined);
     mockUseCharacter.mockReturnValue({
       data: {
-        type: "npc",
+        type: "player",
         isNpc: true,
         corporationId: 1000035,
         gender: "female",
         bloodlineId: 2,
         raceId: 2,
-        // no description -> "No description"
+        // no alliance / faction / security / birthday / description
       },
     });
 
-    renderPage();
+    const { container } = renderPage();
 
     // No selected character -> no info window
     expect(screen.queryByTestId("info-window")).not.toBeInTheDocument();
@@ -207,35 +293,108 @@ describe("Character page", () => {
     expect(screen.getByText("NPC")).toBeInTheDocument();
 
     // Female gender branch
-    expect(screen.getByText("Female")).toBeInTheDocument();
+    expect(screen.getByText("female")).toBeInTheDocument();
 
     // Agent rows are hidden
-    expect(screen.queryByText("Agent Division")).not.toBeInTheDocument();
-    expect(screen.queryByText("Dungeon")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent Details")).not.toBeInTheDocument();
+    expect(screen.queryByText("Division")).not.toBeInTheDocument();
+    expect(screen.queryByText("Solar System")).not.toBeInTheDocument();
 
-    // Alliance row hidden (no allianceId), Corporation shown
-    expect(screen.getByText("Corporation")).toBeInTheDocument();
-    expect(screen.queryByText("Alliance")).not.toBeInTheDocument();
+    // Corporation shown; alliance & faction hidden
+    expect(
+      container.querySelector('a[href="/corporation/1000035"]'),
+    ).toBeInTheDocument();
+    expect(container.querySelector('a[href^="/alliance/"]')).toBeNull();
+    expect(container.querySelector('a[href^="/faction/"]')).toBeNull();
 
-    // Default description fallback
+    // Optional detail rows hidden when their data is absent
+    expect(screen.queryByText("Security Status")).not.toBeInTheDocument();
+    expect(screen.queryByText("Born")).not.toBeInTheDocument();
+    expect(screen.queryByText("Faction")).not.toBeInTheDocument();
+
+    // No signed-in session -> no Capsuleer Status panel
+    expect(screen.queryByText("Capsuleer Status")).not.toBeInTheDocument();
+
+    // Default biography fallback
     expect(screen.getByTestId("mail-viewer")).toHaveTextContent(
-      "No description",
+      "No biography.",
     );
+
+    // Empty employment history
+    expect(
+      screen.getByText("No employment history available."),
+    ).toBeInTheDocument();
   });
 
-  it("renders nothing meaningful when character data is undefined", () => {
-    mockUseSelectedCharacter.mockReturnValue(undefined);
-    mockUseCharacter.mockReturnValue({ data: undefined });
+  it("shows the Capsuleer Status panel for an authenticated own character", () => {
+    mockUseSelectedCharacter.mockReturnValue({ characterId: CHARACTER_ID });
+    mockUseAuthenticatedCharacter.mockReturnValue({
+      characterId: CHARACTER_ID,
+      sessionExpired: false,
+    });
+    mockUseCharacterWalletBalance.mockReturnValue({
+      data: { data: 1234567 },
+      isAllowed: true,
+    });
+    mockUseCharacterSkills.mockReturnValue({
+      data: { data: { total_sp: 5000000 } },
+      hasToken: true,
+    });
+    mockUseCharacter.mockReturnValue({
+      data: {
+        type: "player",
+        isNpc: false,
+        corporationId: 1000035,
+        allianceId: 99000001,
+        gender: "male",
+        securityStatus: 5,
+        birthday: new Date("2010-01-01T00:00:00Z"),
+        bloodlineId: 3,
+        raceId: 8,
+        description: "Capsuleer bio",
+      },
+    });
 
     renderPage();
 
-    // Static rows still render
-    expect(screen.getByText("Bloodline")).toBeInTheDocument();
-    expect(screen.getByText("Race")).toBeInTheDocument();
-    // No badge, no relationship rows, no mail viewer (character falsey)
+    expect(screen.getByText("Capsuleer Status")).toBeInTheDocument();
+    expect(screen.getByText("Wallet")).toBeInTheDocument();
+    expect(screen.getByText("Skill Points")).toBeInTheDocument();
+    expect(screen.getByText("5,000,000 SP")).toBeInTheDocument();
+    expect(screen.getByTestId("location-card")).toBeInTheDocument();
+    expect(screen.getByTestId("skill-training-card")).toBeInTheDocument();
+
+    // Regular player -> no NPC/agent badge, and a >=5 security status
     expect(screen.queryByText("NPC")).not.toBeInTheDocument();
-    expect(screen.queryByText("Corporation")).not.toBeInTheDocument();
+    expect(screen.getByText("5.00")).toBeInTheDocument();
+  });
+
+  it("renders a graceful shell when character data is undefined", () => {
+    mockUseSelectedCharacter.mockReturnValue(undefined);
+    mockUseCharacter.mockReturnValue({ data: undefined });
+    mockUseCorporationHistory.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    renderPage();
+
+    // Static section headers + always-rendered rows
+    expect(screen.getByText("Details")).toBeInTheDocument();
+    expect(screen.getByText("Biography")).toBeInTheDocument();
+    expect(screen.getByText("Employment History")).toBeInTheDocument();
+    expect(screen.getByText("Race")).toBeInTheDocument();
+    expect(screen.getByText("Bloodline")).toBeInTheDocument();
+
+    // No badge, no biography viewer (character falsey -> skeleton)
+    expect(screen.queryByText("NPC")).not.toBeInTheDocument();
     expect(screen.queryByTestId("mail-viewer")).not.toBeInTheDocument();
+
+    // Employment history is loading -> no empty message yet
+    expect(
+      screen.queryByText("No employment history available."),
+    ).not.toBeInTheDocument();
+
     // agent division hook disabled
     expect(mockUseGetNpcCorporationDivisionById).toHaveBeenCalledWith(0, {
       query: { enabled: false },
@@ -253,6 +412,6 @@ describe("Character page", () => {
       </MantineProvider>,
     );
 
-    expect(screen.getByText("Bloodline")).toBeInTheDocument();
+    expect(screen.getByText("Details")).toBeInTheDocument();
   });
 });

--- a/packages/hooks/src/hooks/universe/useBloodline.ts
+++ b/packages/hooks/src/hooks/universe/useBloodline.ts
@@ -4,17 +4,13 @@ import { useMemo } from "react";
 
 import { useGetUniverseBloodlines } from "@jitaspace/esi-client";
 
-
-
-
-
 export const useBloodline = (bloodlineId: number) => {
   const { data, ...others } = useGetUniverseBloodlines();
 
   const bloodline = useMemo(
     () =>
       data?.data.find((bloodline) => bloodline.bloodline_id === bloodlineId),
-    [data],
+    [data, bloodlineId],
   );
 
   return { data: bloodline, ...others };

--- a/packages/hooks/src/hooks/universe/useRace.ts
+++ b/packages/hooks/src/hooks/universe/useRace.ts
@@ -4,16 +4,12 @@ import { useMemo } from "react";
 
 import { useGetUniverseRaces } from "@jitaspace/esi-client";
 
-
-
-
-
 export const useRace = (raceId: number) => {
   const { data, ...others } = useGetUniverseRaces();
 
   const race = useMemo(
     () => data?.data.find((race) => race.race_id === raceId),
-    [data],
+    [data, raceId],
   );
 
   return { data: race, ...others };


### PR DESCRIPTION
## Summary

Redesigns the character detail page (`/character/[characterId]`) from a flat list of label/value rows into a proper profile layout, and fixes a latent race/bloodline lookup bug uncovered while testing it.

## What's new on the page

Everything below is **public** data (works for any character), degrading gracefully when a field is absent:

- **Hero** — large portrait with an online indicator, name, a colour-coded security-status badge, NPC/Agent badge, and **corporation / alliance / faction-militia** affiliations (each with logo + link), plus EveWho / zKillboard buttons.
- **Biography** — the character's bio rendered as formatted EVE-HTML.
- **Employment History** — a timeline of every corporation the character has belonged to (newest first) with corp logos, a teal **CURRENT** badge, red **CLOSED** badges for defunct corps, and the date range + duration spent at each.
- **Details** sidebar — security status, born date + computed age, gender, race, bloodline, faction.
- **Agent Details** — division, level, station, research skills and in-space info for NPC agents.
- **Capsuleer Status** — for your *own* signed-in character only: live wallet balance, skill points, current location and skill-training (reuses the existing dashboard cards).

Layout is the standard content-left / facts-sidebar pattern, so it stays balanced whether the bio is huge or a character has 25+ corp changes, and it stacks cleanly on mobile.

## Bug fix (`@jitaspace/hooks`)

While testing, Race/Bloodline occasionally got stuck on a loading skeleton. Root cause: `useRace` / `useBloodline` built their lookup with `useMemo(() => data?.data.find(... === id), [data])` — the **id was missing from the dependency array**. If a component mounted with an unresolved id (`0`) and received the real id *after* the reference dataset had already loaded, the memo never recomputed and kept resolving to `undefined`. The new employment timeline's extra ESI fan-out shifted request timing enough to make this reproducible. One-line fix in each hook; no other `universe/*` hook has the pattern.

## Verification

- `tsc --noEmit` clean for the page and both hooks; ESLint clean (pre-commit `turbo lint` + `manypkg check` passed with 0 errors).
- Rendered live in the dev server for **Chribba** (7 corp changes) and **Sarah Flynt** (26) — no console errors, no hydration warnings, all data populated; Race/Bloodline now resolve reliably.
- Checked mobile (375px) — columns stack correctly.

## Reviewer notes

- The authenticated **Capsuleer Status** panel only renders when viewing your own signed-in character, which couldn't be exercised in the headless preview. It reuses already-shipped dashboard components but hasn't been visually confirmed in this layout.
- Unrelated heads-up: the repo is actually on **Mantine 9.3.0**, not 8 as `CLAUDE.md` / `AGENTS.md` state (Mantine 9 removed `<Grid gutter>` → use `gap`, which the type-check caught). Worth updating those docs.
- Changesets included: `@jitaspace/web` (minor), `@jitaspace/hooks` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
