### PR TITLE
perf(web): batch war killmails to stop large-war freeze

### DIFF
--- a/.changeset/war-killmails-load-more.md
+++ b/.changeset/war-killmails-load-more.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the war report page freezing on wars with many killmails. Killmails now load in batches of 25 with a "Load more" button, instead of loading every kill at once.

--- a/apps/web/app/war/[warId]/page.client.tsx
+++ b/apps/web/app/war/[warId]/page.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { Button, Container, Group, Stack, Text, Title } from "@mantine/core";
@@ -34,6 +35,11 @@ import {
 import { KillmailCard } from "~/components/Killmails";
 import { WarAggressorName, WarDefenderName } from "~/components/Text";
 
+// How many killmail cards to mount at once. Each card fires its own ESI
+// requests, so rendering an entire war's worth (up to ~2000) at once floods
+// the rate-limited client and freezes the tab. We reveal them in batches.
+const KILLMAILS_PER_PAGE = 25;
+
 export default function Page() {
   const params = useParams();
   const rawWarId = params.warId;
@@ -42,9 +48,25 @@ export default function Page() {
   const { data: war } = useWar(warId);
   const { data: killmails } = useWarKillmails(warId);
 
+  const [visibleKillmailCount, setVisibleKillmailCount] =
+    useState(KILLMAILS_PER_PAGE);
+
+  // Reset the visible window when navigating between wars. The page component
+  // is reused across warId changes, so we reset during render (React's
+  // recommended pattern) instead of in an effect, which would cascade renders.
+  const [trackedWarId, setTrackedWarId] = useState(warId);
+  if (warId !== trackedWarId) {
+    setTrackedWarId(warId);
+    setVisibleKillmailCount(KILLMAILS_PER_PAGE);
+  }
+
   if (!Number.isFinite(warId)) {
     return null;
   }
+
+  const allKillmails = killmails?.data ?? [];
+  const visibleKillmails = allKillmails.slice(0, visibleKillmailCount);
+  const hasMoreKillmails = visibleKillmailCount < allKillmails.length;
 
   return (
     <Container size="lg">
@@ -209,15 +231,27 @@ export default function Page() {
             </Group>
           ))}
         </Stack>
-        <Title order={4}>Killmails ({(killmails?.data ?? []).length})</Title>
+        <Title order={4}>Killmails ({allKillmails.length})</Title>
         <Stack>
-          {(killmails?.data ?? []).map((killmail) => (
+          {visibleKillmails.map((killmail) => (
             <KillmailCard
               key={killmail.killmail_id}
               killmailId={killmail.killmail_id}
               killmailHash={killmail.killmail_hash}
             />
           ))}
+          {hasMoreKillmails && (
+            <Button
+              w="100%"
+              variant="default"
+              onClick={() =>
+                setVisibleKillmailCount((count) => count + KILLMAILS_PER_PAGE)
+              }
+            >
+              Load more killmails (
+              {allKillmails.length - visibleKillmails.length} remaining)
+            </Button>
+          )}
         </Stack>
       </Stack>
     </Container>

--- a/apps/web/tests/warPage.test.tsx
+++ b/apps/web/tests/warPage.test.tsx
@@ -1,9 +1,16 @@
 import "@testing-library/jest-dom/jest-globals";
 
-import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { ReactNode } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
 import { MantineProvider } from "@mantine/core";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 const WAR_ID = 30000142;
 
@@ -118,10 +125,7 @@ describe("War page", () => {
           finished: "2020-01-04T00:00:00Z",
           mutual: true,
           open_for_allies: true,
-          allies: [
-            { alliance_id: 99000003 },
-            { corporation_id: 1000036 },
-          ],
+          allies: [{ alliance_id: 99000003 }, { corporation_id: 1000036 }],
         },
       },
     });
@@ -173,6 +177,39 @@ describe("War page", () => {
     expect(screen.getByText("Killmails (3)")).toBeInTheDocument();
     expect(screen.getAllByTestId("killmail-card")).toHaveLength(3);
     expect(screen.getByText("Killmail 1")).toBeInTheDocument();
+  });
+
+  it("mounts killmails in bounded batches and reveals more on demand", () => {
+    mockUseSelectedCharacter.mockReturnValue(undefined);
+    mockUseWar.mockReturnValue({ data: undefined });
+    const killmails = Array.from({ length: 30 }, (_, index) => ({
+      killmail_id: index + 1,
+      killmail_hash: `hash${index + 1}`,
+    }));
+    mockUseWarKillmails.mockReturnValue({ data: { data: killmails } });
+
+    renderPage();
+
+    // Title reflects the FULL count, not the sliced window.
+    expect(screen.getByText("Killmails (30)")).toBeInTheDocument();
+
+    // Only the first batch of 25 cards is mounted initially.
+    expect(screen.getAllByTestId("killmail-card")).toHaveLength(25);
+    expect(screen.getByText("Killmail 25")).toBeInTheDocument();
+    expect(screen.queryByText("Killmail 26")).not.toBeInTheDocument();
+
+    // "Load more" reveals the next batch (capped at the total).
+    fireEvent.click(
+      screen.getByRole("button", { name: /Load more killmails/ }),
+    );
+
+    expect(screen.getAllByTestId("killmail-card")).toHaveLength(30);
+    expect(screen.getByText("Killmail 30")).toBeInTheDocument();
+
+    // Nothing left to load -> button gone.
+    expect(
+      screen.queryByRole("button", { name: /Load more killmails/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders the empty war state (no war data, no killmails)", () => {


### PR DESCRIPTION
## What

The war report page (`/war/[warId]`) now loads killmails in batches of **25** with a **"Load more"** button, instead of mounting every killmail at once.

## Why

`page.client.tsx` mapped *every* killmail (up to ~2000 from one ESI page) to a `<KillmailCard>`. Each card fires its own `useKillmail` request plus several entity name/avatar fetches through the rate-limited axios ESI client. On a large war this mounted thousands of cards and fired thousands of concurrent ESI requests — freezing the tab and burning the visitor's ESI budget.

This mirrors the existing `/mail` "Load more" pattern to keep the fix low-risk.

## How

- Added a `visibleKillmailCount` state (starts at `KILLMAILS_PER_PAGE = 25`) and render only `killmails.slice(0, visibleKillmailCount)`.
- Added a **"Load more killmails (N remaining)"** button that reveals +25 per click, shown only while more remain.
- The **"Killmails (N)"** title still uses the *full* list length, not the sliced window.
- The visible window resets **during render** (React's recommended pattern for resetting state on a prop change) when `warId` changes, since the page component is reused across war-to-war navigations. Used render-phase reset rather than an effect to satisfy the `react-hooks/set-state-in-effect` lint rule.
- `KillmailCard` itself is unchanged.

## Reviewer notes

- **Test:** [`warPage.test.tsx`](apps/web/tests/warPage.test.tsx) gains a case asserting 25 cards mount initially for a 30-killmail war, that "Load more" reveals the rest, and that the button disappears when exhausted. All 5 tests pass; `page.client.tsx` at ~97% coverage.
- **Type-check:** apps/web baseline is unchanged (no new errors introduced by this change).
- **Manual verification:** against a real 57-killmail war, the page showed `Killmails (57)` with 25 cards mounted → "Load more killmails (32 remaining)" → click → 50 cards "(7 remaining)" → click → 57 cards, button gone. The title stayed at 57 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)