### PR TITLE
fix(tiptap-eve): harden EveFont against CSS injection from crafted EVE HTML

### DIFF
--- a/.changeset/evefont-css-injection.md
+++ b/.changeset/evefont-css-injection.md
@@ -1,0 +1,27 @@
+---
+"@jitaspace/tiptap-eve": patch
+"@jitaspace/web": patch
+---
+
+fix(tiptap-eve): harden EveFont against CSS injection from crafted EVE HTML
+
+The `EveFontColor` mark built an inline `style` from attacker-controlled `<font>`
+attributes (mail bodies, character bios) without validation, letting a payload
+break out of the `color:` / `font-size:` declaration and inject arbitrary CSS
+(a full-viewport fixed overlay for clickjacking, plus an external `url(...)`
+tracking request on view).
+
+- `fromEveColor` now only ever returns an empty string or a plain hex color.
+  The two valid EVE formats still convert (now both require the `0x` prefix),
+  plain `#rgb`/`#rrggbb[aa]` passes through, and anything else is rejected. The
+  null/empty guard that prevented a prior production crash on color-less
+  `<font size="14">` headers is preserved.
+- `size` is coerced to a bounded positive number (clamped to 72pt) before use,
+  so it can no longer inject CSS.
+- Raw `color`/`size` attributes are no longer spread onto the rendered `<span>`;
+  the original EVE color string is re-attached only when it passed validation,
+  keeping mail composition round-trips lossless.
+
+For `@jitaspace/web`: hardened the rendering of EVE-formatted text (mail and
+character bios) so a crafted message can no longer inject page-wide styling or
+hidden tracking requests.

--- a/packages/tiptap-eve/Extensions/EveFont.ts
+++ b/packages/tiptap-eve/Extensions/EveFont.ts
@@ -8,7 +8,7 @@ export const fromEveColor = (eveColor: string | null | undefined): string => {
   // this, renderHTML throws and crashes the whole MailMessageViewer (e.g. the
   // Description tab on /type/44992).
   if (!eveColor) return "";
-  if (eveColor.length === 9) {
+  if (eveColor.length === 9 && eveColor.startsWith("0x")) {
     // 0x0RRGGBB — single-digit alpha prefix, strip "0x0"
     return `#${eveColor.slice(3)}`;
   }
@@ -16,7 +16,15 @@ export const fromEveColor = (eveColor: string | null | undefined): string => {
     // 0xAARRGGBB — two-digit alpha, strip "0xAA"
     return `#${eveColor.slice(4)}`;
   }
-  return eveColor;
+  if (/^#[0-9a-fA-F]{3,8}$/.test(eveColor)) {
+    // Already a plain CSS hex color.
+    return eveColor;
+  }
+  // Reject anything else. `color` comes from attacker-controlled EVE HTML (other
+  // players' mail bodies and character bios); returning it unchanged would let a
+  // value like "blue;position:fixed;inset:0;background:url(https://attacker)"
+  // break out of the `color:` declaration and inject arbitrary inline CSS.
+  return "";
 };
 
 export interface FontColorMarkOptions {
@@ -52,19 +60,38 @@ export const EveFontColor = Mark.create<FontColorMarkOptions>({
 
   renderHTML({ HTMLAttributes }) {
     const styles: string[] = [];
-    if (HTMLAttributes.size) {
-      styles.push(`font-size:${HTMLAttributes.size}pt`);
+
+    // `size` and `color` come from attacker-controlled EVE HTML (other players'
+    // mail bodies and character bios), so both are validated before they reach
+    // the inline `style`, and neither raw value is spread onto the <span> as a
+    // DOM attribute — otherwise a payload like
+    // `<font size="14pt;position:fixed;inset:0;background:url(https://attacker)">`
+    // would break out of the declaration and inject page-wide CSS.
+    const { color, size, ...safeAttributes } = HTMLAttributes;
+
+    const fontSize = Number.parseFloat(String(size));
+    if (Number.isFinite(fontSize) && fontSize > 0) {
+      // Clamp so a single tag cannot blow up the layout (and can never be a
+      // vector for anything other than a plain numeric point size).
+      styles.push(`font-size:${Math.min(fontSize, 72)}pt`);
     }
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const cssColor = fromEveColor(HTMLAttributes.color);
+    const cssColor = fromEveColor(color);
     if (cssColor) {
       styles.push(`color:${cssColor}`);
+      // Preserve the ORIGINAL EVE color string on the span only when it passed
+      // validation, so htmlToEveMail can losslessly round-trip composed mail
+      // (<span color="0x…"> → <color=0x…>). Invalid/attacker values are dropped.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      safeAttributes.color = color;
     }
+
     return [
       "span",
       mergeAttributes(
         { ...this.options.HTMLAttributes },
-        { ...HTMLAttributes, style: styles.join(";") },
+        { ...safeAttributes, style: styles.join(";") },
       ),
       0,
     ];

--- a/packages/tiptap-eve/tests/eveEditorRender.test.ts
+++ b/packages/tiptap-eve/tests/eveEditorRender.test.ts
@@ -42,6 +42,58 @@ describe("eveEditorExtensions render round-trip", () => {
     expect(stripWs(html)).toContain("color:rgb(255,0,0)");
   });
 
+  it("clamps an oversized font-size to the maximum", () => {
+    const html = renderToHtml('<font size="9999">huge</font>');
+    expect(html).toContain("huge");
+    expect(stripWs(html)).toContain("font-size:72pt");
+    expect(stripWs(html)).not.toContain("font-size:9999pt");
+  });
+
+  describe("CSS injection hardening", () => {
+    // `color`/`size` come from attacker-controlled EVE HTML (other players' mail
+    // bodies, character bios). A crafted value must never break out of the CSS
+    // declaration and inject page-wide styling or an external tracking request.
+    const injectionMarkers = [
+      "position",
+      "background",
+      "url(",
+      "inset",
+      "z-index",
+      "fixed",
+    ];
+
+    it("strips a CSS breakout smuggled through the color attribute", () => {
+      const html = renderToHtml(
+        '<font color="blue;position:fixed;inset:0;z-index:99999;background:url(https://attacker/beacon)">x</font>',
+      );
+      expect(html).toContain("x");
+      for (const marker of injectionMarkers) {
+        expect(html).not.toContain(marker);
+      }
+    });
+
+    it("strips a CSS breakout smuggled through the size attribute", () => {
+      const html = renderToHtml(
+        '<font size="14pt;position:fixed;top:0;background:red">x</font>',
+      );
+      expect(html).toContain("x");
+      // Number.parseFloat("14pt;...") is 14, so a plain clamped size survives...
+      expect(stripWs(html)).toContain("font-size:14pt");
+      // ...but none of the injected declarations leak through.
+      for (const marker of injectionMarkers) {
+        expect(html).not.toContain(marker);
+      }
+    });
+
+    it("still renders a legitimate size + EVE color correctly", () => {
+      const html = renderToHtml('<font size="14" color="0x0FF0000">ok</font>');
+      expect(html).toContain("ok");
+      expect(stripWs(html)).toContain("font-size:14pt");
+      // jsdom serializes #FF0000 as rgb(255, 0, 0).
+      expect(stripWs(html)).toContain("color:rgb(255,0,0)");
+    });
+  });
+
   it("renders the PLEX description (mixed size-only and color-only fonts)", () => {
     // Trimmed, real ESI description for type 44992 — the content that crashed.
     const description =

--- a/packages/tiptap-eve/tests/eveFont.test.ts
+++ b/packages/tiptap-eve/tests/eveFont.test.ts
@@ -1,9 +1,9 @@
 import { fromEveColor } from "../Extensions/EveFont";
 
 describe("fromEveColor", () => {
-  describe("9-character EVE color format (0xARRGGBB)", () => {
+  describe("9-character EVE color format (0x0RRGGBB)", () => {
     // EVE colors are stored as 0x + 1 alpha digit + 6 hex color digits = 9 chars.
-    // fromEveColor strips the leading 3 chars (0xA) and prepends '#'.
+    // fromEveColor strips the leading 3 chars (0x0) and prepends '#'.
 
     it.each([
       ["red", "0x0ff0000", "#ff0000"],
@@ -20,18 +20,24 @@ describe("fromEveColor", () => {
     });
   });
 
-  describe("non-EVE color inputs (pass-through)", () => {
+  describe("10-character EVE color format (0xAARRGGBB)", () => {
     it.each([
-      ["CSS hex color (7 chars)", "#ff0000", "#ff0000"],
-      ["10-char alpha=ff, black (0xff000000)", "0xff000000", "#000000"],
-      ["10-char fully opaque red (0xffFF0000)", "0xffFF0000", "#FF0000"],
-      ["10-char fully opaque white (0xffFFFFFF)", "0xffFFFFFF", "#FFFFFF"],
-      ["10-char semi-transparent white (0xbfffffff)", "0xbfffffff", "#ffffff"],
-      ["plain 8-char 0xRRGGBB", "0xff0000", "0xff0000"],
-      ["empty string", "", ""],
-      ["named color", "red", "red"],
-      ["short 3-char string", "abc", "abc"],
-    ])("handles %s correctly", (_name, input, expected) => {
+      ["alpha=ff, black (0xff000000)", "0xff000000", "#000000"],
+      ["fully opaque red (0xffFF0000)", "0xffFF0000", "#FF0000"],
+      ["fully opaque white (0xffFFFFFF)", "0xffFFFFFF", "#FFFFFF"],
+      ["semi-transparent white (0xbfffffff)", "0xbfffffff", "#ffffff"],
+    ])("converts %s", (_name, input, expected) => {
+      expect(fromEveColor(input)).toBe(expected);
+    });
+  });
+
+  describe("plain CSS hex colors (pass-through)", () => {
+    it.each([
+      ["6-char hex", "#ff0000", "#ff0000"],
+      ["3-char shorthand hex", "#abc", "#abc"],
+      ["6-char hex (aabbcc)", "#aabbcc", "#aabbcc"],
+      ["8-char hex with alpha", "#aabbccdd", "#aabbccdd"],
+    ])("passes through %s", (_name, input, expected) => {
       expect(fromEveColor(input)).toBe(expected);
     });
   });
@@ -42,6 +48,7 @@ describe("fromEveColor", () => {
     // which TipTap resolves to `null`. fromEveColor must not throw on this — it
     // used to read `.length` and crash the whole MailMessageViewer.
     it.each([
+      ["empty string", ""],
       ["null", null],
       ["undefined", undefined],
     ])("returns an empty string for %s", (_name, input) => {
@@ -49,9 +56,35 @@ describe("fromEveColor", () => {
     });
   });
 
+  describe("rejects CSS-injection / invalid inputs (returns empty string)", () => {
+    // `color` is attacker-controlled (other players' mail bodies, character
+    // bios). Any value that is not a recognized EVE color or plain hex color
+    // must resolve to "" so it can never be interpolated into a `color:` CSS
+    // declaration — otherwise the value could break out of the declaration and
+    // inject arbitrary page-wide styling or a tracking beacon.
+    it.each([
+      ["CSS breakout via named color", "blue;position:fixed;background:url(x)"],
+      [
+        "CSS breakout via hex color",
+        "#ff0000;position:fixed;inset:0;z-index:99999",
+      ],
+      ["full overlay payload", "red;position:fixed;inset:0;background:url(y)"],
+      ["named color", "red"],
+      ["short non-hex string", "abc"],
+      ["javascript pseudo-url", "javascript:alert(1)"],
+      ["url() value", "url(https://attacker/beacon)"],
+      ["plain 8-char 0xRRGGBB (no alpha, ambiguous)", "0xff0000"],
+      ["hex with too many digits", "#0123456789"],
+      ["hex with non-hex char", "#gggggg"],
+      ["9-char without 0x prefix", "abcdefghi"],
+    ])("returns an empty string for %s", (_name, input) => {
+      expect(fromEveColor(input)).toBe("");
+    });
+  });
+
   describe("inline style integration", () => {
     // Verify the output format matches what renderHTML uses:
-    // `font-size:${size}pt;color:${fromEveColor(color)}`
+    // `color:${fromEveColor(color)}`
 
     it("produces a valid CSS color for inline style", () => {
       const color = fromEveColor("0x0ff0000");
@@ -59,7 +92,7 @@ describe("fromEveColor", () => {
       expect(style).toBe("font-size:12pt;color:#ff0000");
     });
 
-    it("uses the original value when no conversion applies", () => {
+    it("uses the original value when it is already a plain hex color", () => {
       const color = fromEveColor("#ff0000");
       const style = `font-size:10pt;color:${color}`;
       expect(style).toBe("font-size:10pt;color:#ff0000");


### PR DESCRIPTION
## The vulnerability

Attacker-controlled EVE HTML — **another player's mail body** and **character bios** — is parsed by TipTap and rendered via `dangerouslySetInnerHTML` in `apps/web/components/EveMail/MailMessageViewer.tsx`. The `EveFontColor` mark's `renderHTML` built an inline `style` from `<font>` attributes with **no validation**:

- **`size`** was interpolated raw: `font-size:${HTMLAttributes.size}pt`. Payload `<font size="14pt;position:fixed;inset:0;z-index:99999;background:url(https://attacker/beacon)">` breaks out of the declaration.
- **`color`** went through `fromEveColor`, which returned any non-`0x` string **unchanged** (final `return eveColor;`), so `<font color="blue;position:fixed;...;background:url(...)">` injected arbitrary CSS.

Result: a full-viewport `position:fixed` overlay (clickjacking / UI-redress) plus an unconditional external request on view (tracking beacon). CSP is report-only, so it does not block this at runtime. CSS-only — no JS execution — but a real vuln.

## The fix (`packages/tiptap-eve/Extensions/EveFont.ts`)

1. **`fromEveColor` can now only ever return `""` or a plain hex color.** The two valid EVE conversions are kept (both now require the `0x` prefix); a plain `#rgb`/`#rrggbb[aa]` passes through; **everything else is rejected** → `""`. The null/empty guard that fixed a prior production crash on color-less `<font size="14">` headers is preserved.
2. **`size` is coerced** to a bounded positive number and clamped to `72pt` before use, so it can no longer inject CSS.
3. **Raw `color`/`size` are no longer spread onto the `<span>`.** The original EVE color string is re-attached to the span **only when it passed validation**, so `htmlToEveMail` mail-composition round-trips stay lossless while attacker garbage is dropped.

## Tests (`packages/tiptap-eve/tests/`)

- `eveFont.test.ts`: valid EVE (`0x0FF0000`→`#FF0000`, `0xAAFF0000`→`#FF0000`) and hex pass-through cases, plus a rejection suite (`""`/`null`/`undefined`, CSS-breakout strings, `"red"`, `"javascript:alert(1)"`, `url(...)`, ambiguous `0xff0000`, malformed hex) → `""`.
- `eveEditorRender.test.ts`: real `@tiptap` round-trip via jsdom feeding the `color=`/`size=` breakout payloads and asserting the output contains **no** `position`, `background`, `url(`, `inset`, `z-index`, or `fixed`; a valid `<font size="14" color="0x0FF0000">` still yields `font-size:14pt` + `color:rgb(255,0,0)`; and oversized sizes are clamped.

All **226** tests pass. Changed lines are at 100% coverage with full branch coverage; the only uncovered lines in `EveFont.ts` (the pre-existing `removeEmptyTextStyle` command) were untouched.

## Verification

- `pnpm --filter @jitaspace/tiptap-eve test --coverage` → 226 passed
- `pnpm --filter @jitaspace/tiptap-eve lint` → clean
- `pnpm --filter @jitaspace/tiptap-eve type-check` → clean
- `pnpm exec prettier --check` on changed files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)