### PR TITLE
perf(web): stop fetching every calendar event's details up front

### DIFF
--- a/.changeset/calendar-list-fewer-fetches.md
+++ b/.changeset/calendar-list-fewer-fetches.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Made the Calendar page load much faster. It no longer fetches every event's full details and attendee list up front just to render the day view — the response status now comes straight from the calendar feed, and the owner and attendees load only when you open an event. Opening a busy calendar previously fired 100+ background requests before you could interact with it; now it fires almost none.

--- a/apps/web/components/Badge/CalendarEventResponseBadge.tsx
+++ b/apps/web/components/Badge/CalendarEventResponseBadge.tsx
@@ -3,30 +3,39 @@
 import type { BadgeProps } from "@mantine/core";
 import { memo } from "react";
 
+import type { CalendarEventResponse } from "@jitaspace/ui";
 import { useCalendarEvent } from "@jitaspace/hooks";
 import { CalendarEventResponseBadge as UICalendarEventResponseBadge } from "@jitaspace/ui";
 
 export type CalendarEventResponseBadgeProps = BadgeProps & {
   characterId?: number;
   eventId?: number;
+  /**
+   * The response value, when the caller already has it (e.g. from the calendar
+   * summary feed, which includes `event_response`). When provided, the per-event
+   * detail request is skipped entirely.
+   */
+  response?: CalendarEventResponse;
 };
 
 export const CalendarEventResponseBadge = memo(
   ({
     characterId,
     eventId,
+    response,
     ...otherProps
   }: CalendarEventResponseBadgeProps) => {
-    const { data: event } = useCalendarEvent(characterId, eventId);
+    // Only fetch the event detail when the response wasn't supplied directly —
+    // passing an undefined eventId keeps the underlying query disabled.
+    const { data: event } = useCalendarEvent(
+      characterId,
+      response === undefined ? eventId : undefined,
+    );
     return (
       <UICalendarEventResponseBadge
         response={
-          event?.data.response as
-            | "accepted"
-            | "tentative"
-            | "not_responded"
-            | "declined"
-            | undefined
+          response ??
+          (event?.data.response as CalendarEventResponse | undefined)
         }
         {...otherProps}
       />

--- a/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx
@@ -1,16 +1,12 @@
 import type { TableProps } from "@mantine/core";
-import { Anchor, Group, Table, Title, Tooltip } from "@mantine/core";
+import { Anchor, Group, Table, Title } from "@mantine/core";
 import { openContextModal } from "@mantine/modals";
 
 import type { CalendarEvent } from "@jitaspace/hooks";
 import { WarningIcon } from "@jitaspace/eve-icons";
 import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
 
-import { CalendarEventOwnerAnchor } from "~/components/Anchor";
-import { CalendarEventOwnerAvatar } from "~/components/Avatar";
-import { CalendarEventAttendeesAvatarGroup } from "~/components/AvatarGroup";
 import { CalendarEventResponseBadge } from "~/components/Badge";
-import { CalendarEventOwnerName } from "~/components/Text";
 
 type EventListProps = TableProps & {
   characterId: number;
@@ -37,74 +33,41 @@ export function DesktopCalendarEventList({
               </DateHoverCard>
             </Table.Td>
             <Table.Td>
-              <Group wrap="nowrap">
-                <Tooltip
-                  label={
-                    <CalendarEventOwnerName
-                      characterId={characterId}
-                      eventId={event.event_id}
-                    />
-                  }
-                >
-                  <div>
-                    <CalendarEventOwnerAnchor
-                      characterId={characterId}
-                      eventId={event.event_id}
-                    >
-                      <CalendarEventOwnerAvatar
-                        characterId={characterId}
-                        eventId={event.event_id}
-                        size="sm"
-                      />
-                    </CalendarEventOwnerAnchor>
-                  </div>
-                </Tooltip>
-                <Group wrap="nowrap" gap="xs">
-                  {event.importance === 1 && <WarningIcon width={20} />}
-                  <Anchor
-                    size="sm"
-                    lineClamp={1}
-                    onClick={() => {
-                      if (event.event_id) {
-                        openContextModal({
-                          modal: "viewCalendarEvent",
-                          title: (
-                            <Title order={4}>
-                              {event.importance === 1 && (
-                                <WarningIcon width={32} />
-                              )}
-                              {event.title}
-                            </Title>
-                          ),
-                          size: "lg",
-                          innerProps: { characterId, eventId: event.event_id },
-                        });
-                      }
-                    }}
-                  >
-                    {event.title}
-                  </Anchor>
-                </Group>
-              </Group>
-            </Table.Td>
-            <Table.Td align="right" width={1}>
-              <Group justify="flex-end">
-                <CalendarEventAttendeesAvatarGroup
-                  characterId={characterId}
-                  eventId={event.event_id}
-                  limit={5}
+              {/* Owner and attendees are fetched per event (detail endpoint), so
+                  they are shown in the details modal rather than eagerly per row. */}
+              <Group wrap="nowrap" gap="xs">
+                {event.importance === 1 && <WarningIcon width={20} />}
+                <Anchor
                   size="sm"
-                  radius="xl"
-                />
+                  lineClamp={1}
+                  onClick={() => {
+                    if (event.event_id) {
+                      openContextModal({
+                        modal: "viewCalendarEvent",
+                        title: (
+                          <Title order={4}>
+                            {event.importance === 1 && (
+                              <WarningIcon width={32} />
+                            )}
+                            {event.title}
+                          </Title>
+                        ),
+                        size: "lg",
+                        innerProps: { characterId, eventId: event.event_id },
+                      });
+                    }
+                  }}
+                >
+                  {event.title}
+                </Anchor>
               </Group>
             </Table.Td>
             <Table.Td align="right" width={1}>
               <CalendarEventResponseBadge
                 size="sm"
                 variant="subtle"
-                characterId={characterId}
                 w={130}
-                eventId={event.event_id}
+                response={event.event_response}
               />
             </Table.Td>
           </Table.Tr>

--- a/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
+++ b/apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx
@@ -1,16 +1,12 @@
 import type { TableProps } from "@mantine/core";
-import { Anchor, Group, Stack, Table, Title, Tooltip } from "@mantine/core";
+import { Anchor, Group, Stack, Table, Title } from "@mantine/core";
 import { openContextModal } from "@mantine/modals";
 
 import type { CalendarEvent } from "@jitaspace/hooks";
 import { WarningIcon } from "@jitaspace/eve-icons";
 import { DateHoverCard, FormattedDateText } from "@jitaspace/ui";
 
-import { CalendarEventOwnerAnchor } from "~/components/Anchor";
-import { CalendarEventOwnerAvatar } from "~/components/Avatar";
-import { CalendarEventAttendeesAvatarGroup } from "~/components/AvatarGroup";
 import { CalendarEventResponseBadge } from "~/components/Badge";
-import { CalendarEventOwnerName } from "~/components/Text";
 
 type EventListProps = TableProps & {
   characterId: number;
@@ -29,51 +25,20 @@ export function MobileCalendarEventList({
           <Table.Tr key={event.event_id}>
             <Table.Td>
               <Stack>
+                {/* Owner and attendees are fetched per event (detail endpoint),
+                    so they are shown in the details modal rather than per row. */}
                 <Group justify="space-between" gap="xs">
-                  <Group>
-                    <DateHoverCard date={new Date(event.event_date ?? 0)}>
-                      <FormattedDateText
-                        size="sm"
-                        date={new Date(event.event_date ?? 0)}
-                        format="HH:mm"
-                      />
-                    </DateHoverCard>
-                    <Tooltip
-                      label={
-                        <CalendarEventOwnerName
-                          characterId={characterId}
-                          eventId={event.event_id}
-                        />
-                      }
-                    >
-                      <div>
-                        <CalendarEventOwnerAnchor
-                          characterId={characterId}
-                          eventId={event.event_id}
-                        >
-                          <CalendarEventOwnerAvatar
-                            characterId={characterId}
-                            eventId={event.event_id}
-                            size="sm"
-                          />
-                        </CalendarEventOwnerAnchor>
-                      </div>
-                    </Tooltip>
-                  </Group>
-                  <Group justify="flex-end">
-                    <CalendarEventAttendeesAvatarGroup
-                      characterId={characterId}
-                      eventId={event.event_id}
-                      limit={3}
+                  <DateHoverCard date={new Date(event.event_date ?? 0)}>
+                    <FormattedDateText
                       size="sm"
-                      radius="xl"
+                      date={new Date(event.event_date ?? 0)}
+                      format="HH:mm"
                     />
-                    <CalendarEventResponseBadge
-                      characterId={characterId}
-                      size="xs"
-                      eventId={event.event_id}
-                    />
-                  </Group>
+                  </DateHoverCard>
+                  <CalendarEventResponseBadge
+                    size="xs"
+                    response={event.event_response}
+                  />
                 </Group>
                 <Group wrap="nowrap" gap="xs">
                   {event.importance === 1 && <WarningIcon width={20} />}

--- a/apps/web/tests/BadgeAnchorWrappers.test.tsx
+++ b/apps/web/tests/BadgeAnchorWrappers.test.tsx
@@ -267,6 +267,22 @@ describe("CalendarEventResponseBadge (wrapper)", () => {
       "no-response",
     );
   });
+
+  it("uses a provided response directly and skips the per-event fetch", () => {
+    mockUseCalendarEvent.mockReturnValue({ data: undefined });
+    const { CalendarEventResponseBadge } = badges();
+
+    renderWithMantine(
+      <CalendarEventResponseBadge characterId={123} response="declined" />,
+    );
+
+    // The response is already known (from the summary feed), so no event id is
+    // passed to the detail hook — its query stays disabled.
+    expect(mockUseCalendarEvent).toHaveBeenCalledWith(123, undefined);
+    expect(screen.getByTestId("ui-event-response")).toHaveTextContent(
+      "declined",
+    );
+  });
 });
 
 describe("MailLabelBadge (wrapper)", () => {

--- a/apps/web/tests/CalendarComponents.test.tsx
+++ b/apps/web/tests/CalendarComponents.test.tsx
@@ -82,33 +82,20 @@ jest.mock("~/components/Avatar", () => ({
   ),
 }));
 
-jest.mock("~/components/Anchor", () => ({
-  CalendarEventOwnerAnchor: ({ children }: { children?: ReactNode }) => (
-    <a href="#">{children}</a>
-  ),
-}));
-
-jest.mock("~/components/AvatarGroup", () => ({
-  CalendarEventAttendeesAvatarGroup: ({ eventId }: { eventId?: number }) => (
-    <span>{`Attendees ${eventId}`}</span>
-  ),
-}));
-
 jest.mock("~/components/Badge", () => ({
-  CalendarEventResponseBadge: ({ eventId }: { eventId?: number }) => (
-    <span>{`ResponseBadge ${eventId}`}</span>
-  ),
+  // The list passes the summary's `response`; the details panel passes `eventId`.
+  CalendarEventResponseBadge: ({
+    eventId,
+    response,
+  }: {
+    eventId?: number;
+    response?: string;
+  }) => <span>{`ResponseBadge ${response ?? eventId}`}</span>,
 }));
 
 jest.mock("~/components/DurationText", () => ({
   CalendarEventHumanDurationText: ({ eventId }: { eventId?: number }) => (
     <span>{`Duration ${eventId}`}</span>
-  ),
-}));
-
-jest.mock("~/components/Text", () => ({
-  CalendarEventOwnerName: ({ eventId }: { eventId?: number }) => (
-    <span>{`OwnerName ${eventId}`}</span>
   ),
 }));
 
@@ -257,12 +244,14 @@ const SAMPLE_EVENTS = [
     event_date: "2024-06-01T18:00:00Z",
     title: "CTA Fleet",
     importance: 1,
+    event_response: "accepted",
   },
   {
     event_id: 12,
     event_date: "2024-06-02T20:00:00Z",
     title: "Mining Op",
     importance: 0,
+    event_response: "declined",
   },
 ];
 
@@ -291,10 +280,11 @@ describe("DesktopCalendarEventList", () => {
     );
   });
 
-  it("renders attendees and response badge per event", () => {
+  it("renders the response badge from the summary feed per event", () => {
     renderList();
-    expect(screen.getByText("Attendees 11")).toBeInTheDocument();
-    expect(screen.getByText("ResponseBadge 11")).toBeInTheDocument();
+    // The badge reads `event_response` from the summary — no per-row detail fetch.
+    expect(screen.getByText("ResponseBadge accepted")).toBeInTheDocument();
+    expect(screen.getByText("ResponseBadge declined")).toBeInTheDocument();
   });
 
   it("opens the view-calendar-event modal when a title is clicked", async () => {
@@ -332,10 +322,11 @@ describe("MobileCalendarEventList", () => {
     expect(screen.getByText("Mining Op")).toBeInTheDocument();
   });
 
-  it("renders attendees and response badge per event", () => {
+  it("renders the response badge from the summary feed per event", () => {
     renderList();
-    expect(screen.getByText("Attendees 11")).toBeInTheDocument();
-    expect(screen.getByText("ResponseBadge 11")).toBeInTheDocument();
+    // The badge reads `event_response` from the summary — no per-row detail fetch.
+    expect(screen.getByText("ResponseBadge accepted")).toBeInTheDocument();
+    expect(screen.getByText("ResponseBadge declined")).toBeInTheDocument();
   });
 
   it("opens the view-calendar-event modal when a title is clicked", async () => {


### PR DESCRIPTION
## What & why

Opening `/calendar` with a busy month fired **100+ authenticated ESI calls before the user could interact**. Each event row rendered:

- `CalendarEventResponseBadge` + `CalendarEventOwnerName`/`Anchor`/`Avatar` — all calling `useCalendarEvent`, which React Query dedupes into **one `GET /characters/{id}/calendar/{event_id}` detail request per event**, and
- `CalendarEventAttendeesAvatarGroup` — a **second request per event** (`.../attendees`) that then fans out into per-attendee portraits.

Both the Desktop and Mobile lists stay mounted (one is only CSS-hidden via `visibleFrom`/`hiddenFrom`) and the page renders one list per day, so ~50 events ≈ 100+ eager authenticated calls plus a portrait fan-out.

## The fix

- **Response badge reads from the summary feed.** The calendar summary (`useCharacterCalendar` → `CharactersCharacterIdCalendarGet`) already includes `event_response`. `CalendarEventResponseBadge` now takes an optional `response` value-provided prop; when set it passes an `undefined` eventId to `useCalendarEvent`, keeping the underlying query **disabled**. Both lists pass `event.event_response` straight through — **zero detail fetches for the badge**.
- **Owner + attendees are deferred to the details modal.** The summary has no owner/attendee data, so those genuinely need the detail/attendees endpoints. Since the event details modal (`openContextModal("viewCalendarEvent")` → `CalendarEventDetailsPanel`) already renders full owner + attendee detail, the eager per-row owner and attendees group were removed from both list rows entirely.
- The **fetch-by-id path is untouched** for other callers — the details panel and the `/calendar/[eventId]` page keep working exactly as before.

Net effect: the day view fires **no per-row detail/attendee requests on initial load**; owner/attendees load only when an event is opened.

## Changed files

- `apps/web/components/Badge/CalendarEventResponseBadge.tsx` — optional `response` prop (skips fetch when provided)
- `apps/web/components/Calendar/CalendarEventList/DesktopCalendarEventList.tsx` — pass summary `event_response`; drop eager owner/attendees
- `apps/web/components/Calendar/CalendarEventList/MobileCalendarEventList.tsx` — same
- Tests + a user-facing changeset

## Verification

- **Jest**: all relevant suites green (badge/owner/avatar wrappers, both lists, calendar page, event page). The three touched components report 100% statement/function/line coverage. Added a case proving the `response`-provided path skips the fetch, and updated the list mocks/assertions (badge now reads `event_response`; attendees no longer rendered in the list).
- **Type-check**: touched files clean; repo baseline unchanged (identical error count with the change stashed — all pre-existing, none calendar-list-related).
- **Lint**: 0 errors on touched files (pre-commit `turbo lint` + `manypkg check` passed).

> Note: the before/after network reduction can't be observed live in this environment because `/calendar` only renders events (and issues ESI calls) for an authenticated EVE character, and SSO login isn't possible here. The Jest tests render both real list components with sample events and assert the resulting DOM, which is the stronger check in this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)