### PR TITLE
fix(web): harden returnTo guard against backslash/control-char open redirect

### DIFF
--- a/.changeset/fix-return-to-open-redirect.md
+++ b/.changeset/fix-return-to-open-redirect.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the sign-in flow so a crafted login link can no longer bounce you to an external site after you log in.

--- a/apps/web/app/login/complete/page.tsx
+++ b/apps/web/app/login/complete/page.tsx
@@ -7,12 +7,8 @@ import posthog from "posthog-js";
 
 import { useAuthStore } from "@jitaspace/hooks";
 
+import { sanitizeReturnTo } from "~/lib/returnTo";
 import { consumeLoginResult } from "./actions";
-
-function safeReturnTo(value: string | null): string {
-  if (value && value.startsWith("/") && !value.startsWith("//")) return value;
-  return "/";
-}
 
 /**
  * Terminal page of the OAuth flow: drains the single-use result cookie via a
@@ -29,7 +25,7 @@ export default function LoginCompletePage() {
     if (hasRun.current) return;
     hasRun.current = true;
 
-    const returnTo = safeReturnTo(
+    const returnTo = sanitizeReturnTo(
       new URLSearchParams(globalThis.location.search).get("returnTo"),
     );
 

--- a/apps/web/lib/returnTo.ts
+++ b/apps/web/lib/returnTo.ts
@@ -1,0 +1,22 @@
+// Matches any ASCII control character (\x00–\x1f) or a backslash — inputs that
+// browsers normalise cross-origin (e.g. "/\evil.com" resolves to
+// "https://evil.com/").
+// eslint-disable-next-line no-control-regex -- rejecting control chars is the intent
+const UNSAFE_RETURN_TO = /[\x00-\x1f\\]/;
+
+/**
+ * Open-redirect guard: only allow same-site relative paths. Rejects absolute
+ * URLs, protocol-relative ("//evil.com") paths, and backslash/control-char
+ * paths that browsers normalise cross-origin.
+ */
+export function sanitizeReturnTo(value: string | null | undefined): string {
+  if (
+    typeof value === "string" &&
+    value.startsWith("/") &&
+    !value.startsWith("//") &&
+    !UNSAFE_RETURN_TO.test(value)
+  ) {
+    return value;
+  }
+  return "/";
+}

--- a/apps/web/lib/serverAuth.ts
+++ b/apps/web/lib/serverAuth.ts
@@ -1,5 +1,10 @@
 import type { NextRequest } from "next/server";
 
+// Re-exported so existing importers (e.g. the login route) keep a single
+// import site; the guard itself lives in a server-free module so it can be
+// shared with client components.
+export { sanitizeReturnTo } from "./returnTo";
+
 /**
  * Resolve the externally-visible origin of the request, honouring the
  * reverse-proxy headers Vercel sets. Used to build the OAuth `redirect_uri`
@@ -13,15 +18,4 @@ export function getRequestOrigin(req: NextRequest): string {
     forwardedProto?.split(",")[0]?.trim() ??
     req.nextUrl.protocol.replace(":", "");
   return `${proto}://${host}`;
-}
-
-/**
- * Open-redirect guard: only allow same-site relative paths. Rejects absolute
- * URLs and protocol-relative ("//evil.com") paths.
- */
-export function sanitizeReturnTo(returnTo: string | null | undefined): string {
-  if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
-    return returnTo;
-  }
-  return "/";
 }

--- a/apps/web/tests/authLoginRoute.test.ts
+++ b/apps/web/tests/authLoginRoute.test.ts
@@ -83,4 +83,18 @@ describe("GET /api/auth/login", () => {
       expect.objectContaining({ returnTo: "/", scopes: [] }),
     );
   });
+
+  it("rejects backslash/control-char returnTo values that normalise cross-origin", async () => {
+    const GET = loadGET();
+    // "/\evil.com" is escaped as %5Cevil.com; browsers resolve it to
+    // https://evil.com/, so the guard must reject it.
+    const req = new NextRequest(
+      "https://jita.space/api/auth/login?returnTo=/%5Cevil.com",
+      { headers },
+    );
+    await GET(req);
+    expect(mockCreateLoginFlow).toHaveBeenLastCalledWith(
+      expect.objectContaining({ returnTo: "/" }),
+    );
+  });
 });

--- a/apps/web/tests/loginCompletePage.test.tsx
+++ b/apps/web/tests/loginCompletePage.test.tsx
@@ -110,6 +110,19 @@ describe("LoginCompletePage", () => {
     await waitFor(() => expect(captureExceptionMock).toHaveBeenCalled());
   });
 
+  it("redirects to / for a backslash returnTo that would normalise cross-origin", async () => {
+    window.history.pushState({}, "", "/login/complete?returnTo=/%5Cevil.com");
+    mockConsumeLoginResult.mockResolvedValue({
+      accessToken: "AT",
+      encryptedRefreshToken: "ERT",
+    });
+
+    const LoginCompletePage = loadPage();
+    render(<LoginCompletePage />);
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+  });
+
   it("redirects to / when there is no pending result", async () => {
     window.history.pushState({}, "", "/login/complete");
     mockConsumeLoginResult.mockResolvedValue(null);

--- a/apps/web/tests/returnTo.test.ts
+++ b/apps/web/tests/returnTo.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { sanitizeReturnTo } from "../lib/returnTo";
+
+describe("sanitizeReturnTo", () => {
+  it("passes through safe same-site relative paths", () => {
+    expect(sanitizeReturnTo("/")).toBe("/");
+    expect(sanitizeReturnTo("/skills?x=1")).toBe("/skills?x=1");
+  });
+
+  it("falls back to / for nullish or empty input", () => {
+    expect(sanitizeReturnTo(null)).toBe("/");
+    expect(sanitizeReturnTo(undefined)).toBe("/");
+    expect(sanitizeReturnTo("")).toBe("/");
+  });
+
+  it("rejects absolute and protocol-relative URLs", () => {
+    expect(sanitizeReturnTo("//evil.com")).toBe("/");
+    expect(sanitizeReturnTo("https://evil.com")).toBe("/");
+  });
+
+  it("rejects backslash and control-char paths that normalise cross-origin", () => {
+    expect(sanitizeReturnTo("/\\evil.com")).toBe("/");
+    expect(sanitizeReturnTo("/\\@evil.com")).toBe("/");
+    expect(sanitizeReturnTo("/\t/evil.com")).toBe("/");
+  });
+
+  it("keeps the sanitised result same-origin when parsed by the real URL parser", () => {
+    const origin = "https://www.jita.space";
+    for (const input of ["/\\evil.com", "/\\@evil.com", "/\t/evil.com"]) {
+      expect(new URL(sanitizeReturnTo(input), origin).origin).toBe(origin);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The OAuth `returnTo` guard only rejected protocol-relative `//` paths. It **accepted** backslash and ASCII control-char paths that browsers/WHATWG normalise cross-origin, opening an **open-redirect / phishing** vector:

- `/\evil.com`  → `new URL("/\evil.com", origin).href === "https://evil.com/"`
- `/\@evil.com` → same
- `/<TAB>/evil.com` → same

A crafted link such as `…/api/auth/login?returnTo=/%5Cevil.com` sealed the value into the OAuth flow cookie; after the victim completed EVE SSO, the completion page ran `router.replace("/\evil.com")` and navigated off-site.

## Fix

- New single source of truth `apps/web/lib/returnTo.ts` exporting a pure `sanitizeReturnTo(value)` that returns the value only when it is a safe same-site relative path: a string, `startsWith("/")`, NOT `startsWith("//")`, **no backslash**, and **no ASCII control chars**; otherwise `"/"`.
- `apps/web/lib/serverAuth.ts` now re-exports `sanitizeReturnTo` from the new util (the login route's import site is unchanged).
- `apps/web/app/login/complete/page.tsx` (the actual `router.replace` redirect sink) drops its local `safeReturnTo` and imports the shared util — the module has no server-only imports, so it is safe in a client component.

No other behaviour changes: legit paths like `/skills?foo=bar` and `/` still pass; `//evil.com`, `https://evil.com`, `/\evil.com`, `/\@evil.com`, and tab-containing paths all fall back to `/`.

## Tests

- New `apps/web/tests/returnTo.test.ts` — full unit coverage (100%) of `sanitizeReturnTo`, including an assertion via the real `URL` parser that the sanitised result stays same-origin.
- Extended `apps/web/tests/authLoginRoute.test.ts` and `apps/web/tests/loginCompletePage.test.tsx` to cover the new backslash/`%5C` rejection at both call sites.

All web tests pass (932/932); the new util has 100% line/branch coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)