### PR TITLE
fix(web): close backslash open-redirect in OAuth returnTo guard

### DIFF
--- a/.changeset/fix-return-to-open-redirect.md
+++ b/.changeset/fix-return-to-open-redirect.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Hardened the post-login redirect so it can only ever return you to a page on jita.space. Previously a crafted link could slip a backslash past the safety check and bounce you to an external site after signing in; the redirect target is now validated to be same-origin.

--- a/apps/web/app/login/complete/page.tsx
+++ b/apps/web/app/login/complete/page.tsx
@@ -7,12 +7,8 @@ import posthog from "posthog-js";
 
 import { useAuthStore } from "@jitaspace/hooks";
 
+import { sanitizeReturnTo } from "~/lib/returnTo";
 import { consumeLoginResult } from "./actions";
-
-function safeReturnTo(value: string | null): string {
-  if (value && value.startsWith("/") && !value.startsWith("//")) return value;
-  return "/";
-}
 
 /**
  * Terminal page of the OAuth flow: drains the single-use result cookie via a
@@ -29,7 +25,7 @@ export default function LoginCompletePage() {
     if (hasRun.current) return;
     hasRun.current = true;
 
-    const returnTo = safeReturnTo(
+    const returnTo = sanitizeReturnTo(
       new URLSearchParams(globalThis.location.search).get("returnTo"),
     );
 

--- a/apps/web/lib/returnTo.ts
+++ b/apps/web/lib/returnTo.ts
@@ -1,0 +1,28 @@
+/**
+ * Open-redirect guard for the OAuth `returnTo` parameter. Kept in its own
+ * client-safe module (no server-only imports) so the server route
+ * (`serverAuth.ts`) and the client login/complete page share one implementation
+ * and cannot drift.
+ *
+ * The value is resolved against a fixed, unreachable base and accepted only when
+ * it stays same-origin. This closes bypasses that a naive
+ * `startsWith("/") && !startsWith("//")` check misses — most notably backslash
+ * paths like `/\evil.com`, which the WHATWG URL parser normalises to `//evil.com`
+ * and thus resolves to `https://evil.com/`.
+ */
+export function sanitizeReturnTo(value: string | null | undefined): string {
+  if (!value) return "/";
+  try {
+    const base = "https://x.invalid";
+    const url = new URL(value, base);
+    // Absolute, protocol-relative, and backslash paths resolve to a different
+    // origin than the base — reject them.
+    if (url.origin !== base) return "/";
+    // Control characters (tab, newline, etc.) are stripped by browsers before
+    // the URL is parsed, so they could smuggle a payload past the origin check.
+    if ([...value].some((char) => char.charCodeAt(0) < 0x20)) return "/";
+    return url.pathname + url.search + url.hash;
+  } catch {
+    return "/";
+  }
+}

--- a/apps/web/lib/serverAuth.ts
+++ b/apps/web/lib/serverAuth.ts
@@ -1,5 +1,9 @@
 import type { NextRequest } from "next/server";
 
+// Re-exported from a client-safe module so this server helper and the client
+// login/complete page share one open-redirect guard implementation.
+export { sanitizeReturnTo } from "./returnTo";
+
 /**
  * Resolve the externally-visible origin of the request, honouring the
  * reverse-proxy headers Vercel sets. Used to build the OAuth `redirect_uri`
@@ -13,15 +17,4 @@ export function getRequestOrigin(req: NextRequest): string {
     forwardedProto?.split(",")[0]?.trim() ??
     req.nextUrl.protocol.replace(":", "");
   return `${proto}://${host}`;
-}
-
-/**
- * Open-redirect guard: only allow same-site relative paths. Rejects absolute
- * URLs and protocol-relative ("//evil.com") paths.
- */
-export function sanitizeReturnTo(returnTo: string | null | undefined): string {
-  if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
-    return returnTo;
-  }
-  return "/";
 }

--- a/apps/web/tests/returnTo.test.ts
+++ b/apps/web/tests/returnTo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { sanitizeReturnTo } from "../lib/returnTo";
+
+// Built via char codes so the source stays unambiguous — no raw control
+// characters or hard-to-spot backslash escapes in the test literals.
+const BACKSLASH = String.fromCharCode(0x5c); // "\"
+const TAB = String.fromCharCode(0x09);
+const NEWLINE = String.fromCharCode(0x0a);
+const NUL = String.fromCharCode(0x00);
+
+describe("sanitizeReturnTo", () => {
+  it("keeps same-origin relative paths, preserving query and hash", () => {
+    expect(sanitizeReturnTo("/mail?x=1#y")).toBe("/mail?x=1#y");
+    expect(sanitizeReturnTo("/skills")).toBe("/skills");
+    expect(sanitizeReturnTo("/lp-store?corp=1")).toBe("/lp-store?corp=1");
+  });
+
+  it("defaults to / for empty, null, or undefined values", () => {
+    expect(sanitizeReturnTo(null)).toBe("/");
+    expect(sanitizeReturnTo(undefined)).toBe("/");
+    expect(sanitizeReturnTo("")).toBe("/");
+  });
+
+  it("rejects absolute and protocol-relative URLs", () => {
+    expect(sanitizeReturnTo("https://evil.com")).toBe("/");
+    expect(sanitizeReturnTo("//evil.com")).toBe("/");
+  });
+
+  it("rejects backslash paths the WHATWG URL parser normalises off-origin", () => {
+    // The parser reads "\" as "/", so `/\evil.com` resolves to https://evil.com/
+    // — the open-redirect bypass this guard closes.
+    expect(sanitizeReturnTo("/" + BACKSLASH + "evil.com")).toBe("/");
+    expect(sanitizeReturnTo("/" + BACKSLASH + "/evil.com")).toBe("/");
+  });
+
+  it("rejects values containing control characters browsers would strip", () => {
+    expect(sanitizeReturnTo("/" + TAB + "evil.com")).toBe("/");
+    expect(sanitizeReturnTo("/" + NEWLINE + "evil.com")).toBe("/");
+    expect(sanitizeReturnTo("/foo" + NUL)).toBe("/");
+  });
+
+  it("falls back to / when the value cannot be parsed as a URL", () => {
+    expect(sanitizeReturnTo("http://")).toBe("/");
+  });
+});


### PR DESCRIPTION
## What & why

The post-login redirect guard for the OAuth `returnTo` parameter only checked `value.startsWith("/") && !value.startsWith("//")`. That accepts a **backslash path** like `/\evil.com`. The WHATWG URL parser normalises `\` → `/`, so `new URL("/\\evil.com", "https://www.jita.space")` resolves to `https://evil.com/`. The login-complete page then calls `router.replace(returnTo)`, which **hard-navigates off-site** after a legitimate login — an open-redirect / phishing vector.

The same weak check existed in **two** places that could drift apart:

- `apps/web/lib/serverAuth.ts` → `sanitizeReturnTo`
- `apps/web/app/login/complete/page.tsx` → `safeReturnTo`

## The fix

A single hardened `sanitizeReturnTo` that resolves the value against a fixed, unreachable base and accepts **only a same-origin result**, returning `pathname + search + hash` (else `/`). Absolute, protocol-relative, and backslash inputs all resolve to a different origin and are rejected; values containing control characters (which browsers strip before parsing) are rejected too.

Extracted into a new **client-safe** module `apps/web/lib/returnTo.ts` (no server-only imports) so both call sites share one implementation and can't drift. `serverAuth.ts` re-exports it, so the login route's `import { ... } from "~/lib/serverAuth"` is unchanged; the login-complete page imports it from `~/lib/returnTo`.

## Behaviour

| input | before | after |
| --- | --- | --- |
| `/\evil.com` | passed through → `https://evil.com/` | `/` |
| `//evil.com` | `/` | `/` |
| `https://evil.com` | `/` | `/` |
| `/\/evil.com` | passed through | `/` |
| `/mail?x=1#y` | `/mail?x=1#y` | `/mail?x=1#y` |

## Testing

- New `apps/web/tests/returnTo.test.ts` covers backslash, protocol-relative, absolute, control-char, same-origin-with-query/hash, and unparseable inputs — `returnTo.ts` is at **100%** coverage.
- Existing `authLoginRoute` and `loginCompletePage` tests pass unchanged (behaviour for legitimate `/skills`-style targets is preserved). **13/13** across the three suites.
- Touched files type-check and lint clean; `pnpm exec prettier` reports them already formatted.

## Reviewer notes

- The control-character reject flags any character whose code point is below `0x20` (checked via `charCodeAt`) — this avoids needing a `no-control-regex` eslint-disable for a control-char regex literal.
- `getRequestOrigin` stays in `serverAuth.ts` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
