### PR TITLE
fix(web): render individual label id when a contact label cannot be resolved

### DIFF
--- a/.changeset/fix-contacts-labels-badge.md
+++ b/.changeset/fix-contacts-labels-badge.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed contact labels showing a raw list of IDs instead of the individual label when a label could not be found.

--- a/apps/web/components/Contacts/ContactsDataTable/ContactsDataTable.tsx
+++ b/apps/web/components/Contacts/ContactsDataTable/ContactsDataTable.tsx
@@ -133,7 +133,7 @@ export const ContactsDataTable = memo(
             <Group gap="xs">
               {cell.getValue<number[] | undefined>()?.map((labelId) => (
                 <Badge size="sm" key={labelId}>
-                  {labelName[labelId] ?? JSON.stringify(cell.getValue())}
+                  {labelName[labelId] ?? String(labelId)}
                 </Badge>
               ))}
             </Group>

--- a/apps/web/tests/ContactsDataTable.test.tsx
+++ b/apps/web/tests/ContactsDataTable.test.tsx
@@ -53,6 +53,16 @@ const CONTACT_NO_LABELS = {
   // label_ids omitted entirely — ESI leaves it out for contacts with no labels.
 } as unknown as Contact;
 
+const CONTACT_UNRESOLVED_LABEL = {
+  contact_id: 1004,
+  contact_type: "character",
+  standing: 1,
+  is_watched: false,
+  is_blocked: false,
+  // 10 resolves to "Friends"; 999 is absent from LABELS (deleted or not-yet-synced).
+  label_ids: [10, 999],
+} as unknown as Contact;
+
 const LABELS = [{ label_id: 10, label_name: "Friends" }];
 
 function renderTable(contacts: Contact[]) {
@@ -82,6 +92,16 @@ describe("ContactsDataTable", () => {
     renderTable([CONTACT_WATCHED]);
     // labels cell: labelName[labelId] -> "Friends"
     expect(screen.getByText("Friends")).toBeInTheDocument();
+  });
+
+  it("renders the raw label id when a label cannot be resolved", () => {
+    renderTable([CONTACT_UNRESOLVED_LABEL]);
+    // label_ids [10, 999]: 10 resolves to "Friends"; 999 is absent from LABELS.
+    // The fallback must render the individual id ("999"), not JSON.stringify of
+    // the whole label_ids array ("[10,999]").
+    expect(screen.getByText("Friends")).toBeInTheDocument();
+    expect(screen.getByText("999")).toBeInTheDocument();
+    expect(screen.queryByText("[10,999]")).not.toBeInTheDocument();
   });
 
   it("renders 'Yes' in the blocked column when is_blocked is true", () => {


### PR DESCRIPTION
## The bug

In `apps/web/components/Contacts/ContactsDataTable/ContactsDataTable.tsx`, the Labels column Cell fell back to `JSON.stringify(cell.getValue())` when a `labelId` could not be resolved to a name. Because the column's `accessorKey` is `"label_ids"`, `cell.getValue()` returns the **entire** `label_ids` array — so an unresolved label id (a label deleted or not-yet-synced, and therefore absent from the `labels` prop) rendered a badge reading e.g. `[10,999]` instead of `999`.

This state occurs naturally because a contact's `label_ids` and the labels list come from separate ESI endpoints with independent caching.

## The fix

Fall back to the individual id via `String(labelId)`. One-line change; nothing else touched.

## Tests

Added a new `it(...)` to `apps/web/tests/ContactsDataTable.test.tsx` that renders a contact with `label_ids: [10, 999]` where `labels` only defines id 10. It asserts the badge shows `"999"` (not `"[10,999]"`) and that the resolved name `"Friends"` still shows for id 10. Existing tests are left intact.

- `SKIP_ENV_VALIDATION=1 pnpm test tests/ContactsDataTable.test.tsx --coverage`: 8 passed; changed file at 99.45% stmts / 90% branch (only the untouched `capitalizeFirstLetter` line uncovered).
- `SKIP_ENV_VALIDATION=1 pnpm test` (full web suite): 125 suites / 926 tests passing.

## Changeset

`.changeset/fix-contacts-labels-badge.md` — `@jitaspace/web` patch, end-user-readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)