### PR TITLE
fix(web): oversized empty balance bar on the Active Wars page

### DIFF
--- a/apps/web/components/Wars/WarRoom/WarList.tsx
+++ b/apps/web/components/Wars/WarRoom/WarList.tsx
@@ -56,7 +56,7 @@ export function WarList({ wars }: Readonly<{ wars: WarRoomWar[] }>) {
   let listContent;
   if (shown.length === 0) {
     listContent = (
-      <div className={cx(classes.listCard, classes.empty)}>
+      <div className={cx(classes.listCard, classes.emptyMessage)}>
         No wars match these filters.
       </div>
     );

--- a/apps/web/components/Wars/WarRoom/WarRoom.module.css
+++ b/apps/web/components/Wars/WarRoom/WarRoom.module.css
@@ -470,7 +470,10 @@
   justify-content: center;
   margin-top: var(--mantine-spacing-md);
 }
-.empty {
+/* Empty-list message. NOT named `.empty` — that would collide with the balance
+   bar's `.bal.empty` modifier (both resolve to the same CSS-module class) and
+   apply this padding to the thin empty bar. */
+.emptyMessage {
   padding: var(--mantine-spacing-xl);
   text-align: center;
   color: var(--ink-3);


### PR DESCRIPTION
## Summary

Follow-up fix for the redesigned Active Wars page (shipped in #649).

Wars with **no ISK destroyed** rendered their balance bar as a large (~64px) striped blob instead of a thin bar — in both the row and table layouts.

## Cause

A CSS-module class-name collision. Two unrelated things both used `classes.empty`, so they resolved to the **same** class:

- the balance bar's empty state (`.bal.empty`, the striped "no kills yet" bar), and
- the empty-list message (`.empty { padding: var(--mantine-spacing-xl); … }`).

The message's `padding: xl` was therefore applied to the thin empty bar, and (with `box-sizing: border-box`) that padding forced the bar's box to ~64px — which is why an explicit `height: 6px` couldn't shrink it.

## Fix

Renamed the empty-list message class to `.emptyMessage` (with a comment noting the collision), so the balance bar's `.bal.empty` modifier no longer inherits the padding.

Verified in-browser: empty bars now render **6px** (rows) / **5px** (table), matching the filled bars, with uniform row heights in both views. Type-check, ESLint, and the Active Wars tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
