### PR TITLE
fix(background-jobs): stop rewriting every character/corporation row on each sync

### DIFF
--- a/packages/background-jobs/helpers/mergeEntriesIntoCharactersTable.ts
+++ b/packages/background-jobs/helpers/mergeEntriesIntoCharactersTable.ts
@@ -46,7 +46,9 @@ export const mergeEntriesIntoCharactersTable = (
           },
         })
         .then((entries) =>
-          entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+          entries.map((entry) =>
+            excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+          ),
         ),
     fetchRemoteEntries: () => Promise.resolve(characters),
     batchCreate: (entries) =>

--- a/packages/background-jobs/helpers/mergeEntriesIntoCorporationsTable.ts
+++ b/packages/background-jobs/helpers/mergeEntriesIntoCorporationsTable.ts
@@ -59,7 +59,9 @@ export const mergeEntriesIntoCorporationsTable = (
           },
         })
         .then((entries) =>
-          entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+          entries.map((entry) =>
+            excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+          ),
         ),
     fetchRemoteEntries: () => Promise.resolve(corporations),
     batchCreate: (entries) =>

--- a/packages/background-jobs/tests/mergeEntriesIntoCharactersTable.test.ts
+++ b/packages/background-jobs/tests/mergeEntriesIntoCharactersTable.test.ts
@@ -1,0 +1,95 @@
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+import type { Character } from "../db";
+import type { mergeEntriesIntoCharactersTable as MergeEntriesIntoCharactersTable } from "../helpers/mergeEntriesIntoCharactersTable";
+
+// The helper pulls in p-limit (ESM), the zod-checked env (via ../db -> ../env),
+// and a real Prisma client. Stub them so the test exercises only the
+// diff/filter orchestration through updateTable.
+// (@swc/jest doesn't hoist jest.mock, and the real modules crash if loaded, so
+// the helper is imported lazily in beforeAll — after these mocks are registered.)
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => unknown) => fn(),
+}));
+
+const character = {
+  findMany: jest.fn((_args?: unknown) => Promise.resolve<unknown[]>([])),
+  createMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+  update: jest.fn((_args?: unknown) => Promise.resolve({})),
+  updateMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+};
+
+jest.mock("../db", () => ({ prisma: { character } }));
+
+let mergeEntriesIntoCharactersTable: typeof MergeEntriesIntoCharactersTable;
+
+beforeAll(async () => {
+  ({ mergeEntriesIntoCharactersTable } =
+    await import("../helpers/mergeEntriesIntoCharactersTable"));
+});
+
+// An ESI-derived record, as produced by convertEsiCharacterToDomain: it has no
+// createdAt/updatedAt.
+const remoteRecord: Omit<Character, "updatedAt" | "createdAt"> = {
+  characterId: 1,
+  birthday: new Date("2020-01-01"),
+  bloodlineId: 1,
+  corporationId: 1000,
+  description: null,
+  factionId: null,
+  gender: "male",
+  name: "Test Pilot",
+  raceId: 1,
+  securityStatus: null,
+  title: null,
+  isDeleted: false,
+};
+
+describe("mergeEntriesIntoCharactersTable", () => {
+  it("does not update a row whose only difference is the createdAt/updatedAt timestamps", async () => {
+    // The DB row is identical to the incoming ESI record except it also carries
+    // createdAt (a Date) and updatedAt — columns the local fetch must strip so
+    // the diff sees the two records as equal.
+    character.findMany.mockResolvedValueOnce([
+      {
+        ...remoteRecord,
+        createdAt: new Date("2019-06-01"),
+        updatedAt: new Date("2019-06-01"),
+      },
+    ]);
+
+    const stats = await mergeEntriesIntoCharactersTable([remoteRecord]);
+
+    // The unchanged row must land in the "equal" bucket, not "modified", so no
+    // per-row update is issued. (batchDelete still runs updateMany once with an
+    // empty id list — nothing is soft-deleted.)
+    expect(character.update).not.toHaveBeenCalled();
+    expect(character.createMany).toHaveBeenCalledWith({ data: [] });
+    expect(character.updateMany).toHaveBeenCalledWith({
+      data: { isDeleted: true },
+      where: { characterId: { in: [] } },
+    });
+    expect(stats).toMatchObject({ created: 0, modified: 0, equal: 1 });
+  });
+
+  it("updates a row when a real field changed", async () => {
+    character.findMany.mockResolvedValueOnce([
+      {
+        ...remoteRecord,
+        name: "Old Name",
+        createdAt: new Date("2019-06-01"),
+        updatedAt: new Date("2019-06-01"),
+      },
+    ]);
+
+    const stats = await mergeEntriesIntoCharactersTable([remoteRecord]);
+
+    expect(character.update).toHaveBeenCalledTimes(1);
+    expect(character.update).toHaveBeenCalledWith({
+      data: remoteRecord,
+      where: { characterId: 1 },
+    });
+    expect(stats).toMatchObject({ created: 0, modified: 1, equal: 0 });
+  });
+});

--- a/packages/background-jobs/tests/mergeEntriesIntoCorporationsTable.test.ts
+++ b/packages/background-jobs/tests/mergeEntriesIntoCorporationsTable.test.ts
@@ -1,0 +1,99 @@
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+import type { Corporation } from "../db";
+import type { mergeEntriesIntoCorporationsTable as MergeEntriesIntoCorporationsTable } from "../helpers/mergeEntriesIntoCorporationsTable";
+
+// The helper pulls in p-limit (ESM), the zod-checked env (via ../db -> ../env),
+// and a real Prisma client. Stub them so the test exercises only the
+// diff/filter orchestration through updateTable.
+// (@swc/jest doesn't hoist jest.mock, and the real modules crash if loaded, so
+// the helper is imported lazily in beforeAll — after these mocks are registered.)
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => unknown) => fn(),
+}));
+
+const corporation = {
+  findMany: jest.fn((_args?: unknown) => Promise.resolve<unknown[]>([])),
+  createMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+  update: jest.fn((_args?: unknown) => Promise.resolve({})),
+  updateMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+};
+
+jest.mock("../db", () => ({ prisma: { corporation } }));
+
+let mergeEntriesIntoCorporationsTable: typeof MergeEntriesIntoCorporationsTable;
+
+beforeAll(async () => {
+  ({ mergeEntriesIntoCorporationsTable } =
+    await import("../helpers/mergeEntriesIntoCorporationsTable"));
+});
+
+// A corporation record as produced by convertEsiCorporationToDomain: it has no
+// createdAt/updatedAt.
+const remoteRecord: Omit<Corporation, "updatedAt" | "createdAt"> = {
+  corporationId: 1000,
+  allianceId: null,
+  ceoId: 2000,
+  creatorId: 2000,
+  dateFounded: new Date("2018-01-01"),
+  description: null,
+  factionId: null,
+  homeStationId: null,
+  memberCount: 42,
+  name: "Test Corp",
+  shares: null,
+  taxRate: 0.1,
+  ticker: "TEST",
+  url: null,
+  warEligible: null,
+  isDeleted: false,
+};
+
+describe("mergeEntriesIntoCorporationsTable", () => {
+  it("does not update a row whose only difference is the createdAt/updatedAt timestamps", async () => {
+    // The DB row is identical to the incoming ESI record except it also carries
+    // createdAt (a Date) and updatedAt — columns the local fetch must strip so
+    // the diff sees the two records as equal.
+    corporation.findMany.mockResolvedValueOnce([
+      {
+        ...remoteRecord,
+        createdAt: new Date("2017-06-01"),
+        updatedAt: new Date("2017-06-01"),
+      },
+    ]);
+
+    const stats = await mergeEntriesIntoCorporationsTable([remoteRecord]);
+
+    // The unchanged row must land in the "equal" bucket, not "modified", so no
+    // per-row update is issued. (batchDelete still runs updateMany once with an
+    // empty id list — nothing is soft-deleted.)
+    expect(corporation.update).not.toHaveBeenCalled();
+    expect(corporation.createMany).toHaveBeenCalledWith({ data: [] });
+    expect(corporation.updateMany).toHaveBeenCalledWith({
+      data: { isDeleted: true },
+      where: { corporationId: { in: [] } },
+    });
+    expect(stats).toMatchObject({ created: 0, modified: 0, equal: 1 });
+  });
+
+  it("updates a row when a real field changed", async () => {
+    corporation.findMany.mockResolvedValueOnce([
+      {
+        ...remoteRecord,
+        memberCount: 1,
+        createdAt: new Date("2017-06-01"),
+        updatedAt: new Date("2017-06-01"),
+      },
+    ]);
+
+    const stats = await mergeEntriesIntoCorporationsTable([remoteRecord]);
+
+    expect(corporation.update).toHaveBeenCalledTimes(1);
+    expect(corporation.update).toHaveBeenCalledWith({
+      data: remoteRecord,
+      where: { corporationId: 1000 },
+    });
+    expect(stats).toMatchObject({ created: 0, modified: 1, equal: 0 });
+  });
+});


### PR DESCRIPTION
## The bug

`convertEsiCharacterToDomain` / `convertEsiCorporationToDomain` return `Omit<…, "updatedAt" | "createdAt">`, so the **remote** (ESI-derived) records carry no `createdAt`. But the two merge helpers' `fetchLocalEntries` strip only `updatedAt` from the **local** rows:

- `packages/background-jobs/helpers/mergeEntriesIntoCharactersTable.ts` → `excludeObjectKeys(entry, ["updatedAt"])`
- `packages/background-jobs/helpers/mergeEntriesIntoCorporationsTable.ts` → `excludeObjectKeys(entry, ["updatedAt"])`

So the local row keeps `createdAt` (a `Date`) while the remote record lacks the key. In `recordsAreEqual`, `createdAt` then compares `typeof "object"` vs `typeof "undefined"` and returns `false`, so **every existing row is classified "modified"** → a needless `prisma.*.update` for every row on every scrape.

Consequences: write amplification, `updatedAt` churn that pollutes provenance, and permanently wrong `CrudStatistics` (nothing ever lands in the `equal` bucket).

## The fix

Strip **both** timestamp columns so the local shape matches the remote one — exactly what the SDE helper `ingestSdeCompositeTable` already does:

```ts
excludeObjectKeys(entry, ["updatedAt", "createdAt"])
```

## Tests

Adds `tests/mergeEntriesIntoCharactersTable.test.ts` and `tests/mergeEntriesIntoCorporationsTable.test.ts` (mirroring the `ingestSdeCompositeTable` mocking style — lazy import after `jest.mock`, since `@swc/jest` doesn't hoist mocks). Each asserts that a DB row identical to the incoming ESI record **except** for its `createdAt`/`updatedAt` timestamps lands in the `equal` bucket (no `update` issued), while a real field change is still routed to `modified`. Verified these tests **fail** on the old `["updatedAt"]` code and **pass** with the fix.

## Notes

- `@jitaspace/background-jobs` is `private`, so no changeset (per repo convention). No user-visible web effect → no `@jitaspace/web` changeset.
- Backend sync-efficiency fix only; no schema or API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)