### PR TITLE
feat(web): redesign the solar system page

### DIFF
--- a/.changeset/solar-system-jumps-hook.md
+++ b/.changeset/solar-system-jumps-hook.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/hooks": patch
+---
+
+Add `useAllSolarSystemJumps`, exposing ESI per-system ship-jump activity (mirrors `useAllSolarSystemKills`).

--- a/.changeset/solar-system-page-redesign.md
+++ b/.changeset/solar-system-page-redesign.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+Redesigned the solar system page. It now opens with a security-coloured hero (star, security status and band, sovereignty holder) and surfaces far more at a glance: live activity for the last hour (ship jumps, ship/pod/NPC kills), sovereignty, faction-warfare and incursion status, the full list of celestials, stargate connections showing which system each gate leads to (with its security status), stations, industry cost indices, and detailed system information.

--- a/.changeset/solar-system-security-helpers.md
+++ b/.changeset/solar-system-security-helpers.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/ui": patch
+---
+
+Add reusable solar-system security-status helpers (`securityStatusColor`, `securityStatusBand`, `formatSecurityStatus`, `isLightSecurityStatus`, `roundSecurityStatus`) and refactor `SolarSystemSecurityStatusBadge` to consume them, so the CCP security colour ramp lives in one place.

--- a/apps/web/app/system/[systemId]/page.client.tsx
+++ b/apps/web/app/system/[systemId]/page.client.tsx
@@ -30,6 +30,7 @@ import {
   IconSwords,
 } from "@tabler/icons-react";
 
+import type { SolarSystem } from "@jitaspace/sde-client";
 import {
   AllianceName,
   CorporationName,
@@ -78,6 +79,29 @@ interface SovereigntyEntry {
   alliance_id?: number;
   corporation_id?: number;
   faction_id?: number;
+}
+
+/** Coarse security band shown next to the system name. */
+function getSecurityBand(
+  securityStatus: number | undefined,
+  isWormhole: boolean,
+): string | undefined {
+  if (securityStatus == null) return undefined;
+  if (isWormhole) return "W-Space";
+  return securityStatusBand(securityStatus);
+}
+
+/** Format a numeric value with a unit suffix, or an em dash when absent. */
+function withUnit(value: number | null | undefined, unit: string): string {
+  return value == null ? "—" : `${value.toLocaleString()} ${unit}`;
+}
+
+/**
+ * Stringify a number, or an em dash when absent. The SDE types mark some
+ * numeric fields as required but the data can omit them, so accept nullish.
+ */
+function formatNumber(value: number | null | undefined): string {
+  return value == null ? "—" : value.toString();
 }
 
 /** A single labelled live-activity metric. */
@@ -236,6 +260,227 @@ function SovereigntyLabel({ sov }: Readonly<{ sov: SovereigntyEntry }>) {
   return null;
 }
 
+interface FactionWarfare {
+  contested: string;
+  owner_faction_id: number;
+  victory_points: number;
+  victory_points_threshold: number;
+}
+
+interface Incursion {
+  faction_id: number;
+  has_boss: boolean;
+  influence: number;
+  state: string;
+}
+
+/** Sovereignty / faction-warfare / incursion status; null when none apply. */
+function SystemControlPanels({
+  systemId,
+  sov,
+  fw,
+  incursion,
+}: Readonly<{
+  systemId: number;
+  sov?: SovereigntyEntry;
+  fw?: FactionWarfare;
+  incursion?: Incursion;
+}>) {
+  const hasSovereignty = Boolean(
+    sov?.alliance_id ?? sov?.corporation_id ?? sov?.faction_id,
+  );
+  const hasFactionWarfare = fw != null;
+  const hasIncursion = incursion != null;
+
+  if (hasSovereignty || hasFactionWarfare || hasIncursion) {
+    return (
+      <SimpleGrid
+        cols={{ base: 1, md: hasFactionWarfare && hasIncursion ? 2 : 1 }}
+        spacing="md"
+      >
+        {hasSovereignty && sov && (
+          <Paper p="md" radius="md">
+            <Group gap="sm" wrap="nowrap">
+              <IconShieldHalf
+                size={22}
+                color="var(--mantine-color-eve_primary-4)"
+              />
+              <SolarSystemSovereigntyAvatar
+                solarSystemId={systemId}
+                size={34}
+                radius={999}
+              />
+              <div style={{ minWidth: 0 }}>
+                <Text size="xs" c="dimmed" className={classes.statLabel}>
+                  Sovereignty
+                </Text>
+                <Text fw={600}>
+                  <SovereigntyLabel sov={sov} />
+                </Text>
+              </div>
+            </Group>
+          </Paper>
+        )}
+
+        {fw && (
+          <Paper p="md" radius="md">
+            <Group justify="space-between" mb="xs">
+              <Group gap="xs">
+                <IconSwords size={18} color="var(--mantine-color-orange-5)" />
+                <Text fw={600}>Faction Warfare</Text>
+              </Group>
+              <Badge
+                variant="light"
+                color={fw.contested === "contested" ? "orange" : "gray"}
+                tt="capitalize"
+              >
+                {fw.contested}
+              </Badge>
+            </Group>
+            <Group gap={6} mb={6}>
+              <FactionAvatar factionId={fw.owner_faction_id} size={20} />
+              <Text size="sm">
+                <FactionName span factionId={fw.owner_faction_id} />
+              </Text>
+            </Group>
+            <Progress
+              value={
+                fw.victory_points_threshold > 0
+                  ? (fw.victory_points / fw.victory_points_threshold) * 100
+                  : 0
+              }
+              color="orange"
+              size="sm"
+            />
+            <Text size="xs" c="dimmed" mt={4}>
+              {fw.victory_points.toLocaleString()} /{" "}
+              {fw.victory_points_threshold.toLocaleString()} victory points
+            </Text>
+          </Paper>
+        )}
+
+        {incursion && (
+          <Paper p="md" radius="md">
+            <Group justify="space-between" mb="xs">
+              <Group gap="xs">
+                <IconAlertTriangle
+                  size={18}
+                  color="var(--mantine-color-red-5)"
+                />
+                <Text fw={600}>Incursion</Text>
+              </Group>
+              <Badge variant="light" color="red" tt="capitalize">
+                {incursion.state}
+              </Badge>
+            </Group>
+            <Group gap={6} mb={6}>
+              <FactionAvatar factionId={incursion.faction_id} size={20} />
+              <Text size="sm">
+                <FactionName span factionId={incursion.faction_id} />
+              </Text>
+              {incursion.has_boss && (
+                <Badge size="sm" variant="outline" color="red">
+                  Boss
+                </Badge>
+              )}
+            </Group>
+            <Progress value={incursion.influence * 100} color="red" size="sm" />
+            <Text size="xs" c="dimmed" mt={4}>
+              {(incursion.influence * 100).toFixed(0)}% influence
+            </Text>
+          </Paper>
+        )}
+      </SimpleGrid>
+    );
+  }
+
+  return null;
+}
+
+/** The "System Information" panel: physical data, faction owner and traits. */
+function SystemInfoSection({
+  securityStatus,
+  securityClass,
+  star,
+  sde,
+}: Readonly<{
+  securityStatus?: number;
+  securityClass?: string;
+  star?: { data: { spectral_class?: string; temperature?: number } };
+  sde?: SolarSystem;
+}>) {
+  return (
+    <section>
+      <SectionHeader title="System Information" />
+      <Paper p="lg" radius="md">
+        <SimpleGrid cols={{ base: 2, sm: 3 }} spacing="lg">
+          <InfoItem
+            label="Security Status"
+            value={securityStatus?.toFixed(2) ?? "—"}
+          />
+          <InfoItem label="Security Class" value={securityClass ?? "—"} />
+          <InfoItem label="Star Type" value={star?.data.spectral_class ?? "—"} />
+          <InfoItem
+            label="Temperature"
+            value={withUnit(star?.data.temperature, "K")}
+          />
+          <InfoItem
+            label="Luminosity"
+            value={formatNumber(sde?.luminosity)}
+          />
+          <InfoItem label="Radius" value={withUnit(sde?.radius, "m")} />
+          {sde?.wormholeClassID != null && (
+            <InfoItem
+              label="Wormhole Class"
+              value={String(sde.wormholeClassID)}
+            />
+          )}
+          <InfoItem
+            label="Position"
+            value={
+              <Position3DText
+                size="xs"
+                position={
+                  sde?.position.x != null &&
+                  sde.position.y != null &&
+                  sde.position.z != null
+                    ? [sde.position.x, sde.position.y, sde.position.z]
+                    : undefined
+                }
+              />
+            }
+          />
+        </SimpleGrid>
+
+        {sde?.factionID != null && (
+          <Group gap="sm" mt="lg">
+            <FactionAvatar factionId={sde.factionID} size={28} radius={999} />
+            <div>
+              <Text size="xs" c="dimmed" className={classes.statLabel}>
+                Faction
+              </Text>
+              <Text size="sm" fw={500}>
+                <FactionName span factionId={sde.factionID} />
+              </Text>
+            </div>
+          </Group>
+        )}
+
+        {sde && (
+          <Group gap="xs" mt="lg">
+            <FlagChip label="Trade Hub" active={sde.hub} />
+            <FlagChip label="Border" active={sde.border} />
+            <FlagChip label="Fringe" active={sde.fringe} />
+            <FlagChip label="Corridor" active={sde.corridor} />
+            <FlagChip label="International" active={sde.international} />
+            <FlagChip label="Regional" active={sde.regional} />
+          </Group>
+        )}
+      </Paper>
+    </section>
+  );
+}
+
 const EXTERNAL_TOOLS = [
   { label: "DOTLAN", href: (id: number) => `https://evemaps.dotlan.net/system/${id}` },
   { label: "zKillboard", href: (id: number) => `https://zkillboard.com/system/${id}` },
@@ -274,16 +519,11 @@ export default function Page() {
 
   const securityStatus = data?.security_status;
   const secColor =
-    securityStatus != null
-      ? securityStatusColor(securityStatus)
-      : "var(--mantine-color-dark-4)";
-  const isWormhole = (securityStatus ?? 0) < -0.9;
-  const band =
     securityStatus == null
-      ? undefined
-      : isWormhole
-        ? "W-Space"
-        : securityStatusBand(securityStatus);
+      ? "var(--mantine-color-dark-4)"
+      : securityStatusColor(securityStatus);
+  const isWormhole = (securityStatus ?? 0) < -0.9;
+  const band = getSecurityBand(securityStatus, isWormhole);
   const secColorStyle = { "--sec-color": secColor } as CSSProperties;
 
   const planets = data?.planets ?? [];
@@ -308,8 +548,6 @@ export default function Page() {
   const hasSovereignty = Boolean(
     sov?.alliance_id ?? sov?.corporation_id ?? sov?.faction_id,
   );
-  const hasFactionWarfare = fw != null;
-  const hasIncursion = incursion != null;
   const systemCostIndices = Object.hasOwn(costIndices, systemId)
     ? (costIndices[systemId]?.cost_indices ?? [])
     : [];
@@ -471,108 +709,12 @@ export default function Page() {
         </section>
 
         {/* ---- Control: sovereignty / faction warfare / incursion ---- */}
-        {(hasSovereignty || hasFactionWarfare || hasIncursion) && (
-          <SimpleGrid
-            cols={{ base: 1, md: hasFactionWarfare && hasIncursion ? 2 : 1 }}
-            spacing="md"
-          >
-            {hasSovereignty && sov && (
-              <Paper p="md" radius="md">
-                <Group gap="sm" wrap="nowrap">
-                  <IconShieldHalf
-                    size={22}
-                    color="var(--mantine-color-eve_primary-4)"
-                  />
-                  <SolarSystemSovereigntyAvatar
-                    solarSystemId={systemId}
-                    size={34}
-                    radius={999}
-                  />
-                  <div style={{ minWidth: 0 }}>
-                    <Text size="xs" c="dimmed" className={classes.statLabel}>
-                      Sovereignty
-                    </Text>
-                    <Text fw={600}>
-                      <SovereigntyLabel sov={sov} />
-                    </Text>
-                  </div>
-                </Group>
-              </Paper>
-            )}
-
-            {fw && (
-              <Paper p="md" radius="md">
-                <Group justify="space-between" mb="xs">
-                  <Group gap="xs">
-                    <IconSwords
-                      size={18}
-                      color="var(--mantine-color-orange-5)"
-                    />
-                    <Text fw={600}>Faction Warfare</Text>
-                  </Group>
-                  <Badge
-                    variant="light"
-                    color={fw.contested === "contested" ? "orange" : "gray"}
-                    tt="capitalize"
-                  >
-                    {fw.contested}
-                  </Badge>
-                </Group>
-                <Group gap={6} mb={6}>
-                  <FactionAvatar factionId={fw.owner_faction_id} size={20} />
-                  <Text size="sm">
-                    <FactionName span factionId={fw.owner_faction_id} />
-                  </Text>
-                </Group>
-                <Progress
-                  value={
-                    fw.victory_points_threshold > 0
-                      ? (fw.victory_points / fw.victory_points_threshold) * 100
-                      : 0
-                  }
-                  color="orange"
-                  size="sm"
-                />
-                <Text size="xs" c="dimmed" mt={4}>
-                  {fw.victory_points.toLocaleString()} /{" "}
-                  {fw.victory_points_threshold.toLocaleString()} victory points
-                </Text>
-              </Paper>
-            )}
-
-            {incursion && (
-              <Paper p="md" radius="md">
-                <Group justify="space-between" mb="xs">
-                  <Group gap="xs">
-                    <IconAlertTriangle
-                      size={18}
-                      color="var(--mantine-color-red-5)"
-                    />
-                    <Text fw={600}>Incursion</Text>
-                  </Group>
-                  <Badge variant="light" color="red" tt="capitalize">
-                    {incursion.state}
-                  </Badge>
-                </Group>
-                <Group gap={6} mb={6}>
-                  <FactionAvatar factionId={incursion.faction_id} size={20} />
-                  <Text size="sm">
-                    <FactionName span factionId={incursion.faction_id} />
-                  </Text>
-                  {incursion.has_boss && (
-                    <Badge size="sm" variant="outline" color="red">
-                      Boss
-                    </Badge>
-                  )}
-                </Group>
-                <Progress value={incursion.influence * 100} color="red" size="sm" />
-                <Text size="xs" c="dimmed" mt={4}>
-                  {(incursion.influence * 100).toFixed(0)}% influence
-                </Text>
-              </Paper>
-            )}
-          </SimpleGrid>
-        )}
+        <SystemControlPanels
+          systemId={systemId}
+          sov={sov}
+          fw={fw}
+          incursion={incursion}
+        />
 
         {/* ---- Celestials + connections ---- */}
         <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xl">
@@ -666,91 +808,12 @@ export default function Page() {
         )}
 
         {/* ---- System information ---- */}
-        <section>
-          <SectionHeader title="System Information" />
-          <Paper p="lg" radius="md">
-            <SimpleGrid cols={{ base: 2, sm: 3 }} spacing="lg">
-              <InfoItem
-                label="Security Status"
-                value={securityStatus != null ? securityStatus.toFixed(2) : "—"}
-              />
-              <InfoItem
-                label="Security Class"
-                value={data?.security_class ?? "—"}
-              />
-              <InfoItem
-                label="Star Type"
-                value={star?.data.spectral_class ?? "—"}
-              />
-              <InfoItem
-                label="Temperature"
-                value={
-                  star?.data.temperature != null
-                    ? `${star.data.temperature.toLocaleString()} K`
-                    : "—"
-                }
-              />
-              <InfoItem
-                label="Luminosity"
-                value={sde?.luminosity != null ? sde.luminosity.toString() : "—"}
-              />
-              <InfoItem
-                label="Radius"
-                value={
-                  sde?.radius != null
-                    ? `${sde.radius.toLocaleString()} m`
-                    : "—"
-                }
-              />
-              {sde?.wormholeClassID != null && (
-                <InfoItem
-                  label="Wormhole Class"
-                  value={String(sde.wormholeClassID)}
-                />
-              )}
-              <InfoItem
-                label="Position"
-                value={
-                  <Position3DText
-                    size="xs"
-                    position={
-                      sde?.position.x != null &&
-                      sde.position.y != null &&
-                      sde.position.z != null
-                        ? [sde.position.x, sde.position.y, sde.position.z]
-                        : undefined
-                    }
-                  />
-                }
-              />
-            </SimpleGrid>
-
-            {sde?.factionID != null && (
-              <Group gap="sm" mt="lg">
-                <FactionAvatar factionId={sde.factionID} size={28} radius={999} />
-                <div>
-                  <Text size="xs" c="dimmed" className={classes.statLabel}>
-                    Faction
-                  </Text>
-                  <Text size="sm" fw={500}>
-                    <FactionName span factionId={sde.factionID} />
-                  </Text>
-                </div>
-              </Group>
-            )}
-
-            {sde && (
-              <Group gap="xs" mt="lg">
-                <FlagChip label="Trade Hub" active={sde.hub} />
-                <FlagChip label="Border" active={sde.border} />
-                <FlagChip label="Fringe" active={sde.fringe} />
-                <FlagChip label="Corridor" active={sde.corridor} />
-                <FlagChip label="International" active={sde.international} />
-                <FlagChip label="Regional" active={sde.regional} />
-              </Group>
-            )}
-          </Paper>
-        </section>
+        <SystemInfoSection
+          securityStatus={securityStatus}
+          securityClass={data?.security_class}
+          star={star}
+          sde={sde}
+        />
       </Stack>
     </Container>
   );

--- a/apps/web/app/system/[systemId]/page.client.tsx
+++ b/apps/web/app/system/[systemId]/page.client.tsx
@@ -1,56 +1,250 @@
 "use client";
 
+import type { CSSProperties, ReactNode } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import {
   Anchor,
+  Badge,
   Button,
   Container,
   Group,
+  Paper,
+  Progress,
+  SimpleGrid,
+  Skeleton,
   Stack,
   Text,
   Title,
-  Tooltip,
 } from "@mantine/core";
-import { IconExternalLink } from "@tabler/icons-react";
-
-import type { EveIconProps } from "@jitaspace/eve-icons";
 import {
+  IconAlertTriangle,
+  IconChevronRight,
+  IconExternalLink,
+  IconMeteor,
+  IconMoon,
+  IconRobot,
+  IconRocket,
+  IconShieldHalf,
+  IconSkull,
+  IconSwords,
+} from "@tabler/icons-react";
+
+import {
+  AllianceName,
+  CorporationName,
+  FactionName,
   SolarSystemName,
+  SolarSystemSovereigntyAvatar,
   StationAnchor,
   StationName,
 } from "@jitaspace/eve-components";
-import { IndustryIcon } from "@jitaspace/eve-icons";
+import { useGetFwSystems, useGetIncursions } from "@jitaspace/esi-client";
 import {
+  useAllSolarSystemJumps,
+  useAllSolarSystemKills,
   useSelectedCharacter,
   useSolarSystem,
   useSolarSystemCostIndices,
+  useSolarSystemSovereignty,
+  useStar,
+  useStargate,
 } from "@jitaspace/hooks";
 import { useGetSolarSystemById } from "@jitaspace/sde-client";
-import { Position3DText, StarAnchor, TypeAvatar } from "@jitaspace/ui";
+import {
+  FactionAvatar,
+  formatSecurityStatus,
+  isLightSecurityStatus,
+  Position3DText,
+  securityStatusBand,
+  securityStatusColor,
+} from "@jitaspace/ui";
 
 import { SetAutopilotDestinationActionIcon } from "~/components/ActionIcon";
-import { StargateDestinationAnchor } from "~/components/Anchor";
 import {
   PlanetAvatar,
+  SolarSystemStarAvatar,
   StarAvatar,
   StargateAvatar,
   StationAvatar,
 } from "~/components/Avatar";
 import { SolarSystemSecurityStatusBadge } from "~/components/Badge";
 import { SolarSystemBreadcrumbs } from "~/components/Breadcrumbs";
-import {
-  AsteroidBeltName,
-  MoonName,
-  PlanetName,
-  StargateName,
-  StarName,
-} from "~/components/Text";
-import { StatsGrid } from "~/components/UI";
+import { SectionHeader } from "~/components/Home";
+import { PlanetName, StarName } from "~/components/Text";
+import classes from "./page.module.css";
 
-function IndustryIconRender(props: EveIconProps) {
-  return <IndustryIcon {...props} />;
+interface SovereigntyEntry {
+  alliance_id?: number;
+  corporation_id?: number;
+  faction_id?: number;
 }
+
+/** A single labelled live-activity metric. */
+function StatTile({
+  icon,
+  label,
+  value,
+  accent,
+  loading,
+}: Readonly<{
+  icon: ReactNode;
+  label: string;
+  value: ReactNode;
+  accent?: string;
+  loading?: boolean;
+}>) {
+  return (
+    <Paper p="md" radius="md">
+      <Group justify="space-between" align="flex-start" wrap="nowrap" gap="xs">
+        <Text size="xs" c="dimmed" className={classes.statLabel}>
+          {label}
+        </Text>
+        {icon}
+      </Group>
+      <Text
+        component="div"
+        className={classes.statValue}
+        mt="sm"
+        style={accent ? { color: accent } : undefined}
+      >
+        {loading ? <Skeleton height={22} width={52} /> : value}
+      </Text>
+    </Paper>
+  );
+}
+
+/** Key/value pair used in the System Information panel. */
+function InfoItem({
+  label,
+  value,
+}: Readonly<{ label: string; value: ReactNode }>) {
+  return (
+    <div>
+      <Text size="xs" c="dimmed" className={classes.statLabel}>
+        {label}
+      </Text>
+      <Text component="div" size="sm" mt={2}>
+        {value}
+      </Text>
+    </div>
+  );
+}
+
+/** A boolean SDE trait rendered as an on/off chip. */
+function FlagChip({
+  label,
+  active,
+}: Readonly<{ label: string; active?: boolean }>) {
+  return (
+    <Badge
+      variant={active ? "filled" : "outline"}
+      color={active ? "eve_primary" : "gray"}
+      c={active ? undefined : "dimmed"}
+      className={classes.flag}
+      styles={active ? undefined : { root: { opacity: 0.55 } }}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+/** The star, then every planet with its moon / belt tally. */
+function PlanetRow({
+  planetId,
+  moons,
+  belts,
+}: Readonly<{ planetId: number; moons: number; belts: number }>) {
+  return (
+    <Anchor
+      component={Link}
+      href={`/planet/${planetId}`}
+      underline="never"
+      c="inherit"
+      className={classes.row}
+    >
+      <PlanetAvatar planetId={planetId} size="md" radius={999} />
+      <PlanetName
+        span
+        planetId={planetId}
+        fw={500}
+        style={{ flex: 1, minWidth: 0 }}
+      />
+      <Group gap={6} wrap="nowrap">
+        {moons > 0 && (
+          <Badge
+            size="sm"
+            variant="light"
+            color="gray"
+            leftSection={<IconMoon size={12} />}
+          >
+            {moons}
+          </Badge>
+        )}
+        {belts > 0 && (
+          <Badge
+            size="sm"
+            variant="light"
+            color="gray"
+            leftSection={<IconMeteor size={12} />}
+          >
+            {belts}
+          </Badge>
+        )}
+      </Group>
+    </Anchor>
+  );
+}
+
+/** A stargate rendered as a jump to its destination system. */
+function StargateConnection({ stargateId }: Readonly<{ stargateId: number }>) {
+  const { data: stargate } = useStargate(stargateId);
+  const destination = stargate?.data.destination as
+    | { system_id: number }
+    | undefined;
+  const destinationSystemId = destination?.system_id;
+
+  return (
+    <Anchor
+      component={Link}
+      href={destinationSystemId ? `/system/${destinationSystemId}` : "#"}
+      underline="never"
+      c="inherit"
+      className={classes.row}
+    >
+      <StargateAvatar stargateId={stargateId} size="sm" radius={999} />
+      <SolarSystemSecurityStatusBadge
+        solarSystemId={destinationSystemId}
+        size="sm"
+      />
+      <SolarSystemName
+        span
+        solarSystemId={destinationSystemId}
+        style={{ flex: 1, minWidth: 0 }}
+      />
+      <IconChevronRight size={16} color="var(--mantine-color-dimmed)" />
+    </Anchor>
+  );
+}
+
+/** Resolve the sovereignty holder to the right named entity. */
+function SovereigntyLabel({ sov }: Readonly<{ sov: SovereigntyEntry }>) {
+  if (sov.alliance_id) return <AllianceName span allianceId={sov.alliance_id} />;
+  if (sov.corporation_id)
+    return <CorporationName span corporationId={sov.corporation_id} />;
+  if (sov.faction_id) return <FactionName span factionId={sov.faction_id} />;
+  return null;
+}
+
+const EXTERNAL_TOOLS = [
+  { label: "DOTLAN", href: (id: number) => `https://evemaps.dotlan.net/system/${id}` },
+  { label: "zKillboard", href: (id: number) => `https://zkillboard.com/system/${id}` },
+  { label: "Eveeye", href: (id: number) => `https://eveeye.com/?s=${id}` },
+  {
+    label: "Adam4EVE",
+    href: (id: number) => `https://www.adam4eve.eu/location.php?id=${id}`,
+  },
+];
 
 export default function Page() {
   const params = useParams();
@@ -58,210 +252,505 @@ export default function Page() {
   const systemId = Number(
     typeof rawSystemId === "string" ? rawSystemId : rawSystemId?.[0],
   );
+
   const character = useSelectedCharacter();
   const { data: solarSystem } = useSolarSystem(systemId);
   const { data: sdeSolarSystem } = useGetSolarSystemById(systemId);
-  const { data: solarSystemCostIndicesData } = useSolarSystemCostIndices();
+  const starId = solarSystem?.data.star_id;
+  const { data: star } = useStar(starId ?? 0);
+  const sov = useSolarSystemSovereignty(systemId) as SovereigntyEntry | undefined;
+  const { data: costIndices } = useSolarSystemCostIndices();
+  const { data: allJumps } = useAllSolarSystemJumps();
+  const { data: allKills } = useAllSolarSystemKills();
+  const { data: incursions } = useGetIncursions();
+  const { data: fwSystems } = useGetFwSystems();
 
   if (!Number.isFinite(systemId)) {
     return null;
   }
 
+  const data = solarSystem?.data;
+  const sde = sdeSolarSystem?.data;
+
+  const securityStatus = data?.security_status;
+  const secColor =
+    securityStatus != null
+      ? securityStatusColor(securityStatus)
+      : "var(--mantine-color-dark-4)";
+  const isWormhole = (securityStatus ?? 0) < -0.9;
+  const band =
+    securityStatus == null
+      ? undefined
+      : isWormhole
+        ? "W-Space"
+        : securityStatusBand(securityStatus);
+  const secColorStyle = { "--sec-color": secColor } as CSSProperties;
+
+  const planets = data?.planets ?? [];
+  const planetCount = planets.length;
+  const moonCount = planets.reduce((sum, p) => sum + (p.moons?.length ?? 0), 0);
+  const beltCount = planets.reduce(
+    (sum, p) => sum + (p.asteroid_belts?.length ?? 0),
+    0,
+  );
+  const stargates = data?.stargates ?? [];
+  const stations = data?.stations ?? [];
+
+  const jumps = allJumps?.data.find((j) => j.system_id === systemId)?.ship_jumps;
+  const kills = allKills?.data.find((k) => k.system_id === systemId);
+  const incursion = incursions?.data.find(
+    (i) =>
+      i.infested_solar_systems.includes(systemId) ||
+      i.staging_solar_system_id === systemId,
+  );
+  const fw = fwSystems?.data.find((s) => s.solar_system_id === systemId);
+
+  const hasSovereignty = Boolean(
+    sov?.alliance_id ?? sov?.corporation_id ?? sov?.faction_id,
+  );
+  const hasFactionWarfare = fw != null;
+  const hasIncursion = incursion != null;
+  const systemCostIndices = Object.hasOwn(costIndices, systemId)
+    ? (costIndices[systemId]?.cost_indices ?? [])
+    : [];
+
   return (
-    <Container size="sm">
-      <Stack>
-        <Group gap="xl">
-          <Title order={3}>
-            <Group>
-              <SolarSystemName span solarSystemId={systemId} />
-              <SolarSystemSecurityStatusBadge solarSystemId={systemId} />
-              {character && (
-                <SetAutopilotDestinationActionIcon
-                  characterId={character.characterId}
-                  destinationId={systemId}
+    <Container size="lg" py="md">
+      <Stack gap="xl">
+        {/* ---- Hero ---- */}
+        <Paper p="xl" radius="md" className={classes.hero}>
+          <div className={classes.heroGlow} style={secColorStyle} aria-hidden />
+          <Group
+            align="flex-start"
+            gap="xl"
+            wrap="wrap"
+            className={classes.heroInner}
+          >
+            <div className={classes.starWrap} style={secColorStyle}>
+              <SolarSystemStarAvatar
+                solarSystemId={systemId}
+                size={112}
+                radius={999}
+              />
+            </div>
+            <Stack gap="sm" style={{ flex: "1 1 320px", minWidth: 0 }}>
+              <SolarSystemBreadcrumbs
+                solarSystemId={systemId}
+                hideSolarSystem
+                textProps={{ size: "sm" }}
+              />
+              <Group gap="sm" align="center">
+                <Title order={1} className={classes.title}>
+                  <SolarSystemName span solarSystemId={systemId} />
+                </Title>
+                {character && (
+                  <SetAutopilotDestinationActionIcon
+                    characterId={character.characterId}
+                    destinationId={systemId}
+                  />
+                )}
+              </Group>
+
+              <Group gap="sm" align="center">
+                {securityStatus != null && (
+                  <span
+                    className={classes.secPill}
+                    style={{
+                      backgroundColor: secColor,
+                      color: isLightSecurityStatus(securityStatus)
+                        ? "var(--mantine-color-black)"
+                        : "var(--mantine-color-white)",
+                    }}
+                  >
+                    {formatSecurityStatus(securityStatus)}
+                  </span>
+                )}
+                {band && (
+                  <Text fw={600} className={classes.band}>
+                    {band}
+                  </Text>
+                )}
+                {hasSovereignty && sov && (
+                  <div className={classes.holderChip}>
+                    <SolarSystemSovereigntyAvatar
+                      solarSystemId={systemId}
+                      size={22}
+                      radius={999}
+                    />
+                    <Text span size="sm" fw={500}>
+                      <SovereigntyLabel sov={sov} />
+                    </Text>
+                  </div>
+                )}
+              </Group>
+
+              {data ? (
+                <Text size="sm" c="dimmed">
+                  {planetCount} planets · {moonCount} moons · {beltCount} belts ·{" "}
+                  {stations.length} stations · {stargates.length} gates
+                </Text>
+              ) : (
+                <Skeleton height={14} width={280} />
+              )}
+
+              <Group gap="xs" mt={4}>
+                {EXTERNAL_TOOLS.map((tool) => (
+                  <Button
+                    key={tool.label}
+                    component={Link}
+                    href={tool.href(systemId)}
+                    target="_blank"
+                    size="xs"
+                    leftSection={<IconExternalLink size={13} />}
+                  >
+                    {tool.label}
+                  </Button>
+                ))}
+              </Group>
+            </Stack>
+          </Group>
+        </Paper>
+
+        {/* ---- Live activity (last hour) ---- */}
+        <section>
+          <SectionHeader title="Activity · Last Hour" />
+          <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="md">
+            <StatTile
+              icon={
+                <IconRocket
+                  size={18}
+                  stroke={1.6}
+                  color="var(--mantine-color-teal-4)"
+                />
+              }
+              label="Ship Jumps"
+              value={(jumps ?? 0).toLocaleString()}
+              accent="var(--mantine-color-teal-4)"
+              loading={allJumps === undefined}
+            />
+            <StatTile
+              icon={
+                <IconSwords
+                  size={18}
+                  stroke={1.6}
+                  color="var(--mantine-color-red-5)"
+                />
+              }
+              label="Ship Kills"
+              value={(kills?.ship_kills ?? 0).toLocaleString()}
+              accent="var(--mantine-color-red-5)"
+              loading={allKills === undefined}
+            />
+            <StatTile
+              icon={
+                <IconSkull
+                  size={18}
+                  stroke={1.6}
+                  color="var(--mantine-color-grape-4)"
+                />
+              }
+              label="Pod Kills"
+              value={(kills?.pod_kills ?? 0).toLocaleString()}
+              accent="var(--mantine-color-grape-4)"
+              loading={allKills === undefined}
+            />
+            <StatTile
+              icon={
+                <IconRobot
+                  size={18}
+                  stroke={1.6}
+                  color="var(--mantine-color-orange-5)"
+                />
+              }
+              label="NPC Kills"
+              value={(kills?.npc_kills ?? 0).toLocaleString()}
+              accent="var(--mantine-color-orange-5)"
+              loading={allKills === undefined}
+            />
+          </SimpleGrid>
+        </section>
+
+        {/* ---- Control: sovereignty / faction warfare / incursion ---- */}
+        {(hasSovereignty || hasFactionWarfare || hasIncursion) && (
+          <SimpleGrid
+            cols={{ base: 1, md: hasFactionWarfare && hasIncursion ? 2 : 1 }}
+            spacing="md"
+          >
+            {hasSovereignty && sov && (
+              <Paper p="md" radius="md">
+                <Group gap="sm" wrap="nowrap">
+                  <IconShieldHalf
+                    size={22}
+                    color="var(--mantine-color-eve_primary-4)"
+                  />
+                  <SolarSystemSovereigntyAvatar
+                    solarSystemId={systemId}
+                    size={34}
+                    radius={999}
+                  />
+                  <div style={{ minWidth: 0 }}>
+                    <Text size="xs" c="dimmed" className={classes.statLabel}>
+                      Sovereignty
+                    </Text>
+                    <Text fw={600}>
+                      <SovereigntyLabel sov={sov} />
+                    </Text>
+                  </div>
+                </Group>
+              </Paper>
+            )}
+
+            {fw && (
+              <Paper p="md" radius="md">
+                <Group justify="space-between" mb="xs">
+                  <Group gap="xs">
+                    <IconSwords
+                      size={18}
+                      color="var(--mantine-color-orange-5)"
+                    />
+                    <Text fw={600}>Faction Warfare</Text>
+                  </Group>
+                  <Badge
+                    variant="light"
+                    color={fw.contested === "contested" ? "orange" : "gray"}
+                    tt="capitalize"
+                  >
+                    {fw.contested}
+                  </Badge>
+                </Group>
+                <Group gap={6} mb={6}>
+                  <FactionAvatar factionId={fw.owner_faction_id} size={20} />
+                  <Text size="sm">
+                    <FactionName span factionId={fw.owner_faction_id} />
+                  </Text>
+                </Group>
+                <Progress
+                  value={
+                    fw.victory_points_threshold > 0
+                      ? (fw.victory_points / fw.victory_points_threshold) * 100
+                      : 0
+                  }
+                  color="orange"
+                  size="sm"
+                />
+                <Text size="xs" c="dimmed" mt={4}>
+                  {fw.victory_points.toLocaleString()} /{" "}
+                  {fw.victory_points_threshold.toLocaleString()} victory points
+                </Text>
+              </Paper>
+            )}
+
+            {incursion && (
+              <Paper p="md" radius="md">
+                <Group justify="space-between" mb="xs">
+                  <Group gap="xs">
+                    <IconAlertTriangle
+                      size={18}
+                      color="var(--mantine-color-red-5)"
+                    />
+                    <Text fw={600}>Incursion</Text>
+                  </Group>
+                  <Badge variant="light" color="red" tt="capitalize">
+                    {incursion.state}
+                  </Badge>
+                </Group>
+                <Group gap={6} mb={6}>
+                  <FactionAvatar factionId={incursion.faction_id} size={20} />
+                  <Text size="sm">
+                    <FactionName span factionId={incursion.faction_id} />
+                  </Text>
+                  {incursion.has_boss && (
+                    <Badge size="sm" variant="outline" color="red">
+                      Boss
+                    </Badge>
+                  )}
+                </Group>
+                <Progress value={incursion.influence * 100} color="red" size="sm" />
+                <Text size="xs" c="dimmed" mt={4}>
+                  {(incursion.influence * 100).toFixed(0)}% influence
+                </Text>
+              </Paper>
+            )}
+          </SimpleGrid>
+        )}
+
+        {/* ---- Celestials + connections ---- */}
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xl">
+          <div>
+            <SectionHeader title="Celestials" count={planetCount} />
+            <Stack gap={2}>
+              {starId && (
+                <div className={classes.row}>
+                  <StarAvatar starId={starId} size="md" radius={999} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <StarName span starId={starId} fw={500} />
+                    <Text size="xs" c="dimmed">
+                      {star?.data.spectral_class ?? "Star"}
+                      {star?.data.temperature != null &&
+                        ` · ${star.data.temperature.toLocaleString()} K`}
+                    </Text>
+                  </div>
+                </div>
+              )}
+              {planets.map((planet) => (
+                <PlanetRow
+                  key={planet.planet_id}
+                  planetId={planet.planet_id}
+                  moons={planet.moons?.length ?? 0}
+                  belts={planet.asteroid_belts?.length ?? 0}
+                />
+              ))}
+              {!starId && planetCount === 0 && (
+                <Skeleton height={48} radius="sm" />
+              )}
+            </Stack>
+          </div>
+
+          <div>
+            <SectionHeader title="Stargates" count={stargates.length} />
+            <Stack gap={2} mb="lg">
+              {stargates.map((stargateId) => (
+                <StargateConnection key={stargateId} stargateId={stargateId} />
+              ))}
+              {stargates.length === 0 && (
+                <Text size="sm" c="dimmed">
+                  No stargates — this system is only reachable by wormhole.
+                </Text>
+              )}
+            </Stack>
+
+            <SectionHeader title="Stations" count={stations.length} />
+            <Stack gap={2}>
+              {stations.map((stationId) => (
+                <StationAnchor
+                  key={stationId}
+                  stationId={stationId}
+                  underline="never"
+                  c="inherit"
+                  className={classes.row}
+                >
+                  <StationAvatar stationId={stationId} size="sm" radius={999} />
+                  <StationName
+                    span
+                    stationId={stationId}
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                </StationAnchor>
+              ))}
+              {stations.length === 0 && (
+                <Text size="sm" c="dimmed">
+                  No NPC stations in this system.
+                </Text>
+              )}
+            </Stack>
+          </div>
+        </SimpleGrid>
+
+        {/* ---- Industry cost indices ---- */}
+        {systemCostIndices.length > 0 && (
+          <section>
+            <SectionHeader title="Industry Indices" />
+            <SimpleGrid cols={{ base: 2, sm: 3, md: 6 }} spacing="md">
+              {systemCostIndices.map((index) => (
+                <Paper key={index.activity} p="md" radius="md">
+                  <Text size="xs" c="dimmed" className={classes.statLabel}>
+                    {index.activity.replaceAll("_", " ")}
+                  </Text>
+                  <Text className={classes.statValue} mt="sm">
+                    {(index.cost_index * 100).toFixed(2)}%
+                  </Text>
+                </Paper>
+              ))}
+            </SimpleGrid>
+          </section>
+        )}
+
+        {/* ---- System information ---- */}
+        <section>
+          <SectionHeader title="System Information" />
+          <Paper p="lg" radius="md">
+            <SimpleGrid cols={{ base: 2, sm: 3 }} spacing="lg">
+              <InfoItem
+                label="Security Status"
+                value={securityStatus != null ? securityStatus.toFixed(2) : "—"}
+              />
+              <InfoItem
+                label="Security Class"
+                value={data?.security_class ?? "—"}
+              />
+              <InfoItem
+                label="Star Type"
+                value={star?.data.spectral_class ?? "—"}
+              />
+              <InfoItem
+                label="Temperature"
+                value={
+                  star?.data.temperature != null
+                    ? `${star.data.temperature.toLocaleString()} K`
+                    : "—"
+                }
+              />
+              <InfoItem
+                label="Luminosity"
+                value={sde?.luminosity != null ? sde.luminosity.toString() : "—"}
+              />
+              <InfoItem
+                label="Radius"
+                value={
+                  sde?.radius != null
+                    ? `${sde.radius.toLocaleString()} m`
+                    : "—"
+                }
+              />
+              {sde?.wormholeClassID != null && (
+                <InfoItem
+                  label="Wormhole Class"
+                  value={String(sde.wormholeClassID)}
                 />
               )}
-            </Group>
-          </Title>
-        </Group>
-        <SolarSystemBreadcrumbs solarSystemId={systemId} />
-        <Group>
-          <Link
-            href={`https://evemaps.dotlan.net/system/${systemId}`}
-            target="_blank"
-          >
-            <Button>
-              <Group gap="xs">
-                <IconExternalLink size={14} />
-                DOTLAN EveMaps
+              <InfoItem
+                label="Position"
+                value={
+                  <Position3DText
+                    size="xs"
+                    position={
+                      sde?.position.x != null &&
+                      sde.position.y != null &&
+                      sde.position.z != null
+                        ? [sde.position.x, sde.position.y, sde.position.z]
+                        : undefined
+                    }
+                  />
+                }
+              />
+            </SimpleGrid>
+
+            {sde?.factionID != null && (
+              <Group gap="sm" mt="lg">
+                <FactionAvatar factionId={sde.factionID} size={28} radius={999} />
+                <div>
+                  <Text size="xs" c="dimmed" className={classes.statLabel}>
+                    Faction
+                  </Text>
+                  <Text size="sm" fw={500}>
+                    <FactionName span factionId={sde.factionID} />
+                  </Text>
+                </div>
               </Group>
-            </Button>
-          </Link>
-          <Link
-            href={`https://zkillboard.com/system/${systemId}`}
-            target="_blank"
-          >
-            <Button>
-              <Group gap="xs">
-                <IconExternalLink size={14} />
-                zKillboard
+            )}
+
+            {sde && (
+              <Group gap="xs" mt="lg">
+                <FlagChip label="Trade Hub" active={sde.hub} />
+                <FlagChip label="Border" active={sde.border} />
+                <FlagChip label="Fringe" active={sde.fringe} />
+                <FlagChip label="Corridor" active={sde.corridor} />
+                <FlagChip label="International" active={sde.international} />
+                <FlagChip label="Regional" active={sde.regional} />
               </Group>
-            </Button>
-          </Link>
-          <Link href={`https://eveeye.com/?s=${systemId}`} target="_blank">
-            <Button>
-              <Group gap="xs">
-                <IconExternalLink size={14} />
-                Eveeye
-              </Group>
-            </Button>
-          </Link>
-          <Link
-            href={`https://www.adam4eve.eu/location.php?id=${systemId}`}
-            target="_blank"
-          >
-            <Button>
-              <Group gap="xs">
-                <IconExternalLink size={14} />
-                Adam4EVE
-              </Group>
-            </Button>
-          </Link>
-        </Group>
-        <Title order={4}>Stations</Title>
-        <Stack gap="xs">
-          {solarSystem?.data.stations?.map((stationId: number) => (
-            <Group key={stationId} gap="xs">
-              <StationAvatar size="sm" stationId={stationId} />
-              <StationAnchor stationId={stationId}>
-                <StationName span stationId={stationId} />
-              </StationAnchor>
-            </Group>
-          ))}
-        </Stack>
-        <Title order={4}>Stargates</Title>
-        <Stack gap="xs">
-          {solarSystem?.data.stargates?.map((stargateId: number) => (
-            <Group key={stargateId} gap="xs">
-              <StargateAvatar size="sm" stargateId={stargateId} />
-              <StargateDestinationAnchor stargateId={stargateId}>
-                <StargateName span stargateId={stargateId} />
-              </StargateDestinationAnchor>
-            </Group>
-          ))}
-        </Stack>
-        <Title order={4}>Celestials</Title>
-        <Stack gap="xs">
-          {solarSystem?.data.star_id && (
-            <Group>
-              <StarAvatar starId={solarSystem.data.star_id} size="sm" />
-              <StarAnchor starId={solarSystem.data.star_id}>
-                <StarName span starId={solarSystem.data.star_id} />
-              </StarAnchor>
-            </Group>
-          )}
-          {solarSystem?.data.planets?.map(
-            ({ planet_id, moons, asteroid_belts }) => (
-              <Group key={planet_id}>
-                <Group wrap="nowrap">
-                  <PlanetAvatar planetId={planet_id} size="sm" />
-                  <Anchor component={Link} href={`/planet/${planet_id}`}>
-                    <PlanetName span planetId={planet_id} />
-                  </Anchor>
-                </Group>
-                <Group gap="xs">
-                  {moons?.map((moonId: number) => (
-                    <Tooltip label={<MoonName moonId={moonId} />} key={moonId}>
-                      <div>
-                        <TypeAvatar typeId={14} size="xs" />
-                      </div>
-                    </Tooltip>
-                  ))}
-                  {asteroid_belts?.map((asteroidBeltId: number) => (
-                    <Tooltip
-                      label={
-                        <AsteroidBeltName asteroidBeltId={asteroidBeltId} />
-                      }
-                      key={asteroidBeltId}
-                    >
-                      <div>
-                        <TypeAvatar typeId={15} size="xs" />
-                      </div>
-                    </Tooltip>
-                  ))}
-                </Group>
-              </Group>
-            ),
-          )}
-        </Stack>
-        {Object.hasOwn(solarSystemCostIndicesData, systemId) && (
-          <>
-            <Title order={4}>Industry Cost Indices</Title>
-            <StatsGrid
-              cols={{ base: 1, xs: 2, sm: 3 }}
-              spacing="xs"
-              data={(
-                solarSystemCostIndicesData[systemId]?.cost_indices ?? []
-              ).map((index) => ({
-                icon: IndustryIconRender,
-                title: index.activity.replaceAll("_", " "),
-                value: index.cost_index.toString(),
-              }))}
-            />
-          </>
-        )}
-        <Group justify="space-between">
-          <Text>Security Class</Text>
-          <Text>{solarSystem?.data.security_class}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>Luminosity</Text>
-          <Text>{sdeSolarSystem?.data.luminosity}</Text>
-        </Group>
-        {sdeSolarSystem?.data.radius && (
-          <Group justify="space-between">
-            <Text>Radius</Text>
-            <Text>{sdeSolarSystem.data.radius.toLocaleString()} m</Text>
-          </Group>
-        )}
-        <Group justify="space-between">
-          <Text>Border System</Text>
-          <Text>{sdeSolarSystem?.data.border ? "Yes" : "No"}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>Corridor System</Text>
-          <Text>{sdeSolarSystem?.data.corridor ? "Yes" : "No"}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>Fringe System</Text>
-          <Text>{sdeSolarSystem?.data.fringe ? "Yes" : "No"}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>Trading Hub</Text>
-          <Text>{sdeSolarSystem?.data.hub ? "Yes" : "No"}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>International System</Text>
-          <Text>{sdeSolarSystem?.data.international ? "Yes" : "No"}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>Regional System</Text>
-          <Text>{sdeSolarSystem?.data.regional ? "Yes" : "No"}</Text>
-        </Group>
-        <Group justify="space-between">
-          <Text>Position</Text>
-          <Position3DText
-            size="xs"
-            position={(() => {
-              const position = sdeSolarSystem?.data.position;
-              return position?.x !== undefined &&
-                position.y !== undefined &&
-                position.z !== undefined
-                ? [position.x, position.y, position.z]
-                : undefined;
-            })()}
-          />
-        </Group>
+            )}
+          </Paper>
+        </section>
       </Stack>
     </Container>
   );

--- a/apps/web/app/system/[systemId]/page.module.css
+++ b/apps/web/app/system/[systemId]/page.module.css
@@ -1,0 +1,105 @@
+/* Hero panel ------------------------------------------------------------- */
+
+.hero {
+    position: relative;
+    overflow: hidden;
+}
+
+/* Security-tinted glow bleeding in from the top-left corner, behind content. */
+.heroGlow {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+            120% 150% at 14% 12%,
+            color-mix(in srgb, var(--sec-color) 32%, transparent) 0%,
+            color-mix(in srgb, var(--sec-color) 9%, transparent) 34%,
+            transparent 66%
+    );
+}
+
+.heroInner {
+    position: relative; /* sit above .heroGlow */
+}
+
+.starWrap {
+    position: relative;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    box-shadow:
+        0 0 0 rem(1px) color-mix(in srgb, var(--sec-color) 55%, transparent),
+        0 0 rem(38px) rem(4px) color-mix(in srgb, var(--sec-color) 32%, transparent);
+}
+
+.title {
+    margin: 0;
+    font-size: clamp(rem(26px), 4vw, rem(38px));
+    line-height: 1.05;
+}
+
+/* Big colour-coded security number. */
+.secPill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: rem(52px);
+    padding: rem(2px) rem(12px);
+    border-radius: var(--mantine-radius-sm);
+    font-weight: 700;
+    font-size: rem(20px);
+    line-height: 1.5;
+    letter-spacing: 0.03em;
+    box-shadow: inset 0 0 0 rem(1px) rgba(255, 255, 255, 0.12);
+}
+
+.band {
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+}
+
+/* Sovereignty / faction chip. */
+.holderChip {
+    display: inline-flex;
+    align-items: center;
+    gap: rem(8px);
+    padding: rem(3px) rem(10px) rem(3px) rem(4px);
+    border-radius: rem(999px);
+    background: rgba(255, 255, 255, 0.04);
+    box-shadow: inset 0 0 0 rem(1px) rgba(147, 214, 224, 0.22);
+}
+
+/* Stat tiles ------------------------------------------------------------- */
+
+.statValue {
+    font-family: var(--mantine-font-family-monospace);
+    font-size: rem(24px);
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.statLabel {
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+/* Celestial / connection rows ------------------------------------------- */
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+    padding: rem(8px) rem(10px);
+    border-radius: var(--mantine-radius-sm);
+    transition: background-color 120ms ease;
+}
+
+.row:hover {
+    background: rgba(147, 214, 224, 0.06);
+}
+
+/* Flag chips ------------------------------------------------------------- */
+
+.flag {
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}

--- a/apps/web/tests/systemPage.test.tsx
+++ b/apps/web/tests/systemPage.test.tsx
@@ -14,12 +14,20 @@ import { cleanup, render, screen } from "@testing-library/react";
 
 const SYSTEM_ID = 30000142;
 
+const mockUseParams = jest.fn<() => Record<string, string>>();
 const mockUseSelectedCharacter = jest.fn();
 const mockUseSolarSystem = jest.fn();
 const mockUseSolarSystemCostIndices = jest.fn();
+const mockUseSolarSystemSovereignty = jest.fn();
+const mockUseAllSolarSystemJumps = jest.fn();
+const mockUseAllSolarSystemKills = jest.fn();
+const mockUseStar = jest.fn();
+const mockUseStargate = jest.fn();
 const mockUseGetSolarSystemById = jest.fn();
+const mockUseGetFwSystems = jest.fn();
+const mockUseGetIncursions = jest.fn();
 
-// system/[systemId]/page.tsx now imports prisma for generateMetadata
+// system/[systemId]/page.tsx imports prisma for generateMetadata
 jest.mock("~/lib/db", () => ({
   prisma: {
     solarSystem: { findUnique: jest.fn().mockResolvedValue(null) },
@@ -27,7 +35,7 @@ jest.mock("~/lib/db", () => ({
 }));
 
 jest.mock("next/navigation", () => ({
-  useParams: () => ({ systemId: String(SYSTEM_ID) }),
+  useParams: () => mockUseParams(),
   useRouter: () => ({}),
   usePathname: () => "/",
 }));
@@ -36,6 +44,17 @@ jest.mock("@jitaspace/hooks", () => ({
   useSelectedCharacter: () => mockUseSelectedCharacter(),
   useSolarSystem: (...args: unknown[]) => mockUseSolarSystem(...args),
   useSolarSystemCostIndices: () => mockUseSolarSystemCostIndices(),
+  useSolarSystemSovereignty: (...args: unknown[]) =>
+    mockUseSolarSystemSovereignty(...args),
+  useAllSolarSystemJumps: () => mockUseAllSolarSystemJumps(),
+  useAllSolarSystemKills: () => mockUseAllSolarSystemKills(),
+  useStar: (...args: unknown[]) => mockUseStar(...args),
+  useStargate: (...args: unknown[]) => mockUseStargate(...args),
+}));
+
+jest.mock("@jitaspace/esi-client", () => ({
+  useGetFwSystems: () => mockUseGetFwSystems(),
+  useGetIncursions: () => mockUseGetIncursions(),
 }));
 
 jest.mock("@jitaspace/sde-client", () => ({
@@ -43,24 +62,24 @@ jest.mock("@jitaspace/sde-client", () => ({
     mockUseGetSolarSystemById(...args),
 }));
 
-jest.mock("@jitaspace/ui", () => new Proxy({}, { get: () => () => null }));
-
-jest.mock("@jitaspace/eve-icons", () => ({
-  IndustryIcon: () => null,
+// Only the handful of @jitaspace/ui exports the page actually uses. The pure
+// helpers return deterministic values so branch behaviour is predictable.
+jest.mock("@jitaspace/ui", () => ({
+  FactionAvatar: () => null,
+  Position3DText: () => <span data-testid="position" />,
+  formatSecurityStatus: (s: number) => Number(s).toFixed(1),
+  isLightSecurityStatus: () => false,
+  securityStatusBand: () => "High-Sec",
+  securityStatusColor: () => "#4072D9",
 }));
 
 jest.mock("~/components/ActionIcon", () => ({
   SetAutopilotDestinationActionIcon: () => <div data-testid="set-autopilot" />,
 }));
 
-jest.mock("~/components/Anchor", () => ({
-  StargateDestinationAnchor: ({ children }: { children?: ReactNode }) => (
-    <span>{children}</span>
-  ),
-}));
-
 jest.mock("~/components/Avatar", () => ({
   PlanetAvatar: () => null,
+  SolarSystemStarAvatar: () => null,
   StarAvatar: () => null,
   StargateAvatar: () => null,
   StationAvatar: () => null,
@@ -74,22 +93,13 @@ jest.mock("~/components/Breadcrumbs", () => ({
   SolarSystemBreadcrumbs: () => <nav data-testid="breadcrumbs" />,
 }));
 
-jest.mock("~/components/Text", () => ({
-  AsteroidBeltName: () => <span>Asteroid Belt</span>,
-  MoonName: () => <span>Moon</span>,
-  PlanetName: () => <span>Planet</span>,
-  StargateName: () => <span>Stargate</span>,
-  StarName: () => <span>Star</span>,
+jest.mock("~/components/Home", () => ({
+  SectionHeader: ({ title }: { title: string }) => <h3>{title}</h3>,
 }));
 
-jest.mock("~/components/UI", () => ({
-  StatsGrid: ({ data }: { data: { title: string; value: string }[] }) => (
-    <div data-testid="stats-grid">
-      {data.map((d) => (
-        <div key={d.title}>{`${d.title}=${d.value}`}</div>
-      ))}
-    </div>
-  ),
+jest.mock("~/components/Text", () => ({
+  PlanetName: () => <span>Planet</span>,
+  StarName: () => <span>Star</span>,
 }));
 
 jest.mock("next/link", () => ({
@@ -114,37 +124,64 @@ function renderPage() {
 
 describe("System page", () => {
   beforeEach(() => {
-    mockUseSelectedCharacter.mockReset();
-    mockUseSolarSystem.mockReset();
-    mockUseSolarSystemCostIndices.mockReset();
-    mockUseGetSolarSystemById.mockReset();
+    mockUseParams.mockReset().mockReturnValue({ systemId: String(SYSTEM_ID) });
+    mockUseSelectedCharacter.mockReset().mockReturnValue(undefined);
+    mockUseSolarSystem.mockReset().mockReturnValue({ data: undefined });
+    mockUseSolarSystemCostIndices.mockReset().mockReturnValue({ data: {} });
+    mockUseSolarSystemSovereignty.mockReset().mockReturnValue(undefined);
+    mockUseAllSolarSystemJumps.mockReset().mockReturnValue({ data: { data: [] } });
+    mockUseAllSolarSystemKills.mockReset().mockReturnValue({ data: { data: [] } });
+    mockUseStar.mockReset().mockReturnValue({ data: undefined });
+    mockUseStargate.mockReset().mockReturnValue({ data: undefined });
+    mockUseGetSolarSystemById.mockReset().mockReturnValue({ data: undefined });
+    mockUseGetFwSystems.mockReset().mockReturnValue({ data: { data: [] } });
+    mockUseGetIncursions.mockReset().mockReturnValue({ data: { data: [] } });
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("renders all sections with rich data (every branch)", () => {
+  it("renders every section for a rich system (sovereignty, FW, incursion)", () => {
     mockUseSelectedCharacter.mockReturnValue({ characterId: 123456789 });
     mockUseSolarSystem.mockReturnValue({
       data: {
         data: {
-          stations: [60000001, 60000002],
-          stargates: [50000001, 50000002],
+          constellation_id: 20000020,
+          security_status: 0.9459,
+          security_class: "B",
           star_id: 40000001,
           planets: [
-            {
-              planet_id: 40000010,
-              moons: [40000011, 40000012],
-              asteroid_belts: [40000013],
-            },
-            {
-              planet_id: 40000020,
-            },
+            { planet_id: 40000010, moons: [1, 2], asteroid_belts: [3] },
+            { planet_id: 40000020, moons: [], asteroid_belts: [] },
           ],
-          security_class: "B",
+          stargates: [50000001, 50000002],
+          stations: [60000001, 60000002],
         },
       },
+    });
+    mockUseGetSolarSystemById.mockReturnValue({
+      data: {
+        data: {
+          luminosity: 1.692,
+          radius: 1234567,
+          position: { x: 1, y: 2, z: 3 },
+          hub: true,
+          border: true,
+          fringe: false,
+          corridor: false,
+          international: true,
+          regional: false,
+          factionID: 500001,
+          wormholeClassID: null,
+        },
+      },
+    });
+    mockUseStar.mockReturnValue({
+      data: { data: { spectral_class: "F1 V", temperature: 7305 } },
+    });
+    mockUseStargate.mockReturnValue({
+      data: { data: { destination: { system_id: 30000144 } } },
     });
     mockUseSolarSystemCostIndices.mockReturnValue({
       data: {
@@ -156,19 +193,45 @@ describe("System page", () => {
         },
       },
     });
-    mockUseGetSolarSystemById.mockReturnValue({
+    mockUseAllSolarSystemJumps.mockReturnValue({
+      data: { data: [{ system_id: SYSTEM_ID, ship_jumps: 2105 }] },
+    });
+    mockUseAllSolarSystemKills.mockReturnValue({
       data: {
-        data: {
-          luminosity: 0.045,
-          radius: 1234567,
-          border: true,
-          corridor: true,
-          fringe: true,
-          hub: true,
-          international: true,
-          regional: true,
-          position: { x: 1, y: 2, z: 3 },
-        },
+        data: [
+          { system_id: SYSTEM_ID, ship_kills: 65, pod_kills: 62, npc_kills: 43 },
+        ],
+      },
+    });
+    mockUseSolarSystemSovereignty.mockReturnValue({ faction_id: 500001 });
+    mockUseGetFwSystems.mockReturnValue({
+      data: {
+        data: [
+          {
+            solar_system_id: SYSTEM_ID,
+            contested: "contested",
+            owner_faction_id: 500001,
+            occupier_faction_id: 500002,
+            victory_points: 1000,
+            victory_points_threshold: 3000,
+          },
+        ],
+      },
+    });
+    mockUseGetIncursions.mockReturnValue({
+      data: {
+        data: [
+          {
+            constellation_id: 20000020,
+            faction_id: 500019,
+            has_boss: true,
+            infested_solar_systems: [SYSTEM_ID],
+            influence: 0.5,
+            staging_solar_system_id: SYSTEM_ID,
+            state: "established",
+            type: "Incursion",
+          },
+        ],
       },
     });
 
@@ -177,15 +240,16 @@ describe("System page", () => {
     expect(mockUseSolarSystem).toHaveBeenCalledWith(SYSTEM_ID);
     expect(mockUseGetSolarSystemById).toHaveBeenCalledWith(SYSTEM_ID);
 
-    // Autopilot action icon renders because a character is selected
+    // Header widgets
     expect(screen.getByTestId("set-autopilot")).toBeInTheDocument();
-    expect(screen.getByTestId("sec-badge")).toBeInTheDocument();
     expect(screen.getByTestId("breadcrumbs")).toBeInTheDocument();
+    expect(screen.getAllByTestId("sec-badge").length).toBeGreaterThan(0);
 
     // External links
-    expect(
-      screen.getByRole("link", { name: /DOTLAN EveMaps/ }),
-    ).toHaveAttribute("href", `https://evemaps.dotlan.net/system/${SYSTEM_ID}`);
+    expect(screen.getByRole("link", { name: /DOTLAN/ })).toHaveAttribute(
+      "href",
+      `https://evemaps.dotlan.net/system/${SYSTEM_ID}`,
+    );
     expect(screen.getByRole("link", { name: /zKillboard/ })).toHaveAttribute(
       "href",
       `https://zkillboard.com/system/${SYSTEM_ID}`,
@@ -199,72 +263,107 @@ describe("System page", () => {
       `https://www.adam4eve.eu/location.php?id=${SYSTEM_ID}`,
     );
 
-    // Section titles
-    expect(screen.getByText("Stations")).toBeInTheDocument();
-    expect(screen.getByText("Stargates")).toBeInTheDocument();
+    // Section headers
+    expect(screen.getByText("Activity · Last Hour")).toBeInTheDocument();
     expect(screen.getByText("Celestials")).toBeInTheDocument();
+    expect(screen.getByText("Stargates")).toBeInTheDocument();
+    expect(screen.getByText("Stations")).toBeInTheDocument();
+    expect(screen.getByText("Industry Indices")).toBeInTheDocument();
+    expect(screen.getByText("System Information")).toBeInTheDocument();
 
-    // Industry cost indices (Object.hasOwn true branch + StatsGrid mapping)
-    expect(screen.getByText("Industry Cost Indices")).toBeInTheDocument();
-    expect(screen.getByTestId("stats-grid")).toBeInTheDocument();
-    expect(screen.getByText("manufacturing=0.0512")).toBeInTheDocument();
-    // activity underscores replaced with spaces
-    expect(
-      screen.getByText("researching time efficiency=0.0123"),
-    ).toBeInTheDocument();
+    // Live activity value
+    expect(screen.getByText("2,105")).toBeInTheDocument();
 
-    // SDE-derived rows, truthy boolean branches -> "Yes"
-    expect(screen.getByText("Security Class")).toBeInTheDocument();
-    expect(screen.getByText("Border System")).toBeInTheDocument();
-    expect(screen.getByText("Radius")).toBeInTheDocument();
+    // Control panels
+    expect(screen.getByText("Sovereignty")).toBeInTheDocument();
+    expect(screen.getByText("Faction Warfare")).toBeInTheDocument();
+    expect(screen.getByText("Incursion")).toBeInTheDocument();
+    expect(screen.getByText(/1,000 \/ 3,000 victory points/)).toBeInTheDocument();
+    expect(screen.getByText(/50% influence/)).toBeInTheDocument();
+
+    // Industry indices (cost_index rendered as a percentage, underscores spaced)
+    expect(screen.getByText("manufacturing")).toBeInTheDocument();
+    expect(screen.getByText("5.12%")).toBeInTheDocument();
+    expect(screen.getByText("researching time efficiency")).toBeInTheDocument();
+
+    // System information + SDE-derived data
+    expect(screen.getByText("Security Status")).toBeInTheDocument();
+    expect(screen.getByText("0.95")).toBeInTheDocument();
     expect(screen.getByText("1,234,567 m")).toBeInTheDocument();
-    expect(screen.getAllByText("Yes").length).toBe(6);
-    expect(screen.getByText("Position")).toBeInTheDocument();
+    expect(screen.getByText("Trade Hub")).toBeInTheDocument();
+    expect(screen.getByText("Border")).toBeInTheDocument();
+    expect(screen.getByText("Regional")).toBeInTheDocument();
+    expect(screen.getByTestId("position")).toBeInTheDocument();
   });
 
-  it("returns null early for a non-finite system id", () => {
-    // Override useParams indirectly by making everything empty; the id itself
-    // is finite, so instead exercise the empty-data / falsey-boolean branches.
-    mockUseSelectedCharacter.mockReturnValue(undefined);
-    mockUseSolarSystem.mockReturnValue({ data: undefined });
-    mockUseSolarSystemCostIndices.mockReturnValue({ data: {} });
+  it("handles an empty / still-loading system", () => {
+    // No selected character, no system data, no live data, no cost indices.
+    mockUseAllSolarSystemJumps.mockReturnValue({ data: undefined });
+    mockUseAllSolarSystemKills.mockReturnValue({ data: undefined });
+
+    renderPage();
+
+    // No character -> no autopilot icon
+    expect(screen.queryByTestId("set-autopilot")).not.toBeInTheDocument();
+    // No sovereignty / FW / incursion -> those panels are hidden
+    expect(screen.queryByText("Sovereignty")).not.toBeInTheDocument();
+    expect(screen.queryByText("Faction Warfare")).not.toBeInTheDocument();
+    expect(screen.queryByText("Incursion")).not.toBeInTheDocument();
+    // No cost indices for this system -> section hidden
+    expect(screen.queryByText("Industry Indices")).not.toBeInTheDocument();
+    // No SDE data -> no trait chips
+    expect(screen.queryByText("Trade Hub")).not.toBeInTheDocument();
+    // Headers and empty-state copy still render
+    expect(screen.getByText("Celestials")).toBeInTheDocument();
+    expect(screen.getByText("Activity · Last Hour")).toBeInTheDocument();
+    expect(screen.getByText("No NPC stations in this system.")).toBeInTheDocument();
+    expect(screen.getByText(/No stargates/)).toBeInTheDocument();
+  });
+
+  it("labels a wormhole system as W-Space and shows its class", () => {
+    mockUseSolarSystem.mockReturnValue({
+      data: {
+        data: {
+          security_status: -1.0,
+          star_id: 40000001,
+          planets: [],
+          stargates: [],
+          stations: [],
+        },
+      },
+    });
     mockUseGetSolarSystemById.mockReturnValue({
       data: {
         data: {
-          luminosity: undefined,
-          border: false,
-          corridor: false,
-          fringe: false,
+          position: { x: 1, y: 2, z: 3 },
           hub: false,
+          border: false,
+          fringe: false,
+          corridor: false,
           international: false,
           regional: false,
+          wormholeClassID: 3,
         },
       },
     });
 
     renderPage();
 
-    // No selected character -> no autopilot icon
-    expect(screen.queryByTestId("set-autopilot")).not.toBeInTheDocument();
-    // No cost indices for this system -> section hidden
-    expect(screen.queryByText("Industry Cost Indices")).not.toBeInTheDocument();
-    // No radius -> radius row hidden
-    expect(screen.queryByText("Radius")).not.toBeInTheDocument();
-    // Falsey boolean branches -> "No" (Border, Corridor, Fringe, Hub,
-    // International, Regional = 6 rows)
-    expect(screen.getByText("Border System")).toBeInTheDocument();
-    expect(screen.getAllByText("No").length).toBe(6);
-    // Stations / Stargates / Celestials titles still render (lists empty)
-    expect(screen.getByText("Stations")).toBeInTheDocument();
-    expect(screen.getByText("Celestials")).toBeInTheDocument();
+    expect(screen.getByText("W-Space")).toBeInTheDocument();
+    expect(screen.getByText("Wormhole Class")).toBeInTheDocument();
+    expect(screen.getByText(/only reachable by wormhole/)).toBeInTheDocument();
+  });
+
+  it("returns null for a non-finite system id", () => {
+    mockUseParams.mockReturnValue({ systemId: "not-a-number" });
+
+    renderPage();
+
+    expect(screen.queryByText("System Information")).not.toBeInTheDocument();
+    expect(screen.queryByText("Celestials")).not.toBeInTheDocument();
   });
 
   it("renders the server wrapper (page.tsx) inside a Suspense boundary", () => {
-    mockUseSelectedCharacter.mockReturnValue(undefined);
-    mockUseSolarSystem.mockReturnValue({ data: undefined });
-    mockUseSolarSystemCostIndices.mockReturnValue({ data: {} });
-    mockUseGetSolarSystemById.mockReturnValue({ data: { data: {} } });
-
     const WrapperPage = require("~/app/system/[systemId]/page").default;
     render(
       <MantineProvider>

--- a/packages/hooks/src/hooks/universe/index.ts
+++ b/packages/hooks/src/hooks/universe/index.ts
@@ -10,6 +10,7 @@ export * from "./usePlanet";
 export * from "./useRace";
 export * from "./useRegion";
 export * from "./useSolarSystem";
+export * from "./useAllSolarSystemJumps";
 export * from "./useAllSolarSystemKills";
 export * from "./useStar";
 export * from "./useStargate";

--- a/packages/hooks/src/hooks/universe/useAllSolarSystemJumps.ts
+++ b/packages/hooks/src/hooks/universe/useAllSolarSystemJumps.ts
@@ -1,0 +1,3 @@
+"use client";
+
+export { useGetUniverseSystemJumps as useAllSolarSystemJumps } from "@jitaspace/esi-client";

--- a/packages/ui/Badge/SolarSystemSecurityStatusBadge.tsx
+++ b/packages/ui/Badge/SolarSystemSecurityStatusBadge.tsx
@@ -4,6 +4,12 @@ import type { BadgeProps } from "@mantine/core";
 import { memo } from "react";
 import { Badge, Skeleton, useMantineTheme } from "@mantine/core";
 
+import {
+  formatSecurityStatus,
+  isLightSecurityStatus,
+  securityStatusColor,
+} from "./securityStatus";
+
 export type SolarSystemSecurityStatusBadgeProps = BadgeProps & {
   securityStatus?: number;
 };
@@ -11,48 +17,6 @@ export type SolarSystemSecurityStatusBadgeProps = BadgeProps & {
 export const SolarSystemSecurityStatusBadge = memo(
   ({ securityStatus, ...otherProps }: SolarSystemSecurityStatusBadgeProps) => {
     const theme = useMantineTheme();
-    const classes = {
-      "1.0": {
-        backgroundColor: "#4072D9",
-      },
-      "0.9": {
-        backgroundColor: "#5597E3",
-      },
-      "0.8": {
-        color: theme.black,
-        backgroundColor: "#72C9F2",
-      },
-      "0.7": {
-        color: theme.black,
-        backgroundColor: "#81D7A7",
-      },
-      "0.6": {
-        color: theme.black,
-        backgroundColor: "#8FE269",
-      },
-      "0.5": {
-        color: theme.black,
-        backgroundColor: "#F5FD93",
-      },
-      "0.4": {
-        backgroundColor: "#CC722C",
-      },
-      "0.3": {
-        backgroundColor: "#BE4E26",
-      },
-      "0.2": {
-        backgroundColor: "#AB2923",
-      },
-      "0.1": {
-        backgroundColor: "#692623",
-      },
-      "0.0": {
-        backgroundColor: "#813861",
-      },
-      "-0.0": {
-        backgroundColor: "#813861",
-      },
-    };
 
     if (securityStatus === undefined) {
       return (
@@ -64,13 +28,18 @@ export const SolarSystemSecurityStatusBadge = memo(
       );
     }
 
-    const roundedSecStatus = (
-      Math.round(Math.max(securityStatus, 0) * 10) / 10
-    ).toFixed(1) as keyof typeof classes;
-
     return (
-      <Badge variant="filled" style={classes[roundedSecStatus]} {...otherProps}>
-        {roundedSecStatus}
+      <Badge
+        variant="filled"
+        style={{
+          backgroundColor: securityStatusColor(securityStatus),
+          color: isLightSecurityStatus(securityStatus)
+            ? theme.black
+            : undefined,
+        }}
+        {...otherProps}
+      >
+        {formatSecurityStatus(securityStatus)}
       </Badge>
     );
   },

--- a/packages/ui/Badge/index.ts
+++ b/packages/ui/Badge/index.ts
@@ -2,6 +2,7 @@ export * from "./AllianceTickerBadge";
 export * from "./CalendarEventResponseBadge";
 export * from "./CorporationTickerBadge";
 export * from "./MailLabelBadge";
+export * from "./securityStatus";
 export * from "./SolarSystemSecurityStatusBadge";
 export * from "./StandingsBadge";
 export * from "./WarAggressorTickerBadge";

--- a/packages/ui/Badge/securityStatus.ts
+++ b/packages/ui/Badge/securityStatus.ts
@@ -1,0 +1,61 @@
+/**
+ * EVE Online solar-system security-status helpers.
+ *
+ * The canonical CCP colour ramp runs from deep blue (1.0 high-sec) through
+ * yellow (0.5), red (0.1) and finally purple for null-sec (<= 0.0). These
+ * helpers are the single source of truth for that ramp so the security badge
+ * and any richer displays (hero panels, maps, ...) stay consistent.
+ */
+
+/** Null-sec purple — also the fallback for any out-of-range value. */
+const NULL_SEC_COLOR = "#813861";
+
+/** Background colour for each rounded security tier. */
+const SECURITY_STATUS_COLORS: Record<string, string> = {
+  "1.0": "#4072D9",
+  "0.9": "#5597E3",
+  "0.8": "#72C9F2",
+  "0.7": "#81D7A7",
+  "0.6": "#8FE269",
+  "0.5": "#F5FD93",
+  "0.4": "#CC722C",
+  "0.3": "#BE4E26",
+  "0.2": "#AB2923",
+  "0.1": "#692623",
+  "0.0": NULL_SEC_COLOR,
+};
+
+/** Rounded tiers whose bright backgrounds need dark text for contrast. */
+const LIGHT_SECURITY_TIERS = new Set(["0.5", "0.6", "0.7", "0.8"]);
+
+/**
+ * Round a raw security status to its displayed tier (one decimal, clamped at
+ * 0.0 — EVE never shows a negative security number with a distinct colour).
+ */
+export const roundSecurityStatus = (securityStatus: number): number =>
+  Math.round(Math.max(securityStatus, 0) * 10) / 10;
+
+/** Displayed security value, e.g. `0.9`, `0.0`. */
+export const formatSecurityStatus = (securityStatus: number): string =>
+  roundSecurityStatus(securityStatus).toFixed(1);
+
+/** Hex background colour for a security status. */
+export const securityStatusColor = (securityStatus: number): string =>
+  SECURITY_STATUS_COLORS[formatSecurityStatus(securityStatus)] ?? NULL_SEC_COLOR;
+
+/** Whether a tier's background is bright enough to require dark text. */
+export const isLightSecurityStatus = (securityStatus: number): boolean =>
+  LIGHT_SECURITY_TIERS.has(formatSecurityStatus(securityStatus));
+
+export type SecurityBand = "High-Sec" | "Low-Sec" | "Null-Sec";
+
+/**
+ * Coarse security band a system belongs to. High-sec is any status that rounds
+ * to >= 0.5, low-sec is any positive status below that, everything else (0.0
+ * and below, including wormhole space) is null-sec.
+ */
+export const securityStatusBand = (securityStatus: number): SecurityBand => {
+  if (Math.round(securityStatus * 10) / 10 >= 0.5) return "High-Sec";
+  if (securityStatus > 0) return "Low-Sec";
+  return "Null-Sec";
+};

--- a/packages/ui/tests/Badge/Badge.test.tsx
+++ b/packages/ui/tests/Badge/Badge.test.tsx
@@ -15,6 +15,7 @@ import { AllianceTickerBadge } from "../../Badge/AllianceTickerBadge";
 import { CalendarEventResponseBadge } from "../../Badge/CalendarEventResponseBadge";
 import { CorporationTickerBadge } from "../../Badge/CorporationTickerBadge";
 import { MailLabelBadge } from "../../Badge/MailLabelBadge";
+import { securityStatusBand } from "../../Badge/securityStatus";
 import { SolarSystemSecurityStatusBadge } from "../../Badge/SolarSystemSecurityStatusBadge";
 import { StandingsBadge } from "../../Badge/StandingsBadge";
 import { WarAggressorTickerBadge } from "../../Badge/WarAggressorTickerBadge";
@@ -148,5 +149,18 @@ describe("StandingsBadge", () => {
     const { container } = renderWithMantine(<StandingsBadge />);
     expect(screen.getByText("xxx")).toBeInTheDocument();
     expect(container.querySelector(".mantine-Skeleton-root")).toBeTruthy();
+  });
+});
+
+describe("securityStatusBand", () => {
+  it.each<[number, string]>([
+    [1.0, "High-Sec"],
+    [0.5, "High-Sec"],
+    [0.4, "Low-Sec"],
+    [0.1, "Low-Sec"],
+    [0, "Null-Sec"],
+    [-0.5, "Null-Sec"],
+  ])("classifies %p as %s", (securityStatus, expected) => {
+    expect(securityStatusBand(securityStatus)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary

Redesigns the solar system page (`/system/[systemId]`) from a flat list of key/value rows into a sectioned, on-theme overview that surfaces **all** available data for a system. Leans on the existing eve theme (glass `Card`/`Paper` panels, HUD `SectionHeader` accents, `eve_primary` cyan) so it stays visually consistent with the rest of the app.

## What's new on the page

- **Hero** — the star with a security-coloured glow ring, region/constellation breadcrumb, name, a large colour-coded security pill + band (High/Low/Null/**W-Space**), sovereignty holder chip, autopilot action, an at-a-glance composition line, and the external-tool links (DOTLAN / zKillboard / Eveeye / Adam4EVE).
- **Activity · Last Hour** — live ESI stat tiles: ship jumps, ship kills, pod kills, NPC kills.
- **Control** — conditional **Sovereignty** / **Faction Warfare** (victory-point bar) / **Incursion** (influence bar) panels; hidden when not applicable.
- **Celestials** — the star (spectral class + temperature) and every planet with moon / asteroid-belt count badges.
- **Stargates** — each gate shows **which system it leads to**, with that destination's security badge (a mini jump map).
- **Stations**, **Industry Indices**, and full **System Information** (SDE physical data, NPC faction owner, position, wormhole class, and on/off trait chips).

## Supporting changes

- **`packages/ui`** — extracted the CCP security-status colour ramp + band helpers into a reusable `Badge/securityStatus.ts` (`securityStatusColor`, `securityStatusBand`, `formatSecurityStatus`, `isLightSecurityStatus`, `roundSecurityStatus`) and refactored `SolarSystemSecurityStatusBadge` to consume it. Single source of truth — no duplicated colour map (keeps the SonarCloud duplication gate happy).
- **`packages/hooks`** — added `useAllSolarSystemJumps`, mirroring `useAllSolarSystemKills`.
- Changesets for `@jitaspace/web` (user-facing), `@jitaspace/ui`, and `@jitaspace/hooks`.

## Verification

Ran the dev server and verified live, end-to-end:

- **Jita (0.9 highsec):** CONCORD sovereignty, 2,105 jumps / 65 ship / 62 pod / 43 NPC kills, 8 planets, 7 stargates (each with destination + security), 18 stations, industry indices, full info.
- **1DQ1-A (nullsec, Delve):** purple `0.0` pill, "The Initiative." alliance sovereignty (logo + name), 18 asteroid belts (belt badges), "No NPC stations" empty state, raw security −0.39 in details, no Faction row (nullsec has no NPC owner).

`pnpm --filter @jitaspace/web lint` / `type-check` are clean for the new page (repo-wide type-check is red at baseline for unrelated environmental reasons). Fixed a Mantine `<Text>`→`<p>` hydration issue found during verification — the live DOM now has zero invalid nesting.

## Notes for reviewers

- The **Faction Warfare** and **Incursion** panels depend on live game state, so I couldn't trigger them on demand; they're type-checked and use the same rendering patterns as the verified panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
