### PR TITLE
feat(web): experimental redesigned Active Wars page

### DIFF
--- a/.changeset/war-room-active-wars.md
+++ b/.changeset/war-room-active-wars.md
@@ -1,0 +1,11 @@
+---
+"@jitaspace/web": minor
+---
+
+Added a compact, data-first redesign of the Active Wars page, available as an opt-in under **Settings → Experimental → "New Active Wars page"**. When off (the default), the existing table is unchanged.
+
+- **At-a-glance header** — active, starting, ending, in-combat, total ISK destroyed, and ships lost.
+- **Belligerents** — leaderboards of the corporations and alliances declaring the most wars, and the heaviest current fights by ISK destroyed.
+- **All wars** — every war with a clear aggressor-vs-defender damage balance (who is destroying more ISK), filterable by lifecycle (Active / Starting / Ending) and by mutual / open-for-allies / in-combat, sortable, and switchable between a compact row layout and a dense sortable table.
+
+Every figure comes straight from the game data; the previous made-up "activity" score was removed in favour of real ISK-destroyed, ship-kill, and duration numbers.

--- a/apps/web/app/active-wars/data.ts
+++ b/apps/web/app/active-wars/data.ts
@@ -1,0 +1,191 @@
+import { cacheLife } from "next/cache";
+
+import type {
+  WarRoomAggressor,
+  WarRoomData,
+  WarRoomStats,
+  WarRoomWar,
+  WarStatus,
+} from "~/components/Wars/WarRoom/types";
+import { prisma } from "~/lib/db";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface RawWar {
+  warId: number;
+  aggressorCorporationId: number | null;
+  aggressorAllianceId: number | null;
+  aggressorIskDestroyed: number;
+  aggressorShipsKilled: number;
+  allianceAllies: { allianceId: number }[];
+  corporationAllies: { corporationId: number }[];
+  declaredDate: Date;
+  defenderCorporationId: number | null;
+  defenderAllianceId: number | null;
+  defenderIskDestroyed: number;
+  defenderShipsKilled: number;
+  startedDate: Date | null;
+  finishedDate: Date | null;
+  isMutual: boolean;
+  isOpenForAllies: boolean;
+  retractedDate: Date | null;
+  updatedAt: Date;
+}
+
+function deriveStatus(war: RawWar, now: number): WarStatus {
+  const started = war.startedDate?.getTime();
+  if (started === undefined || started > now) return "pending";
+  const retracted = war.retractedDate?.getTime();
+  if (retracted !== undefined && retracted <= now) return "retracting";
+  return "active";
+}
+
+function enrichWar(war: RawWar, now: number): WarRoomWar {
+  const status = deriveStatus(war, now);
+  const totalIskDestroyed =
+    war.aggressorIskDestroyed + war.defenderIskDestroyed;
+  const totalShipsKilled = war.aggressorShipsKilled + war.defenderShipsKilled;
+
+  const started = war.startedDate?.getTime();
+  const ageDays =
+    started !== undefined && started <= now ? (now - started) / DAY_MS : 0;
+  const aggressorIskShare =
+    totalIskDestroyed > 0
+      ? war.aggressorIskDestroyed / totalIskDestroyed
+      : null;
+
+  return {
+    warId: war.warId,
+    aggressorCorporationId: war.aggressorCorporationId ?? undefined,
+    aggressorAllianceId: war.aggressorAllianceId ?? undefined,
+    aggressorIskDestroyed: war.aggressorIskDestroyed,
+    aggressorShipsKilled: war.aggressorShipsKilled,
+    defenderCorporationId: war.defenderCorporationId ?? undefined,
+    defenderAllianceId: war.defenderAllianceId ?? undefined,
+    defenderIskDestroyed: war.defenderIskDestroyed,
+    defenderShipsKilled: war.defenderShipsKilled,
+    allianceAllies: war.allianceAllies.map((a) => a.allianceId),
+    corporationAllies: war.corporationAllies.map((a) => a.corporationId),
+    declaredDate: war.declaredDate.toISOString(),
+    startedDate: war.startedDate?.toISOString(),
+    finishedDate: war.finishedDate?.toISOString(),
+    retractedDate: war.retractedDate?.toISOString(),
+    isMutual: war.isMutual,
+    isOpenForAllies: war.isOpenForAllies,
+    updatedAt: war.updatedAt.toISOString(),
+    status,
+    totalIskDestroyed,
+    totalShipsKilled,
+    ageDays,
+    aggressorIskShare,
+  };
+}
+
+function computeStats(wars: WarRoomWar[], now: number): WarRoomStats {
+  const stats: WarRoomStats = {
+    totalActive: wars.length,
+    activeCount: 0,
+    startingCount: 0,
+    endingCount: 0,
+    mutualCount: 0,
+    openForAlliesCount: 0,
+    totalIskDestroyed: 0,
+    totalShipsKilled: 0,
+    warsWithCombat: 0,
+    declaredLast24h: 0,
+    declaredLast7d: 0,
+    generatedAt: new Date(now).toISOString(),
+  };
+
+  for (const war of wars) {
+    if (war.status === "pending") stats.startingCount += 1;
+    else if (war.status === "retracting") stats.endingCount += 1;
+    else stats.activeCount += 1;
+    if (war.isMutual) stats.mutualCount += 1;
+    if (war.isOpenForAllies) stats.openForAlliesCount += 1;
+    stats.totalIskDestroyed += war.totalIskDestroyed;
+    stats.totalShipsKilled += war.totalShipsKilled;
+    if (war.totalShipsKilled > 0 || war.totalIskDestroyed > 0)
+      stats.warsWithCombat += 1;
+    const declared = new Date(war.declaredDate).getTime();
+    if (now - declared <= DAY_MS) stats.declaredLast24h += 1;
+    if (now - declared <= 7 * DAY_MS) stats.declaredLast7d += 1;
+  }
+
+  return stats;
+}
+
+function computeTopAggressors(wars: WarRoomWar[]): WarRoomAggressor[] {
+  const byEntity = new Map<string, WarRoomAggressor>();
+
+  for (const war of wars) {
+    const isAlliance = war.aggressorAllianceId != null;
+    const id = war.aggressorAllianceId ?? war.aggressorCorporationId;
+    if (id == null) continue;
+    const key = `${isAlliance ? "a" : "c"}:${id}`;
+    const existing = byEntity.get(key);
+    if (existing) {
+      existing.warCount += 1;
+      existing.iskDestroyed += war.aggressorIskDestroyed;
+      existing.shipsKilled += war.aggressorShipsKilled;
+    } else {
+      byEntity.set(key, {
+        allianceId: isAlliance ? id : undefined,
+        corporationId: isAlliance ? undefined : id,
+        warCount: 1,
+        iskDestroyed: war.aggressorIskDestroyed,
+        shipsKilled: war.aggressorShipsKilled,
+      });
+    }
+  }
+
+  return [...byEntity.values()]
+    .sort((a, b) => b.warCount - a.warCount || b.iskDestroyed - a.iskDestroyed)
+    .slice(0, 10);
+}
+
+export async function getWarRoomData(): Promise<WarRoomData> {
+  "use cache";
+  cacheLife("hours");
+
+  const now = Date.now();
+
+  const rawWars = (await prisma.war.findMany({
+    select: {
+      warId: true,
+      aggressorCorporationId: true,
+      aggressorAllianceId: true,
+      aggressorIskDestroyed: true,
+      aggressorShipsKilled: true,
+      allianceAllies: { select: { allianceId: true } },
+      corporationAllies: { select: { corporationId: true } },
+      declaredDate: true,
+      defenderCorporationId: true,
+      defenderAllianceId: true,
+      defenderIskDestroyed: true,
+      defenderShipsKilled: true,
+      startedDate: true,
+      finishedDate: true,
+      isMutual: true,
+      isOpenForAllies: true,
+      retractedDate: true,
+      updatedAt: true,
+    },
+    where: {
+      isDeleted: false,
+      OR: [
+        { finishedDate: { gte: new Date(now) } },
+        { finishedDate: { equals: null } },
+      ],
+    },
+  })) as RawWar[];
+
+  const wars = rawWars
+    .map((war) => enrichWar(war, now))
+    .sort((a, b) => b.totalIskDestroyed - a.totalIskDestroyed);
+
+  const stats = computeStats(wars, now);
+  const topAggressors = computeTopAggressors(wars);
+
+  return { stats, wars, topAggressors };
+}

--- a/apps/web/app/active-wars/page.tsx
+++ b/apps/web/app/active-wars/page.tsx
@@ -1,13 +1,9 @@
 import { Suspense } from "react";
-import { cacheLife } from "next/cache";
 import { notFound } from "next/navigation";
-import { Container, Group, Stack, Title } from "@mantine/core";
-
-import { WarsIcon } from "@jitaspace/eve-icons";
 
 import { PageSkeleton } from "~/components/PageSkeleton";
-import { WarsTable } from "~/components/Wars";
-import { prisma } from "~/lib/db";
+import { ActiveWarsView } from "~/components/Wars/ActiveWarsView";
+import { getWarRoomData } from "./data";
 
 export const metadata = {
   title: "Active Wars",
@@ -15,119 +11,15 @@ export const metadata = {
     "Live list of active wars in EVE Online — track ongoing conflicts between corporations and alliances.",
 };
 
-interface War {
-  warId: number;
-  aggressorCorporationId: number | null;
-  aggressorAllianceId: number | null;
-  aggressorIskDestroyed: number;
-  aggressorShipsKilled: number;
-  allianceAllies: { allianceId: number }[];
-  corporationAllies: { corporationId: number }[];
-  declaredDate: string;
-  defenderCorporationId: number | null;
-  defenderAllianceId: number | null;
-  defenderIskDestroyed: number;
-  defenderShipsKilled: number;
-  startedDate: string | null;
-  finishedDate: string | null;
-  isMutual: boolean;
-  isOpenForAllies: boolean;
-  retractedDate: string | null;
-  updatedAt: string;
-}
-
-async function getCachedWarsData(): Promise<War[]> {
-  "use cache";
-  cacheLife("hours");
-
+async function ActiveWarsContent() {
+  let data;
   try {
-    const now = new Date();
-    return await prisma.war
-      .findMany({
-        select: {
-          warId: true,
-          aggressorCorporationId: true,
-          aggressorAllianceId: true,
-          aggressorIskDestroyed: true,
-          aggressorShipsKilled: true,
-          allianceAllies: { select: { allianceId: true } },
-          corporationAllies: { select: { corporationId: true } },
-          declaredDate: true,
-          defenderCorporationId: true,
-          defenderAllianceId: true,
-          defenderIskDestroyed: true,
-          defenderShipsKilled: true,
-          startedDate: true,
-          finishedDate: true,
-          isMutual: true,
-          isOpenForAllies: true,
-          retractedDate: true,
-          updatedAt: true,
-        },
-        where: {
-          isDeleted: false,
-          OR: [
-            { finishedDate: { gte: now } },
-            { finishedDate: { equals: null } },
-          ],
-        },
-      })
-      .then((wars) =>
-        wars.map((war) => ({
-          ...war,
-          aggressorCorporationId: war.aggressorCorporationId ?? null,
-          aggressorAllianceId: war.aggressorAllianceId ?? null,
-          declaredDate: war.declaredDate.toISOString(),
-          defenderCorporationId: war.defenderCorporationId ?? null,
-          defenderAllianceId: war.defenderAllianceId ?? null,
-          startedDate: war.startedDate?.toISOString() ?? null,
-          finishedDate: war.finishedDate?.toISOString() ?? null,
-          retractedDate: war.retractedDate?.toISOString() ?? null,
-          updatedAt: war.updatedAt.toISOString(),
-        })),
-      );
+    data = await getWarRoomData();
   } catch {
     notFound();
   }
-}
 
-async function ActiveWarsContent() {
-  const wars = await getCachedWarsData();
-
-  return (
-    <Container size="xl">
-      <Stack>
-        <Group>
-          <WarsIcon width={48} />
-          <Title>Active Wars ({wars.length})</Title>
-        </Group>
-        <WarsTable
-          wars={wars.map((war) => ({
-            ...war,
-            aggressorCorporationId: war.aggressorCorporationId ?? undefined,
-            aggressorAllianceId: war.aggressorAllianceId ?? undefined,
-            defenderCorporationId: war.defenderCorporationId ?? undefined,
-            defenderAllianceId: war.defenderAllianceId ?? undefined,
-            allianceAllies: war.allianceAllies.map((ally) => ally.allianceId),
-            corporationAllies: war.corporationAllies.map(
-              (ally) => ally.corporationId,
-            ),
-            declaredDate: new Date(war.declaredDate),
-            startedDate: war.startedDate
-              ? new Date(war.startedDate)
-              : undefined,
-            finishedDate: war.finishedDate
-              ? new Date(war.finishedDate)
-              : undefined,
-            retractedDate: war.retractedDate
-              ? new Date(war.retractedDate)
-              : undefined,
-            updatedAt: new Date(war.updatedAt),
-          }))}
-        />
-      </Stack>
-    </Container>
-  );
+  return <ActiveWarsView data={data} />;
 }
 
 export default function Page() {

--- a/apps/web/components/Settings/SettingsCard.tsx
+++ b/apps/web/components/Settings/SettingsCard.tsx
@@ -41,12 +41,18 @@ export function SettingsCard() {
   const experimentalDataTables = usePreferencesStore(
     (state) => state.experimentalDataTables,
   );
+  const experimentalActiveWars = usePreferencesStore(
+    (state) => state.experimentalActiveWars,
+  );
   const setSelectedAcceptLanguage = usePreferencesStore(
     (state) => state.setEsiAcceptLanguage,
   );
   const setSelectedTheme = usePreferencesStore((state) => state.setAppTheme);
   const setExperimentalDataTables = usePreferencesStore(
     (state) => state.setExperimentalDataTables,
+  );
+  const setExperimentalActiveWars = usePreferencesStore(
+    (state) => state.setExperimentalActiveWars,
   );
 
   const {
@@ -258,6 +264,30 @@ export function SettingsCard() {
                 setExperimentalDataTables(event.currentTarget.checked)
               }
               aria-label="Enable experimental data tables"
+            />
+          </Group>
+
+          <Group
+            justify="space-between"
+            className={classes.item}
+            wrap="nowrap"
+            gap="xl"
+          >
+            <div>
+              <Text>New Active Wars page</Text>
+              <Text size="xs" c="dimmed">
+                Replace the Active Wars table with the redesigned overview —
+                headline stats, aggressor and defender leaderboards, and a
+                filterable list you can switch between rows and a compact table.
+              </Text>
+            </div>
+            <Switch
+              className={classes.switch}
+              checked={experimentalActiveWars}
+              onChange={(event) =>
+                setExperimentalActiveWars(event.currentTarget.checked)
+              }
+              aria-label="Enable the new Active Wars page"
             />
           </Group>
         </Tabs.Panel>

--- a/apps/web/components/Wars/ActiveWarsView.tsx
+++ b/apps/web/components/Wars/ActiveWarsView.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Container, Group, Stack, Title } from "@mantine/core";
+
+import { WarsIcon } from "@jitaspace/eve-icons";
+
+import { usePreferencesStore } from "~/lib/preferences";
+import type { WarRoomData, WarRoomWar } from "./WarRoom";
+import { WarRoom } from "./WarRoom";
+import type { War } from "./WarsTable";
+import { WarsTable } from "./WarsTable";
+
+function toTableWar(war: WarRoomWar): War {
+  return {
+    warId: war.warId,
+    aggressorCorporationId: war.aggressorCorporationId,
+    aggressorAllianceId: war.aggressorAllianceId,
+    aggressorIskDestroyed: war.aggressorIskDestroyed,
+    aggressorShipsKilled: war.aggressorShipsKilled,
+    allianceAllies: war.allianceAllies,
+    corporationAllies: war.corporationAllies,
+    declaredDate: new Date(war.declaredDate),
+    defenderCorporationId: war.defenderCorporationId,
+    defenderAllianceId: war.defenderAllianceId,
+    defenderIskDestroyed: war.defenderIskDestroyed,
+    defenderShipsKilled: war.defenderShipsKilled,
+    startedDate: war.startedDate ? new Date(war.startedDate) : undefined,
+    finishedDate: war.finishedDate ? new Date(war.finishedDate) : undefined,
+    isMutual: war.isMutual,
+    isOpenForAllies: war.isOpenForAllies,
+    retractedDate: war.retractedDate ? new Date(war.retractedDate) : undefined,
+    updatedAt: new Date(war.updatedAt),
+  };
+}
+
+/**
+ * Chooses how to present Active Wars based on the "New Active Wars page"
+ * experimental setting: the redesigned overview when enabled, otherwise the
+ * long-standing table. Both render from the same server-fetched data.
+ */
+export function ActiveWarsView({ data }: { data: WarRoomData }) {
+  const experimental = usePreferencesStore(
+    (state) => state.experimentalActiveWars,
+  );
+
+  if (experimental) {
+    return <WarRoom data={data} />;
+  }
+
+  return (
+    <Container size="xl">
+      <Stack>
+        <Group>
+          <WarsIcon width={48} />
+          <Title>Active Wars ({data.wars.length})</Title>
+        </Group>
+        <WarsTable wars={data.wars.map(toTableWar)} />
+      </Stack>
+    </Container>
+  );
+}

--- a/apps/web/components/Wars/ActiveWarsView.tsx
+++ b/apps/web/components/Wars/ActiveWarsView.tsx
@@ -38,7 +38,7 @@ function toTableWar(war: WarRoomWar): War {
  * experimental setting: the redesigned overview when enabled, otherwise the
  * long-standing table. Both render from the same server-fetched data.
  */
-export function ActiveWarsView({ data }: { data: WarRoomData }) {
+export function ActiveWarsView({ data }: Readonly<{ data: WarRoomData }>) {
   const experimental = usePreferencesStore(
     (state) => state.experimentalActiveWars,
   );

--- a/apps/web/components/Wars/WarRoom/Belligerents.tsx
+++ b/apps/web/components/Wars/WarRoom/Belligerents.tsx
@@ -13,11 +13,12 @@ import classes from "./WarRoom.module.css";
 function SideName({
   corporationId,
   allianceId,
-}: {
+}: Readonly<{
   corporationId?: number;
   allianceId?: number;
-}) {
-  return allianceId != null ? (
+}>) {
+  const isAlliance = allianceId != null;
+  return isAlliance ? (
     <AllianceName allianceId={allianceId} inherit span />
   ) : (
     <CorporationName corporationId={corporationId} inherit span />
@@ -28,11 +29,11 @@ function AggressorRow({
   aggressor,
   rank,
   max,
-}: {
+}: Readonly<{
   aggressor: WarRoomAggressor;
   rank: number;
   max: number;
-}) {
+}>) {
   const width = max > 0 ? Math.max((aggressor.warCount / max) * 100, 3) : 0;
   return (
     <div className={classes.blRow}>
@@ -68,11 +69,11 @@ function FightRow({
   war,
   rank,
   max,
-}: {
+}: Readonly<{
   war: WarRoomWar;
   rank: number;
   max: number;
-}) {
+}>) {
   const width = max > 0 ? Math.max((war.totalIskDestroyed / max) * 100, 3) : 0;
   return (
     <div className={classes.blRow}>
@@ -111,10 +112,10 @@ function FightRow({
 export function Belligerents({
   aggressors,
   wars,
-}: {
+}: Readonly<{
   aggressors: WarRoomAggressor[];
   wars: WarRoomWar[];
-}) {
+}>) {
   const heaviest = useMemo(
     () =>
       wars
@@ -132,7 +133,7 @@ export function Belligerents({
       <section>
         <div className={classes.sectionHead}>
           <div className={classes.sectionTitle}>
-            Most active aggressors
+            Most active aggressors{" "}
             <span className={classes.sectionSub}>wars declared</span>
           </div>
         </div>
@@ -151,7 +152,7 @@ export function Belligerents({
       <section>
         <div className={classes.sectionHead}>
           <div className={classes.sectionTitle}>
-            Heaviest fighting
+            Heaviest fighting{" "}
             <span className={classes.sectionSub}>by ISK destroyed</span>
           </div>
         </div>

--- a/apps/web/components/Wars/WarRoom/Belligerents.tsx
+++ b/apps/web/components/Wars/WarRoom/Belligerents.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { AllianceName, CorporationName } from "@jitaspace/eve-components";
+import { WarAnchor } from "@jitaspace/ui";
+
+import type { WarRoomAggressor, WarRoomWar } from "./types";
+import { cx, WarEntity } from "./parts";
+import { formatCompactNumber, formatIskCompact, warHasCombat } from "./utils";
+import classes from "./WarRoom.module.css";
+
+function SideName({
+  corporationId,
+  allianceId,
+}: {
+  corporationId?: number;
+  allianceId?: number;
+}) {
+  return allianceId != null ? (
+    <AllianceName allianceId={allianceId} inherit span />
+  ) : (
+    <CorporationName corporationId={corporationId} inherit span />
+  );
+}
+
+function AggressorRow({
+  aggressor,
+  rank,
+  max,
+}: {
+  aggressor: WarRoomAggressor;
+  rank: number;
+  max: number;
+}) {
+  const width = max > 0 ? Math.max((aggressor.warCount / max) * 100, 3) : 0;
+  return (
+    <div className={classes.blRow}>
+      <span className={classes.blRank}>{rank}</span>
+      <div className={classes.blMain}>
+        <WarEntity
+          side="aggressor"
+          corporationId={aggressor.corporationId}
+          allianceId={aggressor.allianceId}
+          size={20}
+          linked
+        />
+        <div className={classes.blTrack}>
+          <div
+            className={cx(classes.blFill, classes.a)}
+            style={{ width: `${width}%` }}
+          />
+        </div>
+      </div>
+      <div className={classes.blVal}>
+        <div className={classes.blValNum}>{aggressor.warCount}</div>
+        <div className={classes.blValSub}>
+          {aggressor.iskDestroyed > 0
+            ? `${formatIskCompact(aggressor.iskDestroyed)} dealt`
+            : "wars"}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FightRow({
+  war,
+  rank,
+  max,
+}: {
+  war: WarRoomWar;
+  rank: number;
+  max: number;
+}) {
+  const width = max > 0 ? Math.max((war.totalIskDestroyed / max) * 100, 3) : 0;
+  return (
+    <div className={classes.blRow}>
+      <span className={classes.blRank}>{rank}</span>
+      <div className={classes.blMain}>
+        <WarAnchor warId={war.warId} inherit className={classes.blMatch}>
+          <SideName
+            corporationId={war.aggressorCorporationId}
+            allianceId={war.aggressorAllianceId}
+          />
+          <span className={classes.dim}> vs </span>
+          <SideName
+            corporationId={war.defenderCorporationId}
+            allianceId={war.defenderAllianceId}
+          />
+        </WarAnchor>
+        <div className={classes.blTrack}>
+          <div
+            className={cx(classes.blFill, classes.d)}
+            style={{ width: `${width}%` }}
+          />
+        </div>
+      </div>
+      <div className={classes.blVal}>
+        <div className={classes.blValNum}>
+          {formatIskCompact(war.totalIskDestroyed)}
+        </div>
+        <div className={classes.blValSub}>
+          {formatCompactNumber(war.totalShipsKilled)} ships
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Belligerents({
+  aggressors,
+  wars,
+}: {
+  aggressors: WarRoomAggressor[];
+  wars: WarRoomWar[];
+}) {
+  const heaviest = useMemo(
+    () =>
+      wars
+        .filter(warHasCombat)
+        .sort((a, b) => b.totalIskDestroyed - a.totalIskDestroyed)
+        .slice(0, 5),
+    [wars],
+  );
+
+  const maxWars = aggressors[0]?.warCount ?? 0;
+  const maxIsk = heaviest[0]?.totalIskDestroyed ?? 0;
+
+  return (
+    <div className={classes.blCols}>
+      <section>
+        <div className={classes.sectionHead}>
+          <div className={classes.sectionTitle}>
+            Most active aggressors
+            <span className={classes.sectionSub}>wars declared</span>
+          </div>
+        </div>
+        <div className={classes.blCard}>
+          {aggressors.slice(0, 5).map((aggressor, index) => (
+            <AggressorRow
+              key={`${aggressor.allianceId ?? "c"}-${aggressor.corporationId ?? "a"}`}
+              aggressor={aggressor}
+              rank={index + 1}
+              max={maxWars}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className={classes.sectionHead}>
+          <div className={classes.sectionTitle}>
+            Heaviest fighting
+            <span className={classes.sectionSub}>by ISK destroyed</span>
+          </div>
+        </div>
+        <div className={classes.blCard}>
+          {heaviest.length > 0 ? (
+            heaviest.map((war, index) => (
+              <FightRow
+                key={war.warId}
+                war={war}
+                rank={index + 1}
+                max={maxIsk}
+              />
+            ))
+          ) : (
+            <div className={classes.blNote}>No kills recorded yet.</div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/StatHeader.tsx
+++ b/apps/web/components/Wars/WarRoom/StatHeader.tsx
@@ -5,7 +5,7 @@ import { cx } from "./parts";
 import { formatCompactNumber, formatIskCompact } from "./utils";
 import classes from "./WarRoom.module.css";
 
-export function StatHeader({ stats }: { stats: WarRoomStats }) {
+export function StatHeader({ stats }: Readonly<{ stats: WarRoomStats }>) {
   const cells: { value: string; label: string; dot?: string }[] = [
     {
       value: formatCompactNumber(stats.activeCount),

--- a/apps/web/components/Wars/WarRoom/StatHeader.tsx
+++ b/apps/web/components/Wars/WarRoom/StatHeader.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { WarRoomStats } from "./types";
+import { cx } from "./parts";
+import { formatCompactNumber, formatIskCompact } from "./utils";
+import classes from "./WarRoom.module.css";
+
+export function StatHeader({ stats }: { stats: WarRoomStats }) {
+  const cells: { value: string; label: string; dot?: string }[] = [
+    {
+      value: formatCompactNumber(stats.activeCount),
+      label: "Active",
+      dot: classes.dotActive,
+    },
+    {
+      value: formatCompactNumber(stats.startingCount),
+      label: "Starting",
+      dot: classes.dotStarting,
+    },
+    {
+      value: formatCompactNumber(stats.endingCount),
+      label: "Ending",
+      dot: classes.dotEnding,
+    },
+    { value: formatCompactNumber(stats.warsWithCombat), label: "In combat" },
+    {
+      value: formatIskCompact(stats.totalIskDestroyed),
+      label: "ISK destroyed",
+    },
+    { value: formatCompactNumber(stats.totalShipsKilled), label: "Ships lost" },
+  ];
+
+  return (
+    <div className={classes.statGrid}>
+      {cells.map((cell) => (
+        <div className={classes.statCell} key={cell.label}>
+          <div className={classes.statValue}>{cell.value}</div>
+          <div className={classes.statLabel}>
+            {cell.dot ? <span className={cx(classes.dot, cell.dot)} /> : null}
+            {cell.label}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/WarList.tsx
+++ b/apps/web/components/Wars/WarRoom/WarList.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button, Chip, SegmentedControl, Select } from "@mantine/core";
+
+import type { WarRoomWar } from "./types";
+import type { SortKey, StatusFilter } from "./utils";
+import { cx } from "./parts";
+import { filterWars, SORT_OPTIONS, sortWars, STATUS_FILTERS } from "./utils";
+import classes from "./WarRoom.module.css";
+import { WarRow } from "./WarRow";
+import { WarTable } from "./WarTable";
+
+type ViewMode = "rows" | "table";
+
+const INITIAL_VISIBLE = 24;
+const VISIBLE_STEP = 24;
+
+export function WarList({ wars }: { wars: WarRoomWar[] }) {
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [combat, setCombat] = useState(false);
+  const [mutual, setMutual] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<ViewMode>("rows");
+  const [sortKey, setSortKey] = useState<SortKey>("isk");
+  const [sortDir, setSortDir] = useState<-1 | 1>(-1);
+  const [visible, setVisible] = useState(INITIAL_VISIBLE);
+
+  const filtered = useMemo(
+    () => filterWars(wars, { status, combat, mutual, open }),
+    [wars, status, combat, mutual, open],
+  );
+  const sorted = useMemo(
+    () => sortWars(filtered, sortKey, sortDir),
+    [filtered, sortKey, sortDir],
+  );
+
+  // Reset the load-more window when the filters change (render-time, no effect).
+  const filterKey = `${status}:${combat}:${mutual}:${open}`;
+  const [prevFilterKey, setPrevFilterKey] = useState(filterKey);
+  if (filterKey !== prevFilterKey) {
+    setPrevFilterKey(filterKey);
+    setVisible(INITIAL_VISIBLE);
+  }
+
+  const shown = sorted.slice(0, visible);
+
+  const handleTableSort = (key: SortKey) => {
+    if (key === sortKey) setSortDir((dir) => (dir === -1 ? 1 : -1));
+    else {
+      setSortKey(key);
+      setSortDir(-1);
+    }
+  };
+
+  return (
+    <section className={classes.section}>
+      <div className={classes.sectionHead}>
+        <div className={classes.sectionTitle}>
+          All wars
+          <span className={classes.sectionSub}>
+            {filtered.length.toLocaleString()} shown
+          </span>
+        </div>
+        <div className={classes.controlsGroup}>
+          <Select
+            size="xs"
+            w={168}
+            aria-label="Sort wars"
+            value={sortKey}
+            onChange={(value) => value && setSortKey(value)}
+            data={SORT_OPTIONS.map((option) => ({
+              value: option.value,
+              label: option.label,
+            }))}
+            allowDeselect={false}
+            checkIconPosition="right"
+          />
+          <SegmentedControl
+            size="xs"
+            value={view}
+            onChange={(value) => setView(value)}
+            data={[
+              { value: "rows", label: "Rows" },
+              { value: "table", label: "Table" },
+            ]}
+          />
+        </div>
+      </div>
+
+      <div className={classes.controls}>
+        <div className={classes.controlsGroup}>
+          <SegmentedControl
+            size="xs"
+            value={status}
+            onChange={(value) => setStatus(value)}
+            data={STATUS_FILTERS.map((option) => ({
+              value: option.value,
+              label: option.label,
+            }))}
+          />
+          <Chip size="xs" radius="sm" checked={combat} onChange={setCombat}>
+            In combat
+          </Chip>
+          <Chip size="xs" radius="sm" checked={mutual} onChange={setMutual}>
+            Mutual
+          </Chip>
+          <Chip size="xs" radius="sm" checked={open} onChange={setOpen}>
+            Open for allies
+          </Chip>
+        </div>
+      </div>
+
+      {shown.length === 0 ? (
+        <div className={cx(classes.listCard, classes.empty)}>
+          No wars match these filters.
+        </div>
+      ) : view === "table" ? (
+        <div className={classes.swap} key="table">
+          <WarTable
+            wars={shown}
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleTableSort}
+          />
+        </div>
+      ) : (
+        <div className={cx(classes.listCard, classes.swap)} key="rows">
+          {shown.map((war) => (
+            <WarRow key={war.warId} war={war} />
+          ))}
+        </div>
+      )}
+
+      {visible < sorted.length ? (
+        <div className={classes.moreWrap}>
+          <Button
+            size="xs"
+            variant="default"
+            onClick={() => setVisible((current) => current + VISIBLE_STEP)}
+          >
+            Show more ({(sorted.length - visible).toLocaleString()} more)
+          </Button>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/WarList.tsx
+++ b/apps/web/components/Wars/WarRoom/WarList.tsx
@@ -16,7 +16,7 @@ type ViewMode = "rows" | "table";
 const INITIAL_VISIBLE = 24;
 const VISIBLE_STEP = 24;
 
-export function WarList({ wars }: { wars: WarRoomWar[] }) {
+export function WarList({ wars }: Readonly<{ wars: WarRoomWar[] }>) {
   const [status, setStatus] = useState<StatusFilter>("all");
   const [combat, setCombat] = useState(false);
   const [mutual, setMutual] = useState(false);
@@ -53,11 +53,39 @@ export function WarList({ wars }: { wars: WarRoomWar[] }) {
     }
   };
 
+  let listContent;
+  if (shown.length === 0) {
+    listContent = (
+      <div className={cx(classes.listCard, classes.empty)}>
+        No wars match these filters.
+      </div>
+    );
+  } else if (view === "table") {
+    listContent = (
+      <div className={classes.swap} key="table">
+        <WarTable
+          wars={shown}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleTableSort}
+        />
+      </div>
+    );
+  } else {
+    listContent = (
+      <div className={cx(classes.listCard, classes.swap)} key="rows">
+        {shown.map((war) => (
+          <WarRow key={war.warId} war={war} />
+        ))}
+      </div>
+    );
+  }
+
   return (
     <section className={classes.section}>
       <div className={classes.sectionHead}>
         <div className={classes.sectionTitle}>
-          All wars
+          All wars{" "}
           <span className={classes.sectionSub}>
             {filtered.length.toLocaleString()} shown
           </span>
@@ -111,26 +139,7 @@ export function WarList({ wars }: { wars: WarRoomWar[] }) {
         </div>
       </div>
 
-      {shown.length === 0 ? (
-        <div className={cx(classes.listCard, classes.empty)}>
-          No wars match these filters.
-        </div>
-      ) : view === "table" ? (
-        <div className={classes.swap} key="table">
-          <WarTable
-            wars={shown}
-            sortKey={sortKey}
-            sortDir={sortDir}
-            onSort={handleTableSort}
-          />
-        </div>
-      ) : (
-        <div className={cx(classes.listCard, classes.swap)} key="rows">
-          {shown.map((war) => (
-            <WarRow key={war.warId} war={war} />
-          ))}
-        </div>
-      )}
+      {listContent}
 
       {visible < sorted.length ? (
         <div className={classes.moreWrap}>

--- a/apps/web/components/Wars/WarRoom/WarRoom.module.css
+++ b/apps/web/components/Wars/WarRoom/WarRoom.module.css
@@ -1,0 +1,484 @@
+/* ============================================================================
+   Active Wars — a compact, data-first read of New Eden's wars.
+   Killboard vernacular: hairline rules, monospace figures, muted surfaces.
+   Two low-saturation accents ENCODE the two sides (aggressor warm, defender
+   cool); semantic state colours are separate. Works under any dark app theme.
+   ========================================================================== */
+
+.root {
+  --agg: #d1795c;
+  --agg-dim: rgba(209, 121, 92, 0.16);
+  --agg-line: rgba(209, 121, 92, 0.44);
+  --def: #5f9cba;
+  --def-dim: rgba(95, 156, 186, 0.16);
+  --def-line: rgba(95, 156, 186, 0.44);
+  --st-active: #6fa66f;
+  --st-starting: #c2a15a;
+  --st-ending: #9aa4b2;
+  --line: rgba(150, 172, 200, 0.13);
+  --line-2: rgba(150, 172, 200, 0.24);
+  --surface: rgba(15, 18, 24, 0.62);
+  --surface-2: rgba(23, 27, 34, 0.66);
+  --ink: #e3e7ec;
+  --ink-2: #98a1af;
+  --ink-3: #646d7b;
+}
+
+.mono {
+  font-family: var(--mantine-font-family-monospace);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+.dim {
+  color: var(--ink-3);
+}
+
+/* ---- Masthead ---- */
+.masthead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 12px;
+  margin-bottom: var(--mantine-spacing-md);
+}
+.title {
+  font-size: clamp(1.3rem, 2.6vw, 1.7rem);
+  font-weight: 650;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+}
+.subtitle {
+  color: var(--ink-2);
+  font-size: 0.82rem;
+}
+
+/* ---- Stat header (flat, no animation) ---- */
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(rem(112px), 1fr));
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--mantine-radius-sm);
+  overflow: hidden;
+}
+.statCell {
+  background: var(--surface);
+  padding: rem(11px) rem(14px);
+}
+.statValue {
+  font-family: var(--mantine-font-family-monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: clamp(1.15rem, 2.4vw, 1.5rem);
+  font-weight: 600;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.statLabel {
+  display: flex;
+  align-items: center;
+  gap: rem(5px);
+  font-size: rem(10px);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin-top: rem(3px);
+}
+
+/* ---- Sections ---- */
+.section {
+  margin-top: var(--mantine-spacing-xl);
+}
+.sectionHead {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: rem(6px) var(--mantine-spacing-md);
+  margin-bottom: var(--mantine-spacing-sm);
+}
+.sectionTitle {
+  font-size: rem(13px);
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--ink);
+}
+.sectionSub {
+  font-family: var(--mantine-font-family-monospace);
+  font-size: rem(11px);
+  color: var(--ink-3);
+  font-weight: 400;
+  margin-left: rem(8px);
+}
+
+/* ---- Shared: entity, balance bar, state ---- */
+.entity {
+  display: flex;
+  align-items: center;
+  gap: rem(8px);
+  min-width: 0;
+}
+.entity.right {
+  flex-direction: row-reverse;
+  text-align: right;
+}
+.entityName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ink);
+}
+.avatarRing {
+  border-radius: var(--mantine-radius-xs);
+  flex: 0 0 auto;
+}
+.avatarRing.agg {
+  box-shadow: 0 0 0 1px var(--agg-line);
+}
+.avatarRing.def {
+  box-shadow: 0 0 0 1px var(--def-line);
+}
+
+.bal {
+  position: relative;
+  height: rem(6px);
+  border-radius: 999px;
+  background: rgba(150, 172, 200, 0.09);
+  overflow: hidden;
+  display: flex;
+}
+.bal .a {
+  height: 100%;
+  background: var(--agg);
+}
+.bal .d {
+  height: 100%;
+  background: var(--def);
+  margin-left: auto;
+}
+.bal::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: -1px;
+  bottom: -1px;
+  width: 1px;
+  background: rgba(255, 255, 255, 0.22);
+}
+.bal.empty {
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(150, 172, 200, 0.08),
+    rgba(150, 172, 200, 0.08) 5px,
+    transparent 5px,
+    transparent 10px
+  );
+}
+.bal.empty::after {
+  display: none;
+}
+
+.figA {
+  color: var(--agg);
+}
+.figD {
+  color: var(--def);
+}
+.lead {
+  font-weight: 650;
+}
+.figDim {
+  color: var(--ink-3);
+}
+
+.state {
+  display: inline-flex;
+  align-items: center;
+  gap: rem(6px);
+  font-size: rem(11px);
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+.dot {
+  width: rem(7px);
+  height: rem(7px);
+  border-radius: 999px;
+  display: inline-block;
+  flex: 0 0 auto;
+}
+.dotActive {
+  background: var(--st-active);
+}
+.dotStarting {
+  background: var(--st-starting);
+}
+.dotEnding {
+  background: var(--st-ending);
+}
+
+/* ---- Belligerents leaderboards ---- */
+.blCols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--mantine-spacing-lg);
+}
+@media (max-width: 48em) {
+  .blCols {
+    grid-template-columns: 1fr;
+  }
+}
+.blCard {
+  border: 1px solid var(--line);
+  border-radius: var(--mantine-radius-sm);
+  background: var(--surface);
+  padding: rem(10px) rem(14px) rem(6px);
+}
+.blRow {
+  display: grid;
+  grid-template-columns: rem(16px) 1fr auto;
+  gap: rem(10px);
+  align-items: center;
+  padding: rem(8px) 0;
+  border-bottom: 1px solid var(--line);
+}
+.blRow:last-child {
+  border-bottom: 0;
+}
+.blRank {
+  font-family: var(--mantine-font-family-monospace);
+  font-size: rem(11px);
+  color: var(--ink-3);
+  text-align: right;
+}
+.blMain {
+  min-width: 0;
+}
+.blTrack {
+  height: rem(4px);
+  border-radius: 999px;
+  background: rgba(150, 172, 200, 0.09);
+  margin-top: rem(5px);
+  overflow: hidden;
+}
+.blFill {
+  height: 100%;
+  border-radius: 999px;
+}
+.blFill.a {
+  background: var(--agg);
+}
+.blFill.d {
+  background: var(--def);
+}
+.blMatch {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ink);
+  font-size: rem(13px);
+}
+
+.blVal {
+  text-align: right;
+  white-space: nowrap;
+}
+.blValNum {
+  font-family: var(--mantine-font-family-monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: rem(14px);
+  font-weight: 650;
+  color: var(--ink);
+}
+.blValSub {
+  font-family: var(--mantine-font-family-monospace);
+  font-size: rem(10px);
+  color: var(--ink-3);
+}
+.blNote {
+  font-size: rem(11px);
+  color: var(--ink-3);
+  padding: rem(8px) 0 rem(4px);
+}
+
+/* ---- Controls ---- */
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--mantine-spacing-sm);
+  margin-bottom: var(--mantine-spacing-sm);
+}
+.controlsGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: rem(8px);
+}
+.resultCount {
+  font-family: var(--mantine-font-family-monospace);
+  font-size: rem(11px);
+  color: var(--ink-3);
+}
+
+/* ---- War list: rows (fixtures) ---- */
+.listCard {
+  border: 1px solid var(--line);
+  border-radius: var(--mantine-radius-sm);
+  background: var(--surface);
+  overflow: hidden;
+}
+.warRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(rem(132px), rem(208px)) minmax(
+      0,
+      1fr
+    );
+  gap: var(--mantine-spacing-md);
+  align-items: center;
+  padding: rem(11px) rem(14px);
+  border-bottom: 1px solid var(--line);
+  color: inherit;
+  text-decoration: none;
+}
+.warRow:last-child {
+  border-bottom: 0;
+}
+.warRow:hover {
+  background: rgba(150, 172, 200, 0.035);
+}
+.rowMid {
+  display: flex;
+  flex-direction: column;
+  gap: rem(5px);
+}
+.rowFigs {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--mantine-font-family-monospace);
+  font-variant-numeric: tabular-nums;
+  font-size: rem(11px);
+}
+.rowMeta {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: rem(4px) rem(12px);
+  font-family: var(--mantine-font-family-monospace);
+  font-size: rem(10.5px);
+  color: var(--ink-3);
+  padding-top: rem(1px);
+}
+.rowMeta .sep {
+  color: var(--line-2);
+}
+@media (max-width: 40em) {
+  .warRow {
+    grid-template-columns: 1fr;
+    gap: rem(8px);
+  }
+  .entity.right {
+    flex-direction: row;
+    text-align: left;
+  }
+}
+
+/* ---- War list: table (ledger) ---- */
+.tableScroll {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--mantine-radius-sm);
+  background: var(--surface);
+}
+.ledger {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: rem(660px);
+  font-size: rem(12.5px);
+}
+.ledger th {
+  font-family: var(--mantine-font-family-monospace);
+  font-size: rem(10px);
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  text-align: left;
+  padding: rem(8px) rem(10px);
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  background: var(--surface-2);
+}
+.ledger th.num {
+  text-align: right;
+}
+.ledger th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.ledger th.sortable:hover {
+  color: var(--ink-2);
+}
+.ledger th .car {
+  color: var(--def);
+  margin-left: rem(2px);
+}
+.ledger td {
+  padding: rem(7px) rem(10px);
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+.ledger tr:last-child td {
+  border-bottom: 0;
+}
+.ledger tbody tr:hover td {
+  background: rgba(150, 172, 200, 0.04);
+}
+.ledger td.num {
+  text-align: right;
+  font-family: var(--mantine-font-family-monospace);
+  font-variant-numeric: tabular-nums;
+}
+.ledger .balCell {
+  width: rem(104px);
+  min-width: rem(84px);
+}
+.ledger .nameCell {
+  max-width: rem(190px);
+}
+
+/* ---- Load more ---- */
+.moreWrap {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--mantine-spacing-md);
+}
+.empty {
+  padding: var(--mantine-spacing-xl);
+  text-align: center;
+  color: var(--ink-3);
+  font-size: rem(13px);
+}
+
+/* subtle view swap */
+.swap {
+  animation: warFade 0.16s ease;
+}
+@keyframes warFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .swap {
+    animation: none;
+  }
+}

--- a/apps/web/components/Wars/WarRoom/WarRoom.module.css
+++ b/apps/web/components/Wars/WarRoom/WarRoom.module.css
@@ -417,11 +417,23 @@
 .ledger th.num {
   text-align: right;
 }
-.ledger th.sortable {
+.sortBtn {
+  appearance: none;
+  background: none;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
   cursor: pointer;
   user-select: none;
+  display: inline-flex;
+  align-items: center;
+  gap: rem(2px);
 }
-.ledger th.sortable:hover {
+.sortBtn:hover {
   color: var(--ink-2);
 }
 .ledger th .car {

--- a/apps/web/components/Wars/WarRoom/WarRoom.tsx
+++ b/apps/web/components/Wars/WarRoom/WarRoom.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Container } from "@mantine/core";
+
+import type { WarRoomData } from "./types";
+import { Belligerents } from "./Belligerents";
+import { StatHeader } from "./StatHeader";
+import { WarList } from "./WarList";
+import classes from "./WarRoom.module.css";
+
+export function WarRoom({ data }: { data: WarRoomData }) {
+  const { stats, wars, topAggressors } = data;
+
+  return (
+    <Container size="lg" py="md" className={classes.root}>
+      <header className={classes.masthead}>
+        <h1 className={classes.title}>Active Wars</h1>
+        <span className={classes.subtitle}>
+          {stats.totalActive.toLocaleString()} ongoing across New Eden
+        </span>
+      </header>
+
+      <StatHeader stats={stats} />
+
+      <div className={classes.section}>
+        <Belligerents aggressors={topAggressors} wars={wars} />
+      </div>
+
+      <WarList wars={wars} />
+    </Container>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/WarRoom.tsx
+++ b/apps/web/components/Wars/WarRoom/WarRoom.tsx
@@ -8,7 +8,7 @@ import { StatHeader } from "./StatHeader";
 import { WarList } from "./WarList";
 import classes from "./WarRoom.module.css";
 
-export function WarRoom({ data }: { data: WarRoomData }) {
+export function WarRoom({ data }: Readonly<{ data: WarRoomData }>) {
   const { stats, wars, topAggressors } = data;
 
   return (

--- a/apps/web/components/Wars/WarRoom/WarRow.tsx
+++ b/apps/web/components/Wars/WarRoom/WarRow.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Fragment } from "react";
+
+import { WarAnchor } from "@jitaspace/ui";
+
+import type { WarRoomWar } from "./types";
+import { BalanceBar, IskFigure, StatusPill, WarEntity } from "./parts";
+import { allyCount, formatDuration } from "./utils";
+import classes from "./WarRoom.module.css";
+
+export function WarRow({ war }: { war: WarRoomWar }) {
+  const allies = allyCount(war);
+  const meta = [
+    `${war.aggressorShipsKilled}·${war.defenderShipsKilled} ships`,
+    war.status === "pending" ? "not started" : formatDuration(war.ageDays),
+    war.isMutual ? "mutual" : null,
+    war.isOpenForAllies ? "open for allies" : null,
+    allies > 0 ? `${allies} ${allies === 1 ? "ally" : "allies"}` : null,
+  ].filter(Boolean);
+
+  return (
+    <WarAnchor warId={war.warId} className={classes.warRow} underline="never">
+      <WarEntity
+        side="aggressor"
+        corporationId={war.aggressorCorporationId}
+        allianceId={war.aggressorAllianceId}
+      />
+      <div className={classes.rowMid}>
+        <div className={classes.rowFigs}>
+          <IskFigure war={war} side="aggressor" />
+          <span className={classes.dim}>ISK destroyed</span>
+          <IskFigure war={war} side="defender" />
+        </div>
+        <BalanceBar share={war.aggressorIskShare} />
+      </div>
+      <WarEntity
+        side="defender"
+        corporationId={war.defenderCorporationId}
+        allianceId={war.defenderAllianceId}
+        reversed
+      />
+      <div className={classes.rowMeta}>
+        <StatusPill status={war.status} />
+        {meta.map((item) => (
+          <Fragment key={item}>
+            <span className={classes.sep}>·</span>
+            <span>{item}</span>
+          </Fragment>
+        ))}
+      </div>
+    </WarAnchor>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/WarRow.tsx
+++ b/apps/web/components/Wars/WarRoom/WarRow.tsx
@@ -9,14 +9,15 @@ import { BalanceBar, IskFigure, StatusPill, WarEntity } from "./parts";
 import { allyCount, formatDuration } from "./utils";
 import classes from "./WarRoom.module.css";
 
-export function WarRow({ war }: { war: WarRoomWar }) {
+export function WarRow({ war }: Readonly<{ war: WarRoomWar }>) {
   const allies = allyCount(war);
+  const allyLabel = allies === 1 ? "ally" : "allies";
   const meta = [
     `${war.aggressorShipsKilled}·${war.defenderShipsKilled} ships`,
     war.status === "pending" ? "not started" : formatDuration(war.ageDays),
     war.isMutual ? "mutual" : null,
     war.isOpenForAllies ? "open for allies" : null,
-    allies > 0 ? `${allies} ${allies === 1 ? "ally" : "allies"}` : null,
+    allies > 0 ? `${allies} ${allyLabel}` : null,
   ].filter(Boolean);
 
   return (

--- a/apps/web/components/Wars/WarRoom/WarTable.tsx
+++ b/apps/web/components/Wars/WarRoom/WarTable.tsx
@@ -14,32 +14,31 @@ function SortableTh({
   sortKey,
   sortDir,
   onSort,
-}: {
+}: Readonly<{
   sortId: SortKey;
   label: string;
   sortKey: SortKey;
   sortDir: -1 | 1;
   onSort: (key: SortKey) => void;
-}) {
+}>) {
   const active = sortKey === sortId;
+  let ariaSort: "ascending" | "descending" | "none" = "none";
+  if (active) ariaSort = sortDir < 0 ? "descending" : "ascending";
+
+  // A real <button> keeps the header keyboard-accessible; aria-sort stays on the
+  // <th> (its native columnheader role supports it).
   return (
-    <th
-      className={cx(classes.num, classes.sortable)}
-      onClick={() => onSort(sortId)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          onSort(sortId);
-        }
-      }}
-      tabIndex={0}
-      role="button"
-      aria-sort={active ? (sortDir < 0 ? "descending" : "ascending") : "none"}
-    >
-      {label}
-      {active ? (
-        <span className={classes.car}>{sortDir < 0 ? "↓" : "↑"}</span>
-      ) : null}
+    <th className={classes.num} aria-sort={ariaSort}>
+      <button
+        type="button"
+        className={classes.sortBtn}
+        onClick={() => onSort(sortId)}
+      >
+        {label}
+        {active ? (
+          <span className={classes.car}>{sortDir < 0 ? "↓" : "↑"}</span>
+        ) : null}
+      </button>
     </th>
   );
 }
@@ -49,12 +48,12 @@ export function WarTable({
   sortKey,
   sortDir,
   onSort,
-}: {
+}: Readonly<{
   wars: WarRoomWar[];
   sortKey: SortKey;
   sortDir: -1 | 1;
   onSort: (key: SortKey) => void;
-}) {
+}>) {
   return (
     <div className={classes.tableScroll}>
       <table className={classes.ledger}>

--- a/apps/web/components/Wars/WarRoom/WarTable.tsx
+++ b/apps/web/components/Wars/WarRoom/WarTable.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { WarAnchor } from "@jitaspace/ui";
+
+import type { WarRoomWar } from "./types";
+import type { SortKey } from "./utils";
+import { BalanceBar, cx, IskFigure, StatusPill, WarEntity } from "./parts";
+import { formatDuration } from "./utils";
+import classes from "./WarRoom.module.css";
+
+function SortableTh({
+  sortId,
+  label,
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  sortId: SortKey;
+  label: string;
+  sortKey: SortKey;
+  sortDir: -1 | 1;
+  onSort: (key: SortKey) => void;
+}) {
+  const active = sortKey === sortId;
+  return (
+    <th
+      className={cx(classes.num, classes.sortable)}
+      onClick={() => onSort(sortId)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onSort(sortId);
+        }
+      }}
+      tabIndex={0}
+      role="button"
+      aria-sort={active ? (sortDir < 0 ? "descending" : "ascending") : "none"}
+    >
+      {label}
+      {active ? (
+        <span className={classes.car}>{sortDir < 0 ? "↓" : "↑"}</span>
+      ) : null}
+    </th>
+  );
+}
+
+export function WarTable({
+  wars,
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  wars: WarRoomWar[];
+  sortKey: SortKey;
+  sortDir: -1 | 1;
+  onSort: (key: SortKey) => void;
+}) {
+  return (
+    <div className={classes.tableScroll}>
+      <table className={classes.ledger}>
+        <thead>
+          <tr>
+            <th>War</th>
+            <th>Aggressor</th>
+            <SortableTh
+              sortId="isk"
+              label="ISK dealt"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            />
+            <th style={{ textAlign: "center" }}>Balance</th>
+            <th className={classes.num}>ISK dealt</th>
+            <th>Defender</th>
+            <SortableTh
+              sortId="ships"
+              label="Ships"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            />
+            <SortableTh
+              sortId="longest"
+              label="Age"
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={onSort}
+            />
+            <th>State</th>
+          </tr>
+        </thead>
+        <tbody>
+          {wars.map((war) => (
+            <tr key={war.warId}>
+              <td className={cx(classes.num, classes.dim)}>
+                <WarAnchor warId={war.warId} inherit>
+                  #{war.warId}
+                </WarAnchor>
+              </td>
+              <td className={classes.nameCell}>
+                <WarEntity
+                  side="aggressor"
+                  corporationId={war.aggressorCorporationId}
+                  allianceId={war.aggressorAllianceId}
+                  size={18}
+                  linked
+                />
+              </td>
+              <td className={classes.num}>
+                <IskFigure war={war} side="aggressor" />
+              </td>
+              <td className={classes.balCell}>
+                <BalanceBar share={war.aggressorIskShare} height={5} />
+              </td>
+              <td className={classes.num}>
+                <IskFigure war={war} side="defender" />
+              </td>
+              <td className={classes.nameCell}>
+                <WarEntity
+                  side="defender"
+                  corporationId={war.defenderCorporationId}
+                  allianceId={war.defenderAllianceId}
+                  size={18}
+                  linked
+                />
+              </td>
+              <td className={classes.num}>
+                {war.aggressorShipsKilled}·{war.defenderShipsKilled}
+              </td>
+              <td className={classes.num}>{formatDuration(war.ageDays)}</td>
+              <td>
+                <StatusPill status={war.status} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/index.ts
+++ b/apps/web/components/Wars/WarRoom/index.ts
@@ -1,0 +1,8 @@
+export { WarRoom } from "./WarRoom";
+export type {
+  WarRoomAggressor,
+  WarRoomData,
+  WarRoomStats,
+  WarRoomWar,
+  WarStatus,
+} from "./types";

--- a/apps/web/components/Wars/WarRoom/parts.tsx
+++ b/apps/web/components/Wars/WarRoom/parts.tsx
@@ -26,39 +26,38 @@ export function WarEntity({
   size = 20,
   reversed = false,
   linked = false,
-}: {
+}: Readonly<{
   side: "aggressor" | "defender";
   corporationId?: number;
   allianceId?: number;
   size?: number;
   reversed?: boolean;
   linked?: boolean;
-}) {
+}>) {
+  const isAlliance = allianceId != null;
   const ring = cx(
     classes.avatarRing,
     side === "aggressor" ? classes.agg : classes.def,
   );
 
-  const avatar =
-    allianceId != null ? (
-      <AllianceAvatar allianceId={allianceId} size={size} className={ring} />
-    ) : (
-      <CorporationAvatar
-        corporationId={corporationId}
-        size={size}
-        className={ring}
-      />
-    );
+  const avatar = isAlliance ? (
+    <AllianceAvatar allianceId={allianceId} size={size} className={ring} />
+  ) : (
+    <CorporationAvatar
+      corporationId={corporationId}
+      size={size}
+      className={ring}
+    />
+  );
 
-  const rawName =
-    allianceId != null ? (
-      <AllianceName allianceId={allianceId} className={classes.entityName} />
-    ) : (
-      <CorporationName
-        corporationId={corporationId}
-        className={classes.entityName}
-      />
-    );
+  const rawName = isAlliance ? (
+    <AllianceName allianceId={allianceId} className={classes.entityName} />
+  ) : (
+    <CorporationName
+      corporationId={corporationId}
+      className={classes.entityName}
+    />
+  );
 
   let name = rawName;
   if (linked && allianceId != null) {
@@ -95,10 +94,10 @@ export function WarEntity({
 export function BalanceBar({
   share,
   height,
-}: {
+}: Readonly<{
   share: number | null;
   height?: number;
-}) {
+}>) {
   const style: CSSProperties | undefined = height ? { height } : undefined;
   if (share === null) {
     return <span className={cx(classes.bal, classes.empty)} style={style} />;
@@ -115,15 +114,18 @@ export function BalanceBar({
 export function IskFigure({
   war,
   side,
-}: {
+}: Readonly<{
   war: WarRoomWar;
   side: "aggressor" | "defender";
-}) {
+}>) {
   const lead = leadingSide(war);
   const value =
     side === "aggressor" ? war.aggressorIskDestroyed : war.defenderIskDestroyed;
-  const emphasis =
-    lead === side ? classes.lead : lead ? classes.figDim : undefined;
+
+  let emphasis: string | undefined;
+  if (lead === side) emphasis = classes.lead;
+  else if (lead) emphasis = classes.figDim;
+
   return (
     <span
       className={cx(
@@ -143,7 +145,7 @@ export function statusDotClass(status: WarStatus): string | undefined {
   return classes.dotActive;
 }
 
-export function StatusPill({ status }: { status: WarStatus }) {
+export function StatusPill({ status }: Readonly<{ status: WarStatus }>) {
   return (
     <span className={classes.state}>
       <span className={cx(classes.dot, statusDotClass(status))} />

--- a/apps/web/components/Wars/WarRoom/parts.tsx
+++ b/apps/web/components/Wars/WarRoom/parts.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import type { CSSProperties } from "react";
+
+import { AllianceName, CorporationName } from "@jitaspace/eve-components";
+import {
+  AllianceAnchor,
+  AllianceAvatar,
+  CorporationAnchor,
+  CorporationAvatar,
+} from "@jitaspace/ui";
+
+import type { WarRoomWar, WarStatus } from "./types";
+import { formatIskCompact, leadingSide, STATUS_LABEL } from "./utils";
+import classes from "./WarRoom.module.css";
+
+export function cx(...values: (string | false | undefined | null)[]): string {
+  return values.filter(Boolean).join(" ");
+}
+
+/** Small logo + name for one belligerent. `side` tints the logo ring. */
+export function WarEntity({
+  side,
+  corporationId,
+  allianceId,
+  size = 20,
+  reversed = false,
+  linked = false,
+}: {
+  side: "aggressor" | "defender";
+  corporationId?: number;
+  allianceId?: number;
+  size?: number;
+  reversed?: boolean;
+  linked?: boolean;
+}) {
+  const ring = cx(
+    classes.avatarRing,
+    side === "aggressor" ? classes.agg : classes.def,
+  );
+
+  const avatar =
+    allianceId != null ? (
+      <AllianceAvatar allianceId={allianceId} size={size} className={ring} />
+    ) : (
+      <CorporationAvatar
+        corporationId={corporationId}
+        size={size}
+        className={ring}
+      />
+    );
+
+  const rawName =
+    allianceId != null ? (
+      <AllianceName allianceId={allianceId} className={classes.entityName} />
+    ) : (
+      <CorporationName
+        corporationId={corporationId}
+        className={classes.entityName}
+      />
+    );
+
+  let name = rawName;
+  if (linked && allianceId != null) {
+    name = (
+      <AllianceAnchor
+        allianceId={allianceId}
+        inherit
+        className={classes.entityName}
+      >
+        {rawName}
+      </AllianceAnchor>
+    );
+  } else if (linked && corporationId != null) {
+    name = (
+      <CorporationAnchor
+        corporationId={corporationId}
+        inherit
+        className={classes.entityName}
+      >
+        {rawName}
+      </CorporationAnchor>
+    );
+  }
+
+  return (
+    <span className={cx(classes.entity, reversed && classes.right)}>
+      {avatar}
+      {name}
+    </span>
+  );
+}
+
+/** Proportional ISK-destroyed split. `share` = aggressor's fraction, or null. */
+export function BalanceBar({
+  share,
+  height,
+}: {
+  share: number | null;
+  height?: number;
+}) {
+  const style: CSSProperties | undefined = height ? { height } : undefined;
+  if (share === null) {
+    return <span className={cx(classes.bal, classes.empty)} style={style} />;
+  }
+  return (
+    <span className={classes.bal} style={style}>
+      <span className={classes.a} style={{ width: `${share * 100}%` }} />
+      <span className={classes.d} style={{ width: `${(1 - share) * 100}%` }} />
+    </span>
+  );
+}
+
+/** One side's ISK-destroyed figure; the leading side is emphasised. */
+export function IskFigure({
+  war,
+  side,
+}: {
+  war: WarRoomWar;
+  side: "aggressor" | "defender";
+}) {
+  const lead = leadingSide(war);
+  const value =
+    side === "aggressor" ? war.aggressorIskDestroyed : war.defenderIskDestroyed;
+  const emphasis =
+    lead === side ? classes.lead : lead ? classes.figDim : undefined;
+  return (
+    <span
+      className={cx(
+        classes.mono,
+        side === "aggressor" ? classes.figA : classes.figD,
+        emphasis,
+      )}
+    >
+      {formatIskCompact(value)}
+    </span>
+  );
+}
+
+export function statusDotClass(status: WarStatus): string | undefined {
+  if (status === "pending") return classes.dotStarting;
+  if (status === "retracting") return classes.dotEnding;
+  return classes.dotActive;
+}
+
+export function StatusPill({ status }: { status: WarStatus }) {
+  return (
+    <span className={classes.state}>
+      <span className={cx(classes.dot, statusDotClass(status))} />
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/apps/web/components/Wars/WarRoom/types.ts
+++ b/apps/web/components/Wars/WarRoom/types.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared types for the Active Wars view.
+ *
+ * The server (active-wars/page.tsx) reads raw wars from the local database and
+ * enriches each with a handful of derived, deterministic fields (status, totals,
+ * ISK share) so the client can render, sort and filter without recomputing
+ * anything time-sensitive (which would risk hydration mismatches). All dates
+ * cross the server→client boundary as ISO strings.
+ *
+ * Lifecycle terms shown to users: pending → "Starting", active → "Active",
+ * retracting → "Ending". A retracting war is still shooting until it finishes.
+ */
+
+export type WarStatus = "pending" | "active" | "retracting";
+
+export interface WarRoomWar {
+  warId: number;
+
+  // Belligerents — exactly one of corporation/alliance id is set per side.
+  aggressorCorporationId?: number;
+  aggressorAllianceId?: number;
+  aggressorIskDestroyed: number;
+  aggressorShipsKilled: number;
+  defenderCorporationId?: number;
+  defenderAllianceId?: number;
+  defenderIskDestroyed: number;
+  defenderShipsKilled: number;
+
+  allianceAllies: number[];
+  corporationAllies: number[];
+
+  declaredDate: string;
+  startedDate?: string;
+  finishedDate?: string;
+  retractedDate?: string;
+  isMutual: boolean;
+  isOpenForAllies: boolean;
+  updatedAt: string;
+
+  // ---- Derived (computed server-side, frozen at cache time) ----
+  status: WarStatus;
+  /** aggressorIskDestroyed + defenderIskDestroyed (ISK value both sides wrecked) */
+  totalIskDestroyed: number;
+  /** aggressorShipsKilled + defenderShipsKilled */
+  totalShipsKilled: number;
+  /** How long the war has been shooting, in days (0 while still starting). */
+  ageDays: number;
+  /** Aggressor's share (0–1) of total ISK destroyed, or null if no combat yet. */
+  aggressorIskShare: number | null;
+}
+
+/** A belligerent aggregated across every war it is currently prosecuting. */
+export interface WarRoomAggressor {
+  corporationId?: number;
+  allianceId?: number;
+  warCount: number;
+  iskDestroyed: number;
+  shipsKilled: number;
+}
+
+export interface WarRoomStats {
+  totalActive: number;
+  /** Shooting now (started, not winding down). */
+  activeCount: number;
+  /** Declared but not yet shooting (24h prep). */
+  startingCount: number;
+  /** One side has withdrawn — still shooting until it finishes. */
+  endingCount: number;
+  mutualCount: number;
+  openForAlliesCount: number;
+  totalIskDestroyed: number;
+  totalShipsKilled: number;
+  /** Wars with at least one kill on record. */
+  warsWithCombat: number;
+  declaredLast24h: number;
+  declaredLast7d: number;
+  /** When this snapshot was computed (ISO). */
+  generatedAt: string;
+}
+
+export interface WarRoomData {
+  stats: WarRoomStats;
+  wars: WarRoomWar[];
+  topAggressors: WarRoomAggressor[];
+}

--- a/apps/web/components/Wars/WarRoom/utils.ts
+++ b/apps/web/components/Wars/WarRoom/utils.ts
@@ -1,0 +1,137 @@
+import type { WarRoomWar, WarStatus } from "./types";
+
+/** Compact ISK formatter mirroring the shared <ISKAmount> component's scale. */
+export function formatIskCompact(amount: number): string {
+  const lookup = [
+    { value: 1e12, symbol: "T" },
+    { value: 1e9, symbol: "B" },
+    { value: 1e6, symbol: "M" },
+    { value: 1e3, symbol: "K" },
+  ];
+  const abs = Math.abs(amount);
+  const item = lookup.find((entry) => abs >= entry.value);
+  if (!item) return Math.round(amount).toString();
+  const rx = /\.0+$|(\.\d*[1-9])0+$/;
+  return (amount / item.value).toFixed(1).replace(rx, "$1") + item.symbol;
+}
+
+export function formatCompactNumber(value: number): string {
+  return Math.round(value).toLocaleString();
+}
+
+/** Human "12d 4h" / "9h" duration from a fractional number of days. */
+export function formatDuration(days: number): string {
+  if (days <= 0) return "—";
+  if (days < 1) {
+    const hours = Math.max(1, Math.round(days * 24));
+    return `${hours}h`;
+  }
+  const whole = Math.floor(days);
+  const hours = Math.round((days - whole) * 24);
+  return hours > 0 ? `${whole}d ${hours}h` : `${whole}d`;
+}
+
+/** Plain-English lifecycle labels. */
+export const STATUS_LABEL: Record<WarStatus, string> = {
+  pending: "Starting",
+  active: "Active",
+  retracting: "Ending",
+};
+
+/** The side dealing more damage, or null when nothing has died / it's even. */
+export function leadingSide(war: WarRoomWar): "aggressor" | "defender" | null {
+  if (war.aggressorIskShare === null) return null;
+  if (war.aggressorIskDestroyed === war.defenderIskDestroyed) return null;
+  return war.aggressorIskShare > 0.5 ? "aggressor" : "defender";
+}
+
+export function allyCount(war: WarRoomWar): number {
+  return war.allianceAllies.length + war.corporationAllies.length;
+}
+
+export function warHasCombat(war: WarRoomWar): boolean {
+  return war.totalShipsKilled > 0 || war.totalIskDestroyed > 0;
+}
+
+/* ---- Filtering ---- */
+
+export type StatusFilter = "all" | "active" | "starting" | "ending";
+
+export const STATUS_FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "starting", label: "Starting" },
+  { value: "ending", label: "Ending" },
+];
+
+export interface WarFilters {
+  status: StatusFilter;
+  combat: boolean;
+  mutual: boolean;
+  open: boolean;
+}
+
+function matchesStatus(war: WarRoomWar, filter: StatusFilter): boolean {
+  switch (filter) {
+    case "active":
+      return war.status === "active";
+    case "starting":
+      return war.status === "pending";
+    case "ending":
+      return war.status === "retracting";
+    default:
+      return true;
+  }
+}
+
+export function filterWars(wars: WarRoomWar[], f: WarFilters): WarRoomWar[] {
+  return wars.filter(
+    (war) =>
+      matchesStatus(war, f.status) &&
+      (!f.combat || warHasCombat(war)) &&
+      (!f.mutual || war.isMutual) &&
+      (!f.open || war.isOpenForAllies),
+  );
+}
+
+/* ---- Sorting (shared by the dropdown and the table headers) ---- */
+
+export type SortKey = "isk" | "ships" | "newest" | "longest" | "allies";
+
+export const SORT_OPTIONS: { value: SortKey; label: string }[] = [
+  { value: "isk", label: "ISK destroyed" },
+  { value: "ships", label: "Ships killed" },
+  { value: "newest", label: "Newest" },
+  { value: "longest", label: "Longest running" },
+  { value: "allies", label: "Most allies" },
+];
+
+function sortValue(war: WarRoomWar, key: SortKey): number {
+  switch (key) {
+    case "ships":
+      return war.totalShipsKilled;
+    case "newest":
+      return new Date(war.declaredDate).getTime();
+    case "longest":
+      return war.ageDays;
+    case "allies":
+      return allyCount(war);
+    case "isk":
+    default:
+      return war.totalIskDestroyed;
+  }
+}
+
+/** dir = -1 → high/new first (default); dir = 1 → reversed. */
+export function sortWars(
+  wars: WarRoomWar[],
+  key: SortKey,
+  dir: -1 | 1 = -1,
+): WarRoomWar[] {
+  const flip = dir === -1 ? 1 : -1;
+  return [...wars].sort(
+    (a, b) =>
+      (sortValue(b, key) - sortValue(a, key)) * flip ||
+      b.totalIskDestroyed - a.totalIskDestroyed,
+  );
+}

--- a/apps/web/components/Wars/index.ts
+++ b/apps/web/components/Wars/index.ts
@@ -1,1 +1,3 @@
 export * from "./WarsTable.tsx";
+export * from "./WarRoom";
+export * from "./ActiveWarsView";

--- a/apps/web/lib/preferences.ts
+++ b/apps/web/lib/preferences.ts
@@ -8,6 +8,7 @@ export const PREFERENCES_STORAGE_KEY = "jitaspace.preferences";
 export const DEFAULT_ESI_ACCEPT_LANGUAGE = "en";
 export const DEFAULT_APP_THEME = "default";
 export const DEFAULT_EXPERIMENTAL_DATA_TABLES = false;
+export const DEFAULT_EXPERIMENTAL_ACTIVE_WARS = false;
 
 export const ESI_ACCEPT_LANGUAGE_OPTIONS = [
   { languageCode: "en", label: "English", countryCode: "GB" },
@@ -39,9 +40,11 @@ interface PreferencesState {
   esiAcceptLanguage: EsiAcceptLanguage;
   appTheme: AppTheme;
   experimentalDataTables: boolean;
+  experimentalActiveWars: boolean;
   setEsiAcceptLanguage: (value: EsiAcceptLanguage) => void;
   setAppTheme: (value: AppTheme) => void;
   setExperimentalDataTables: (value: boolean) => void;
+  setExperimentalActiveWars: (value: boolean) => void;
 }
 
 export const sanitizeAppTheme = (
@@ -80,10 +83,13 @@ export const usePreferencesStore = create<PreferencesState>()(
       esiAcceptLanguage: DEFAULT_ESI_ACCEPT_LANGUAGE,
       appTheme: DEFAULT_APP_THEME,
       experimentalDataTables: DEFAULT_EXPERIMENTAL_DATA_TABLES,
+      experimentalActiveWars: DEFAULT_EXPERIMENTAL_ACTIVE_WARS,
       setEsiAcceptLanguage: (value) => set({ esiAcceptLanguage: value }),
       setAppTheme: (value) => set({ appTheme: value }),
       setExperimentalDataTables: (value) =>
         set({ experimentalDataTables: value }),
+      setExperimentalActiveWars: (value) =>
+        set({ experimentalActiveWars: value }),
     }),
     {
       name: PREFERENCES_STORAGE_KEY,
@@ -101,6 +107,10 @@ export const usePreferencesStore = create<PreferencesState>()(
             typeof persisted.experimentalDataTables === "boolean"
               ? persisted.experimentalDataTables
               : DEFAULT_EXPERIMENTAL_DATA_TABLES,
+          experimentalActiveWars:
+            typeof persisted.experimentalActiveWars === "boolean"
+              ? persisted.experimentalActiveWars
+              : DEFAULT_EXPERIMENTAL_ACTIVE_WARS,
         };
       },
     },

--- a/apps/web/tests/activeWarsData.test.ts
+++ b/apps/web/tests/activeWarsData.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { WarRoomData } from "~/components/Wars/WarRoom/types";
+
+// data.ts reads wars from the DB-backed prisma client; stub it so we can drive
+// the pure enrichment/aggregation with fixed rows. next/cache is stubbed globally
+// (moduleNameMapper) so the "use cache" directive is inert here.
+const mockFindMany = jest.fn<() => Promise<unknown[]>>();
+jest.mock("~/lib/db", () => ({
+  prisma: { war: { findMany: (...args: unknown[]) => mockFindMany(...args) } },
+}));
+
+const DAY = 86_400_000;
+const now = Date.now();
+const d = (offsetDays: number) => new Date(now + offsetDays * DAY);
+
+interface RawWar {
+  warId: number;
+  aggressorCorporationId: number | null;
+  aggressorAllianceId: number | null;
+  aggressorIskDestroyed: number;
+  aggressorShipsKilled: number;
+  allianceAllies: { allianceId: number }[];
+  corporationAllies: { corporationId: number }[];
+  declaredDate: Date;
+  defenderCorporationId: number | null;
+  defenderAllianceId: number | null;
+  defenderIskDestroyed: number;
+  defenderShipsKilled: number;
+  startedDate: Date | null;
+  finishedDate: Date | null;
+  isMutual: boolean;
+  isOpenForAllies: boolean;
+  retractedDate: Date | null;
+  updatedAt: Date;
+}
+
+function rawWar(overrides: Partial<RawWar>): RawWar {
+  return {
+    warId: 0,
+    aggressorCorporationId: null,
+    aggressorAllianceId: null,
+    aggressorIskDestroyed: 0,
+    aggressorShipsKilled: 0,
+    allianceAllies: [],
+    corporationAllies: [],
+    declaredDate: d(-3),
+    defenderCorporationId: null,
+    defenderAllianceId: null,
+    defenderIskDestroyed: 0,
+    defenderShipsKilled: 0,
+    startedDate: d(-5),
+    finishedDate: null,
+    isMutual: false,
+    isOpenForAllies: false,
+    retractedDate: null,
+    updatedAt: d(-1),
+    ...overrides,
+  };
+}
+
+const RAW: RawWar[] = [
+  // 1 — active, alliance aggressor leading, mutual, open, allies, combat
+  rawWar({
+    warId: 1,
+    aggressorAllianceId: 1001,
+    aggressorIskDestroyed: 100e9,
+    aggressorShipsKilled: 100,
+    defenderCorporationId: 2001,
+    defenderIskDestroyed: 40e9,
+    defenderShipsKilled: 40,
+    startedDate: d(-10),
+    finishedDate: d(30),
+    declaredDate: d(-10),
+    isMutual: true,
+    isOpenForAllies: true,
+    allianceAllies: [{ allianceId: 3001 }],
+    corporationAllies: [{ corporationId: 3002 }],
+  }),
+  // 2 — active, corp aggressor, defender leading, declared within 24h
+  rawWar({
+    warId: 2,
+    aggressorCorporationId: 1002,
+    aggressorIskDestroyed: 20e9,
+    aggressorShipsKilled: 20,
+    defenderAllianceId: 2002,
+    defenderIskDestroyed: 80e9,
+    defenderShipsKilled: 80,
+    startedDate: d(-2),
+    declaredDate: d(-0.5),
+  }),
+  // 3 — starting (no start date), no combat
+  rawWar({
+    warId: 3,
+    aggressorCorporationId: 1003,
+    defenderCorporationId: 2003,
+    startedDate: null,
+    declaredDate: d(-3),
+  }),
+  // 4 — starting (start date in the future)
+  rawWar({
+    warId: 4,
+    aggressorCorporationId: 1004,
+    defenderCorporationId: 2004,
+    startedDate: d(1),
+    declaredDate: d(-3),
+  }),
+  // 5 — ending (retracted in the past), even combat
+  rawWar({
+    warId: 5,
+    aggressorAllianceId: 1005,
+    aggressorIskDestroyed: 5e9,
+    aggressorShipsKilled: 5,
+    defenderCorporationId: 2005,
+    defenderIskDestroyed: 5e9,
+    defenderShipsKilled: 5,
+    startedDate: d(-20),
+    retractedDate: d(-1),
+    declaredDate: d(-10),
+  }),
+  // 6 — active, no combat
+  rawWar({
+    warId: 6,
+    aggressorCorporationId: 1006,
+    defenderCorporationId: 2006,
+    startedDate: d(-5),
+    declaredDate: d(-10),
+  }),
+  // 7 — aggressor with neither corp nor alliance id (skipped in leaderboard)
+  rawWar({
+    warId: 7,
+    defenderCorporationId: 2007,
+    startedDate: d(-1),
+    declaredDate: d(-3),
+  }),
+  // 8 — second war for alliance 1001 (grouping + tiebreak)
+  rawWar({
+    warId: 8,
+    aggressorAllianceId: 1001,
+    aggressorIskDestroyed: 10e9,
+    aggressorShipsKilled: 10,
+    defenderCorporationId: 2008,
+    startedDate: d(-1),
+    declaredDate: d(-0.4),
+  }),
+];
+
+function load(): Promise<WarRoomData> {
+  const { getWarRoomData } = require("~/app/active-wars/data");
+  return getWarRoomData();
+}
+
+describe("getWarRoomData", () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockFindMany.mockResolvedValue(RAW);
+  });
+
+  it("derives lifecycle status for every war", async () => {
+    const { wars } = await load();
+    const byId = Object.fromEntries(
+      wars.map((w: { warId: number }) => [w.warId, w]),
+    );
+    expect(byId[1].status).toBe("active");
+    expect(byId[3].status).toBe("pending"); // no start date
+    expect(byId[4].status).toBe("pending"); // future start date
+    expect(byId[5].status).toBe("retracting"); // retracted in the past
+    expect(byId[6].status).toBe("active");
+  });
+
+  it("enriches totals, ISK share, age and allies", async () => {
+    const { wars } = await load();
+    const byId = Object.fromEntries(
+      wars.map((w: { warId: number }) => [w.warId, w]),
+    );
+
+    // war 1: 140B destroyed, aggressor share 100/140
+    expect(byId[1].totalIskDestroyed).toBe(140e9);
+    expect(byId[1].totalShipsKilled).toBe(140);
+    expect(byId[1].aggressorIskShare).toBeCloseTo(100 / 140, 5);
+    expect(byId[1].ageDays).toBeGreaterThan(9);
+    expect(byId[1].allianceAllies).toEqual([3001]);
+    expect(byId[1].corporationAllies).toEqual([3002]);
+    expect(byId[1].aggressorAllianceId).toBe(1001);
+    expect(byId[1].aggressorCorporationId).toBeUndefined();
+
+    // starting war: no age, no combat share
+    expect(byId[3].ageDays).toBe(0);
+    expect(byId[3].aggressorIskShare).toBeNull();
+
+    // dates are serialised to ISO strings
+    expect(typeof byId[1].declaredDate).toBe("string");
+  });
+
+  it("sorts wars by total ISK destroyed and drops hotspots", async () => {
+    const data = await load();
+    expect(data.wars[0].warId).toBe(1); // 140B is the largest
+    expect("hotspots" in data).toBe(false);
+  });
+
+  it("computes aggregate stats", async () => {
+    const { stats } = await load();
+    expect(stats.totalActive).toBe(8);
+    expect(stats.activeCount).toBe(5); // 1,2,6,7,8
+    expect(stats.startingCount).toBe(2); // 3,4
+    expect(stats.endingCount).toBe(1); // 5
+    expect(stats.mutualCount).toBe(1);
+    expect(stats.openForAlliesCount).toBe(1);
+    expect(stats.warsWithCombat).toBe(4); // 1,2,5,8
+    expect(stats.totalIskDestroyed).toBe(260e9);
+    expect(stats.totalShipsKilled).toBe(260);
+    expect(stats.declaredLast24h).toBe(2); // 2,8
+    expect(stats.declaredLast7d).toBe(5); // 2,3,4,7,8
+    expect(typeof stats.generatedAt).toBe("string");
+  });
+
+  it("builds the aggressor leaderboard, grouping and skipping id-less sides", async () => {
+    const { topAggressors } = await load();
+    // alliance 1001 prosecutes wars 1 and 8 → top by war count
+    expect(topAggressors[0]).toMatchObject({
+      allianceId: 1001,
+      warCount: 2,
+      iskDestroyed: 110e9,
+    });
+    // war 7 has no aggressor id → excluded, so 6 distinct aggressors remain
+    expect(topAggressors).toHaveLength(6);
+    expect(
+      topAggressors.every(
+        (a: { corporationId?: number; allianceId?: number }) =>
+          a.corporationId != null || a.allianceId != null,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns an empty aggregate for no wars", async () => {
+    mockFindMany.mockResolvedValue([]);
+    const data = await load();
+    expect(data.wars).toEqual([]);
+    expect(data.topAggressors).toEqual([]);
+    expect(data.stats.totalActive).toBe(0);
+  });
+});

--- a/apps/web/tests/activeWarsView.test.tsx
+++ b/apps/web/tests/activeWarsView.test.tsx
@@ -1,0 +1,122 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+import type { WarRoomData, WarRoomWar } from "~/components/Wars/WarRoom";
+
+const passThroughProxy = () => {
+  const React = require("react");
+  const passThrough = ({ children }: { children?: unknown }) =>
+    children == null
+      ? null
+      : React.createElement(React.Fragment, null, children);
+  return new Proxy({}, { get: () => passThrough });
+};
+jest.mock("@jitaspace/ui", () => passThroughProxy());
+jest.mock("@jitaspace/eve-components", () => passThroughProxy());
+jest.mock(
+  "@jitaspace/eve-icons",
+  () => new Proxy({}, { get: () => () => null }),
+);
+
+function war(overrides: Partial<WarRoomWar>): WarRoomWar {
+  const iso = new Date("2026-06-01T00:00:00Z").toISOString();
+  return {
+    warId: 1,
+    aggressorIskDestroyed: 0,
+    aggressorShipsKilled: 0,
+    defenderIskDestroyed: 0,
+    defenderShipsKilled: 0,
+    allianceAllies: [],
+    corporationAllies: [],
+    declaredDate: iso,
+    startedDate: iso,
+    finishedDate: undefined,
+    retractedDate: undefined,
+    isMutual: false,
+    isOpenForAllies: false,
+    updatedAt: iso,
+    status: "active",
+    totalIskDestroyed: 0,
+    totalShipsKilled: 0,
+    ageDays: 3,
+    aggressorIskShare: null,
+    ...overrides,
+  };
+}
+
+const DATA: WarRoomData = {
+  stats: {
+    totalActive: 2,
+    activeCount: 2,
+    startingCount: 0,
+    endingCount: 0,
+    mutualCount: 0,
+    openForAlliesCount: 0,
+    totalIskDestroyed: 5e9,
+    totalShipsKilled: 3,
+    warsWithCombat: 1,
+    declaredLast24h: 0,
+    declaredLast7d: 2,
+    generatedAt: new Date("2026-06-05T00:00:00Z").toISOString(),
+  },
+  wars: [
+    war({
+      warId: 1,
+      aggressorCorporationId: 111,
+      defenderAllianceId: 222,
+      aggressorIskDestroyed: 5e9,
+      aggressorShipsKilled: 3,
+      totalIskDestroyed: 5e9,
+      totalShipsKilled: 3,
+      aggressorIskShare: 1,
+      // all optional dates set → exercises the toTableWar date branches
+      finishedDate: new Date("2026-07-01T00:00:00Z").toISOString(),
+      retractedDate: new Date("2026-06-20T00:00:00Z").toISOString(),
+    }),
+    war({
+      warId: 2,
+      aggressorCorporationId: 333,
+      defenderCorporationId: 444,
+      startedDate: undefined,
+      status: "pending",
+    }),
+  ],
+  topAggressors: [
+    { corporationId: 111, warCount: 1, iskDestroyed: 5e9, shipsKilled: 3 },
+  ],
+};
+
+function renderView(experimental: boolean) {
+  const { usePreferencesStore } = require("~/lib/preferences");
+  usePreferencesStore.setState({ experimentalActiveWars: experimental });
+  const { ActiveWarsView } = require("~/components/Wars/ActiveWarsView");
+  return render(
+    <MantineProvider>
+      <ActiveWarsView data={DATA} />
+    </MantineProvider>,
+  );
+}
+
+afterEach(() => {
+  const { usePreferencesStore } = require("~/lib/preferences");
+  usePreferencesStore.setState({ experimentalActiveWars: false });
+});
+
+describe("ActiveWarsView feature gate", () => {
+  it("renders the classic table when the flag is off", () => {
+    renderView(false);
+    expect(screen.getByText(/Active Wars \(2\)/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("Most active aggressors"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the new overview when the flag is on", () => {
+    renderView(true);
+    expect(screen.getByText("Most active aggressors")).toBeInTheDocument();
+    expect(screen.queryByText(/Active Wars \(2\)/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/preferencesActiveWars.test.ts
+++ b/apps/web/tests/preferencesActiveWars.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
+
+import {
+  DEFAULT_EXPERIMENTAL_ACTIVE_WARS,
+  usePreferencesStore,
+} from "~/lib/preferences";
+
+describe("experimentalActiveWars preference", () => {
+  beforeEach(() => {
+    usePreferencesStore.setState({
+      experimentalActiveWars: DEFAULT_EXPERIMENTAL_ACTIVE_WARS,
+    });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    usePreferencesStore.setState({ experimentalActiveWars: false });
+  });
+
+  it("defaults to off", () => {
+    expect(DEFAULT_EXPERIMENTAL_ACTIVE_WARS).toBe(false);
+    expect(usePreferencesStore.getState().experimentalActiveWars).toBe(false);
+  });
+
+  it("updates through the setter", () => {
+    usePreferencesStore.getState().setExperimentalActiveWars(true);
+    expect(usePreferencesStore.getState().experimentalActiveWars).toBe(true);
+  });
+
+  it("rehydrates a valid persisted value and falls back on an invalid one", async () => {
+    localStorage.setItem(
+      "jitaspace.preferences",
+      JSON.stringify({ state: { experimentalActiveWars: true }, version: 0 }),
+    );
+    await usePreferencesStore.persist.rehydrate();
+    expect(usePreferencesStore.getState().experimentalActiveWars).toBe(true);
+
+    localStorage.setItem(
+      "jitaspace.preferences",
+      JSON.stringify({
+        state: { experimentalActiveWars: "yes-please" },
+        version: 0,
+      }),
+    );
+    await usePreferencesStore.persist.rehydrate();
+    expect(usePreferencesStore.getState().experimentalActiveWars).toBe(false);
+  });
+});

--- a/apps/web/tests/settingsCard.test.tsx
+++ b/apps/web/tests/settingsCard.test.tsx
@@ -195,4 +195,26 @@ describe("SettingsCard", () => {
     fireEvent.click(toggle);
     expect(usePreferencesStore.getState().experimentalDataTables).toBe(true);
   });
+
+  it("toggles the new Active Wars page from the Experimental tab", async () => {
+    usePreferencesStore.setState({ experimentalActiveWars: false });
+
+    const { SettingsCard } = require("~/components/Settings/SettingsCard");
+
+    render(
+      <AppMantineProvider>
+        <SettingsCard />
+      </AppMantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Experimental" }));
+
+    const toggle = await screen.findByLabelText(
+      "Enable the new Active Wars page",
+    );
+    expect(toggle).not.toBeChecked();
+
+    fireEvent.click(toggle);
+    expect(usePreferencesStore.getState().experimentalActiveWars).toBe(true);
+  });
 });

--- a/apps/web/tests/warRoom.test.tsx
+++ b/apps/web/tests/warRoom.test.tsx
@@ -1,0 +1,251 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import type { WarRoomData, WarRoomWar } from "~/components/Wars/WarRoom";
+
+// The EVE "smart" components fetch data; stub every export to a pass-through so
+// the war rows/table/leaderboards render deterministically. eve-icons → null.
+const passThroughProxy = () => {
+  const React = require("react");
+  const passThrough = ({ children }: { children?: unknown }) =>
+    children == null
+      ? null
+      : React.createElement(React.Fragment, null, children);
+  return new Proxy({}, { get: () => passThrough });
+};
+jest.mock("@jitaspace/ui", () => passThroughProxy());
+jest.mock("@jitaspace/eve-components", () => passThroughProxy());
+jest.mock(
+  "@jitaspace/eve-icons",
+  () => new Proxy({}, { get: () => () => null }),
+);
+
+function war(overrides: Partial<WarRoomWar> = {}): WarRoomWar {
+  const iso = new Date("2026-06-01T00:00:00Z").toISOString();
+  return {
+    warId: 1,
+    aggressorIskDestroyed: 0,
+    aggressorShipsKilled: 0,
+    defenderIskDestroyed: 0,
+    defenderShipsKilled: 0,
+    allianceAllies: [],
+    corporationAllies: [],
+    declaredDate: iso,
+    isMutual: false,
+    isOpenForAllies: false,
+    updatedAt: iso,
+    status: "active",
+    totalIskDestroyed: 0,
+    totalShipsKilled: 0,
+    ageDays: 3,
+    aggressorIskShare: null,
+    ...overrides,
+  };
+}
+
+function richData(): WarRoomData {
+  const wars: WarRoomWar[] = [
+    war({
+      warId: 1,
+      aggressorAllianceId: 1001,
+      defenderCorporationId: 2001,
+      aggressorIskDestroyed: 48.2e9,
+      defenderIskDestroyed: 39.6e9,
+      aggressorShipsKilled: 134,
+      defenderShipsKilled: 110,
+      totalIskDestroyed: 87.8e9,
+      totalShipsKilled: 244,
+      ageDays: 34,
+      aggressorIskShare: 48.2 / 87.8,
+      status: "active",
+      isMutual: true,
+      allianceAllies: [3001, 3002], // plural "allies"
+    }),
+    war({
+      warId: 2,
+      aggressorCorporationId: 1002,
+      defenderAllianceId: 2002,
+      aggressorIskDestroyed: 20e9,
+      defenderIskDestroyed: 80e9,
+      aggressorShipsKilled: 20,
+      defenderShipsKilled: 80,
+      totalIskDestroyed: 100e9,
+      totalShipsKilled: 100,
+      ageDays: 15,
+      aggressorIskShare: 0.2,
+      status: "active",
+      isOpenForAllies: true,
+      corporationAllies: [5001], // singular "ally"
+    }),
+    war({
+      warId: 3,
+      aggressorCorporationId: 1003,
+      defenderCorporationId: 2003,
+      status: "pending",
+      ageDays: 0,
+    }),
+    war({
+      warId: 4,
+      aggressorAllianceId: 1004,
+      defenderCorporationId: 2004,
+      status: "retracting",
+      aggressorIskDestroyed: 5e9,
+      defenderIskDestroyed: 5e9,
+      aggressorShipsKilled: 5,
+      defenderShipsKilled: 5,
+      totalIskDestroyed: 10e9,
+      totalShipsKilled: 10,
+      ageDays: 20,
+      aggressorIskShare: 0.5,
+    }),
+  ];
+  for (let i = 5; i <= 30; i++) {
+    wars.push(
+      war({
+        warId: i,
+        aggressorCorporationId: 1000 + i,
+        defenderCorporationId: 2000 + i,
+        status: "active",
+        ageDays: 3,
+      }),
+    );
+  }
+
+  return {
+    stats: {
+      totalActive: wars.length,
+      activeCount: 28,
+      startingCount: 1,
+      endingCount: 1,
+      mutualCount: 1,
+      openForAlliesCount: 1,
+      totalIskDestroyed: 197.8e9,
+      totalShipsKilled: 354,
+      warsWithCombat: 3,
+      declaredLast24h: 0,
+      declaredLast7d: 4,
+      generatedAt: new Date("2026-06-05T00:00:00Z").toISOString(),
+    },
+    wars,
+    topAggressors: [
+      { allianceId: 1001, warCount: 5, iskDestroyed: 48.2e9, shipsKilled: 134 },
+      { corporationId: 1002, warCount: 3, iskDestroyed: 0, shipsKilled: 0 },
+    ],
+  };
+}
+
+function renderRoom(data: WarRoomData) {
+  const { WarRoom } = require("~/components/Wars/WarRoom");
+  return render(
+    <MantineProvider>
+      <WarRoom data={data} />
+    </MantineProvider>,
+  );
+}
+
+describe("WarRoom overview", () => {
+  it("renders the masthead, stat header and both leaderboards", () => {
+    renderRoom(richData());
+    expect(screen.getByText("Active Wars")).toBeInTheDocument();
+    expect(screen.getByText("Most active aggressors")).toBeInTheDocument();
+    expect(screen.getByText("Heaviest fighting")).toBeInTheDocument();
+    expect(screen.getByText("All wars")).toBeInTheDocument();
+    // leaderboard value + "wars" fallback when an aggressor has no ISK dealt
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("wars")).toBeInTheDocument();
+  });
+
+  it("paginates the row view with 'Show more'", () => {
+    renderRoom(richData());
+    // 30 wars, 24 shown initially → 6 remaining
+    fireEvent.click(
+      screen.getByRole("button", { name: /show more \(6 more\)/i }),
+    );
+    expect(screen.queryByText(/show more/i)).toBeNull();
+  });
+
+  it("switches to the table view and sorts by column (both directions)", () => {
+    const { container } = renderRoom(richData());
+    fireEvent.click(container.querySelector('input[value="table"]')!);
+    expect(container.querySelector("table")).toBeInTheDocument();
+    expect(screen.getByText("Balance")).toBeInTheDocument();
+
+    const sortable = container.querySelectorAll('[class*="sortable"]');
+    // first sortable header is the active "ISK dealt" sort → toggles to ascending
+    fireEvent.click(sortable[0]!);
+    expect(
+      container.querySelector('th[aria-sort="ascending"]'),
+    ).toBeInTheDocument();
+    // a different header switches the key (descending)
+    fireEvent.click(sortable[1]!);
+    expect(
+      container.querySelector('th[aria-sort="descending"]'),
+    ).toBeInTheDocument();
+    // keyboard activation is supported
+    fireEvent.keyDown(sortable[2]!, { key: "Enter" });
+    expect(container.querySelector("th[aria-sort]")).toBeInTheDocument();
+  });
+
+  it("filters by status and attribute, showing an empty state", () => {
+    const { container } = renderRoom(richData());
+    // narrow to the single 'Starting' war
+    fireEvent.click(container.querySelector('input[value="starting"]')!);
+    expect(screen.getByText(/1 shown/)).toBeInTheDocument();
+    // add the 'In combat' toggle → the starting war has no kills → empty
+    fireEvent.click(screen.getByRole("checkbox", { name: "In combat" }));
+    expect(
+      screen.getByText("No wars match these filters."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("WarRoom with no combat", () => {
+  it("shows the empty heaviest-fighting note", () => {
+    const data = richData();
+    const quiet = {
+      ...data,
+      wars: data.wars.map((w) => ({
+        ...w,
+        aggressorIskDestroyed: 0,
+        defenderIskDestroyed: 0,
+        aggressorShipsKilled: 0,
+        defenderShipsKilled: 0,
+        totalIskDestroyed: 0,
+        totalShipsKilled: 0,
+        aggressorIskShare: null,
+      })),
+    };
+    renderRoom(quiet);
+    expect(screen.getByText("No kills recorded yet.")).toBeInTheDocument();
+  });
+});
+
+describe("WarRoom with no wars", () => {
+  it("renders empty leaderboards and an empty war list", () => {
+    renderRoom({
+      stats: {
+        totalActive: 0,
+        activeCount: 0,
+        startingCount: 0,
+        endingCount: 0,
+        mutualCount: 0,
+        openForAlliesCount: 0,
+        totalIskDestroyed: 0,
+        totalShipsKilled: 0,
+        warsWithCombat: 0,
+        declaredLast24h: 0,
+        declaredLast7d: 0,
+        generatedAt: new Date("2026-06-05T00:00:00Z").toISOString(),
+      },
+      wars: [],
+      topAggressors: [],
+    });
+    expect(
+      screen.getByText("No wars match these filters."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No kills recorded yet.")).toBeInTheDocument();
+  });
+});

--- a/apps/web/tests/warRoom.test.tsx
+++ b/apps/web/tests/warRoom.test.tsx
@@ -173,7 +173,7 @@ describe("WarRoom overview", () => {
     expect(container.querySelector("table")).toBeInTheDocument();
     expect(screen.getByText("Balance")).toBeInTheDocument();
 
-    const sortable = container.querySelectorAll('[class*="sortable"]');
+    const sortable = container.querySelectorAll("th button");
     // first sortable header is the active "ISK dealt" sort → toggles to ascending
     fireEvent.click(sortable[0]!);
     expect(
@@ -184,9 +184,9 @@ describe("WarRoom overview", () => {
     expect(
       container.querySelector('th[aria-sort="descending"]'),
     ).toBeInTheDocument();
-    // keyboard activation is supported
-    fireEvent.keyDown(sortable[2]!, { key: "Enter" });
-    expect(container.querySelector("th[aria-sort]")).toBeInTheDocument();
+    // a third sortable header re-keys the sort
+    fireEvent.click(sortable[2]!);
+    expect(container.querySelector('th[aria-sort="descending"]')).toBeInTheDocument();
   });
 
   it("filters by status and attribute, showing an empty state", () => {

--- a/apps/web/tests/warRoomUtils.test.ts
+++ b/apps/web/tests/warRoomUtils.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { WarRoomWar } from "~/components/Wars/WarRoom/types";
+import {
+  allyCount,
+  filterWars,
+  formatCompactNumber,
+  formatDuration,
+  formatIskCompact,
+  leadingSide,
+  SORT_OPTIONS,
+  sortWars,
+  STATUS_FILTERS,
+  STATUS_LABEL,
+  warHasCombat,
+} from "~/components/Wars/WarRoom/utils";
+
+const DAY = 86_400_000;
+
+function war(overrides: Partial<WarRoomWar> = {}): WarRoomWar {
+  const now = new Date().toISOString();
+  return {
+    warId: 1,
+    aggressorIskDestroyed: 0,
+    aggressorShipsKilled: 0,
+    defenderIskDestroyed: 0,
+    defenderShipsKilled: 0,
+    allianceAllies: [],
+    corporationAllies: [],
+    declaredDate: now,
+    isMutual: false,
+    isOpenForAllies: false,
+    updatedAt: now,
+    status: "active",
+    totalIskDestroyed: 0,
+    totalShipsKilled: 0,
+    ageDays: 0,
+    aggressorIskShare: null,
+    ...overrides,
+  };
+}
+
+describe("formatIskCompact", () => {
+  it("formats across magnitudes and trims trailing zeros", () => {
+    expect(formatIskCompact(0)).toBe("0");
+    expect(formatIskCompact(999)).toBe("999");
+    expect(formatIskCompact(1_000)).toBe("1K");
+    expect(formatIskCompact(1_500)).toBe("1.5K");
+    expect(formatIskCompact(1_000_000)).toBe("1M");
+    expect(formatIskCompact(48_200_000_000)).toBe("48.2B");
+    expect(formatIskCompact(2_000_000_000)).toBe("2B");
+    expect(formatIskCompact(1_000_000_000_000)).toBe("1T");
+  });
+
+  it("handles negative values", () => {
+    expect(formatIskCompact(-5_000)).toBe("-5K");
+  });
+});
+
+describe("formatCompactNumber", () => {
+  it("rounds and adds thousands separators", () => {
+    expect(formatCompactNumber(1234.6)).toBe("1,235");
+    expect(formatCompactNumber(0)).toBe("0");
+  });
+});
+
+describe("formatDuration", () => {
+  it("covers zero, sub-day, whole-day and day+hour cases", () => {
+    expect(formatDuration(0)).toBe("—");
+    expect(formatDuration(-3)).toBe("—");
+    expect(formatDuration(0.25)).toBe("6h");
+    expect(formatDuration(0.001)).toBe("1h"); // clamped to at least 1h
+    expect(formatDuration(3)).toBe("3d");
+    expect(formatDuration(3.5)).toBe("3d 12h");
+  });
+});
+
+describe("STATUS_LABEL + option tables", () => {
+  it("maps lifecycle to plain terms", () => {
+    expect(STATUS_LABEL.pending).toBe("Starting");
+    expect(STATUS_LABEL.active).toBe("Active");
+    expect(STATUS_LABEL.retracting).toBe("Ending");
+  });
+
+  it("exposes filter and sort option tables", () => {
+    expect(STATUS_FILTERS.map((o) => o.value)).toEqual([
+      "all",
+      "active",
+      "starting",
+      "ending",
+    ]);
+    expect(SORT_OPTIONS.map((o) => o.value)).toContain("isk");
+    expect(SORT_OPTIONS).toHaveLength(5);
+  });
+});
+
+describe("leadingSide", () => {
+  it("returns null with no combat, null when even, else the leader", () => {
+    expect(leadingSide(war({ aggressorIskShare: null }))).toBeNull();
+    expect(
+      leadingSide(
+        war({
+          aggressorIskDestroyed: 5,
+          defenderIskDestroyed: 5,
+          aggressorIskShare: 0.5,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      leadingSide(
+        war({
+          aggressorIskDestroyed: 8,
+          defenderIskDestroyed: 2,
+          aggressorIskShare: 0.8,
+        }),
+      ),
+    ).toBe("aggressor");
+    expect(
+      leadingSide(
+        war({
+          aggressorIskDestroyed: 2,
+          defenderIskDestroyed: 8,
+          aggressorIskShare: 0.2,
+        }),
+      ),
+    ).toBe("defender");
+  });
+});
+
+describe("allyCount + warHasCombat", () => {
+  it("counts allies across both lists", () => {
+    expect(
+      allyCount(war({ allianceAllies: [1, 2], corporationAllies: [3] })),
+    ).toBe(3);
+    expect(allyCount(war())).toBe(0);
+  });
+
+  it("detects combat from ships or isk", () => {
+    expect(warHasCombat(war())).toBe(false);
+    expect(warHasCombat(war({ totalShipsKilled: 1 }))).toBe(true);
+    expect(warHasCombat(war({ totalIskDestroyed: 1 }))).toBe(true);
+  });
+});
+
+describe("filterWars", () => {
+  const wars = [
+    war({ warId: 1, status: "active", totalShipsKilled: 5, isMutual: true }),
+    war({ warId: 2, status: "pending" }),
+    war({ warId: 3, status: "retracting", isOpenForAllies: true }),
+    war({ warId: 4, status: "active", totalIskDestroyed: 10 }),
+  ];
+
+  const ids = (list: WarRoomWar[]) => list.map((w) => w.warId).sort();
+
+  it("filters by lifecycle status", () => {
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "all",
+          combat: false,
+          mutual: false,
+          open: false,
+        }),
+      ),
+    ).toEqual([1, 2, 3, 4]);
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "active",
+          combat: false,
+          mutual: false,
+          open: false,
+        }),
+      ),
+    ).toEqual([1, 4]);
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "starting",
+          combat: false,
+          mutual: false,
+          open: false,
+        }),
+      ),
+    ).toEqual([2]);
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "ending",
+          combat: false,
+          mutual: false,
+          open: false,
+        }),
+      ),
+    ).toEqual([3]);
+  });
+
+  it("filters by attribute toggles", () => {
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "all",
+          combat: true,
+          mutual: false,
+          open: false,
+        }),
+      ),
+    ).toEqual([1, 4]);
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "all",
+          combat: false,
+          mutual: true,
+          open: false,
+        }),
+      ),
+    ).toEqual([1]);
+    expect(
+      ids(
+        filterWars(wars, {
+          status: "all",
+          combat: false,
+          mutual: false,
+          open: true,
+        }),
+      ),
+    ).toEqual([3]);
+  });
+});
+
+describe("sortWars", () => {
+  const base = new Date("2026-01-01T00:00:00Z").getTime();
+  const wars = [
+    war({
+      warId: 1,
+      totalIskDestroyed: 10,
+      totalShipsKilled: 1,
+      ageDays: 5,
+      allianceAllies: [1],
+      declaredDate: new Date(base).toISOString(),
+    }),
+    war({
+      warId: 2,
+      totalIskDestroyed: 30,
+      totalShipsKilled: 3,
+      ageDays: 1,
+      declaredDate: new Date(base + DAY).toISOString(),
+    }),
+    war({
+      warId: 3,
+      totalIskDestroyed: 20,
+      totalShipsKilled: 9,
+      ageDays: 9,
+      corporationAllies: [1, 2],
+      declaredDate: new Date(base + 2 * DAY).toISOString(),
+    }),
+  ];
+  const order = (key: Parameters<typeof sortWars>[1], dir?: -1 | 1) =>
+    sortWars(wars, key, dir).map((w) => w.warId);
+
+  it("sorts descending by default for each key", () => {
+    expect(order("isk")).toEqual([2, 3, 1]);
+    expect(order("ships")).toEqual([3, 2, 1]);
+    expect(order("longest")).toEqual([3, 1, 2]);
+    expect(order("newest")).toEqual([3, 2, 1]);
+    expect(order("allies")).toEqual([3, 1, 2]);
+  });
+
+  it("reverses when direction is ascending and does not mutate input", () => {
+    expect(order("isk", 1)).toEqual([1, 3, 2]);
+    expect(wars.map((w) => w.warId)).toEqual([1, 2, 3]);
+  });
+
+  it("breaks ties on total ISK destroyed", () => {
+    const tied = [
+      war({ warId: 10, totalShipsKilled: 4, totalIskDestroyed: 5 }),
+      war({ warId: 20, totalShipsKilled: 4, totalIskDestroyed: 9 }),
+    ];
+    expect(sortWars(tied, "ships").map((w) => w.warId)).toEqual([20, 10]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a compact, data-first redesign of the **Active Wars** page (`/active-wars`), available as an **opt-in** under **Settings → Experimental → "New Active Wars page"**. It defaults **off**, so the existing table is unchanged for everyone who doesn't enable it.

## What's in the new page

- **At-a-glance stat header** — Active · Starting · Ending · In combat · ISK destroyed · Ships lost (flat, no animation).
- **Belligerents** — two leaderboards: *most active aggressors* (who's declaring the most wars) and *heaviest fighting* (biggest current fights by ISK destroyed).
- **All wars** — a filterable, sortable list with a **Rows ⇄ Table** switch. Filter by lifecycle (`All / Active / Starting / Ending`) and by `In combat` / `Mutual` / `Open for allies`; the table's sortable column headers and the sort dropdown share one state.

## Design / data-accuracy notes

- Lifecycle is shown in plain words — **Starting** (declared, 24h prep), **Active** (shooting), **Ending** (one side withdrew, still shooting until it finishes).
- "Who's winning" is only ever an **ISK-destroyed balance bar** (the leading side's figure is emphasised) — an objective damage tally, never labelled a verdict.
- The earlier prototype's invented "Heat" score (kills ÷ war age) was **removed**. Every figure now maps to a real field: ISK destroyed by each side, ship kills, war duration, war counts.
- Aesthetic: restrained killboard look — hairline rules, monospace figures, two low-saturation accents for the two sides. Palette vars are scoped so it works under any dark app theme.

## How it's wired

- Server (`app/active-wars/data.ts`) reads the **DB-backed `War` model** (synced by background jobs, cached hourly — no live ESI fan-out) and enriches each war with derived, deterministic fields (status, totals, ISK share) plus aggregate stats and top aggressors.
- `ActiveWarsView` is a small client gate: it reads the `experimentalActiveWars` preference and renders **either** the new overview **or** the classic `WarsTable`, both from the same server-fetched data (no double fetch).
- The flag was added to the preferences store (`lib/preferences.ts`) and a `Switch` to the Settings **Experimental** tab (`components/Settings/SettingsCard.tsx`), mirroring the existing `experimentalDataTables` feature exactly.

## How to test

1. `/active-wars` looks unchanged (classic table) by default.
2. Open **Settings** (account menu) → **Experimental** → enable **"New Active Wars page"**.
3. Reload `/active-wars` → the new overview appears. Flip **Rows/Table**, apply status filters, toggle the attribute chips, and click a table column header to sort.

Verified locally against a mock dataset (real EVE corp/alliance IDs so names/logos resolve) on desktop and mobile — no horizontal overflow, no console errors. `pnpm type-check` and ESLint are clean, and the full jest suite passes (944 tests).

## Tests

New unit tests cover the added code (~100% statements/lines on the new files, high branch coverage):

- `warRoomUtils.test.ts` — format/filter/sort/lifecycle helpers.
- `activeWarsData.test.ts` — `getWarRoomData` enrichment + aggregation via a mocked prisma client (status derivation, ISK share, stats, aggressor leaderboard).
- `warRoom.test.tsx` — overview render plus WarList/WarTable/WarRow interactions: view switch, column sort, status/attribute filters, empty state, pagination.
- `activeWarsView.test.tsx` — the feature gate (classic table vs new overview).
- `preferencesActiveWars.test.ts` + an added `settingsCard` case — the flag's setter, persisted rehydrate, and the Settings toggle.

## Reviewer notes

- **Low blast radius**: gated behind a default-off flag; the classic table remains the default path.
- The legacy `WarsTable` (mantine-react-table) is intentionally kept — it's the off-state view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
