### PR TITLE
perf(web): cache the market sidebar for a day to cut CockroachDB usage

### DIFF
--- a/.changeset/market-nav-cache-days.md
+++ b/.changeset/market-nav-cache-days.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Reduced the database load from the Market page's group sidebar. The sidebar's data is now cached for a day instead of an hour — it changes only when EVE ships new game data — which avoids a large, repeated database read that was driving heavy usage. The sidebar looks and behaves exactly the same, and expanding a group is still instant.

--- a/apps/web/components/Market/MarketGroupsNavigation.tsx
+++ b/apps/web/components/Market/MarketGroupsNavigation.tsx
@@ -6,7 +6,17 @@ import { MarketGroupNavLink } from "./MarketGroupNavLink";
 
 export async function MarketGroupsNavigation() {
   "use cache";
-  cacheLife("hours");
+  // Load the whole market tree (groups + their types) up front so expanding a
+  // group is instant — no per-group loading spinner. This is one large read of
+  // the Type table (Prisma resolves the `types` relation as
+  // `SELECT ... FROM "Type" WHERE "marketGroupId" IN (…all groups…)`), so it
+  // MUST stay cached: at "hours" it re-ran ~24×/day per region (and on every
+  // deploy) and became ~30% of the database's request-unit usage. The market
+  // taxonomy only moves when a new SDE build is ingested (rare), so cache it for
+  // a day. NB: if this payload ever exceeds the platform's per-entry data-cache
+  // limit it silently won't be stored and the query runs per request again —
+  // watch the DB's top statements after deploying.
+  cacheLife("days");
 
   const marketGroups = await prisma.marketGroup.findMany({
     select: {


### PR DESCRIPTION
## What

The Market page's group sidebar (`MarketGroupsNavigation`) loads the whole market tree — every group **plus its types** — up front, so expanding a group is instant. Prisma resolves the nested `types` relation as:

```sql
SELECT "typeId","name","marketGroupId" FROM "Type" WHERE "marketGroupId" IN (…every group…)
```

— one large read of the `Type` table. It was cached with `cacheLife("hours")`, but that re-ran the query ~24×/day per region (and on every deploy, since `"use cache"` entries reset per deploy), and this single statement grew to **~30% of CockroachDB Cloud request-unit usage over 48h**.

## Change

One line: `cacheLife("hours")` → `cacheLife("days")`. The market taxonomy only changes when EVE ships a new SDE build (rare), so a day-long cache is safe and cuts the query's execution frequency ~24×.

The sidebar is otherwise **unchanged** — the eager load is kept on purpose, so expanding a group stays instant with no per-group loading spinners.

## Why not lazy-load per group?

An earlier revision of this PR lazy-loaded each group's types on expand (tiny per-group queries). It fixed the DB cost too, but it introduced a loading spinner every time you open a group. Since the cost problem was driven by *frequency*, not the per-run size, the cache bump alone addresses it while preserving the instant-expand UX — so the lazy-load was dropped.

## Caveat to watch

The eager payload ships every market type's `{ typeId, name }` in one cached entry. If that ever exceeds the platform's per-cache-entry size limit (~2MB for the Next.js data cache), the entry is silently **not** stored and the query runs per request again — which would make this bump a no-op. **After deploy, check CockroachDB → Statements:** the `Type … marketGroupId IN … OFFSET` statement should fall off the top consumers. If it doesn't, the follow-up is to filter the sidebar to `published` types (smaller payload) or go back to lazy per-group loading.

## Verification

- Full web Jest suite green; `MarketGroupNavLink` tests pass (behaviour unchanged).
- Type-check clean on the changed file; ESLint pre-commit gate passed.
- Not driven in a live browser here — this worktree has no root `.env` and the sidebar reads the real SDE dataset (prod CockroachDB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)