### PR TITLE
fix(web): wrap Compare table header cells in a row to stop hydration mismatch

### DIFF
--- a/.changeset/fix-compare-table-header-markup.md
+++ b/.changeset/fix-compare-table-header-markup.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed a rendering glitch on the Compare page where the table header could briefly flicker and re-render on load.

--- a/apps/web/components/Compare/CompareTable.tsx
+++ b/apps/web/components/Compare/CompareTable.tsx
@@ -83,17 +83,19 @@ export const CompareTable = memo(({ typeIds }: CompareTableProps) => {
     <>
       <Table highlightOnHover>
         <Table.Thead>
-          <th>Attribute</th>
-          {sortedTypes.map((type) => (
-            <th key={type.type_id}>
-              <Group gap="xs">
-                <TypeAvatar typeId={type.type_id} size="sm" />
-                <TypeAnchor typeId={type.type_id} target="_blank">
-                  <TypeName typeId={type.type_id} />
-                </TypeAnchor>
-              </Group>
-            </th>
-          ))}
+          <Table.Tr>
+            <Table.Th>Attribute</Table.Th>
+            {sortedTypes.map((type) => (
+              <Table.Th key={type.type_id}>
+                <Group gap="xs">
+                  <TypeAvatar typeId={type.type_id} size="sm" />
+                  <TypeAnchor typeId={type.type_id} target="_blank">
+                    <TypeName typeId={type.type_id} />
+                  </TypeAnchor>
+                </Group>
+              </Table.Th>
+            ))}
+          </Table.Tr>
         </Table.Thead>
         <Table.Tbody>
           {sortedAttributes.map((attribute) => (


### PR DESCRIPTION
## What

The Compare page (`/compare`) rendered its header cells as loose `<th>` directly inside `<Table.Thead>` with no row wrapper:

```tsx
<Table.Thead>
  <th>Attribute</th>
  {sortedTypes.map((type) => (<th key={type.type_id}>…</th>))}
</Table.Thead>
```

This wraps the header cells in `<Table.Tr>` and switches the raw `<th>` to Mantine's `<Table.Th>`, matching the `<Table.Tbody>` pattern right below it (and the other tables in the app). Keys and the `TypeAvatar`/`TypeAnchor`/`TypeName` contents are unchanged.

## Why

The browser's HTML parser inserts an implied `<tr>` around loose `<th>` inside `<thead>`, so the server-rendered DOM (`<thead><tr><th>`) didn't match React's client tree (`<thead><th>`). That produced a **React 19 hydration mismatch** — a recoverable error plus a full client re-render (and Sentry noise) on **every** `/compare` load. It fired even with no types selected, since the lone "Attribute" header is enough to trigger it. In dev it also logged a `validateDOMNesting` warning.

## Verification

- **SSR HTML** now emits `<thead><tr class="mantine-Table-tr">…<th>Attribute</th></tr></thead>` — the same structure the parser produces and React expects, so there's no server/client mismatch. Confirmed against the live hydrated DOM (`thead` has only `<tr>` children) and the raw server response.
- Browser-checked `/compare`: renders cleanly, no hydration error, no Next.js error overlay.
- **Jest**: `dataTables.test.tsx` + `compareToolPage.test.tsx` pass (29/29); no test changes needed since they assert on text, not header markup. `CompareTable.tsx` stays at 100% line coverage.
- **Type-check** / **lint**: no new errors reference the touched file.

## Changeset

`@jitaspace/web` patch — user-facing: "Fixed a rendering glitch on the Compare page where the table header could briefly flicker and re-render on load."

🤖 Generated with [Claude Code](https://claude.com/claude-code)