### PR TITLE
feat(esi-client): bump ESI compatibility date to 2026-07-17

### DIFF
--- a/.changeset/esi-compatibility-date-2026-07-17-web.md
+++ b/.changeset/esi-compatibility-date-2026-07-17-web.md
@@ -2,4 +2,6 @@
 "@jitaspace/web": patch
 ---
 
-Updated JitaSpace to EVE's latest ESI API version (compatibility date 2026-07-17), keeping it current with changes CCP shipped since December. Character titles and solar system sovereignty owners continue to display correctly — EVE renamed and reworked both of those behind the scenes, and they would otherwise have silently stopped showing. The Server Status page now reports the new compatibility date, and can no longer show a stale one.
+Updated JitaSpace to EVE's latest ESI API version (compatibility date 2026-07-17), keeping it current with changes CCP shipped since December. Character titles and solar system sovereignty owners keep displaying correctly across known space — EVE renamed and reworked both behind the scenes, and they would otherwise have silently stopped showing. The Server Status page now reports the new compatibility date and can no longer show a stale one.
+
+One small regression rides along with EVE's sovereignty rework: five Drifter-hub wormhole systems (Sentinel MZ, Liberated Barbican, Sanctified Vidette, Conflux Eyrie and Azdaja Redoubt) used to show an NPC-faction owner and now show none, because EVE's new sovereignty data covers only known space. There is no replacement source for those systems.

--- a/.changeset/esi-compatibility-date-2026-07-17-web.md
+++ b/.changeset/esi-compatibility-date-2026-07-17-web.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Updated JitaSpace to EVE's latest ESI API version (compatibility date 2026-07-17), keeping it current with changes CCP shipped since December. Character titles and solar system sovereignty owners continue to display correctly — EVE renamed and reworked both of those behind the scenes, and they would otherwise have silently stopped showing. The Server Status page now reports the new compatibility date, and can no longer show a stale one.

--- a/.changeset/esi-compatibility-date-2026-07-17.md
+++ b/.changeset/esi-compatibility-date-2026-07-17.md
@@ -1,0 +1,17 @@
+---
+"@jitaspace/esi-metadata": minor
+---
+
+chore(esi-client): bump the ESI compatibility date from `2025-12-16` to `2026-07-17`
+
+Regenerates `endpointScopes` from the newly downloaded spec. The scope list itself is unchanged (ESI advertises every scope regardless of compatibility date), but the endpoint map picks up the routes added between the two dates:
+
+- **Sovereignty rework (`2026-05-19`)**: `/sovereignty/map` and `/sovereignty/structures` are gone, unified into `/sovereignty/systems`.
+- **New routes**: character access-lists, mercenary tactical operations and mercenary dens, corporation skyhooks and sovereignty hubs, `/skyhooks/raidable`, and `/meta/name`.
+
+Consumer-visible changes in `@jitaspace/esi-client` (private, so not versioned here):
+
+- `GetCharactersCharacterId` was renamed to `GetCharactersDetail` upstream, renaming every generated symbol for `GET /characters/{character_id}` (`getCharactersDetail`, `useGetCharactersDetail`, `GetCharactersDetailQueryResponse`, …).
+- `CharactersDetail.title` was renamed to `corporation_title`, and gained the required `achievement_score` plus an optional `character_title_id`.
+
+The compatibility date is now stored in one place: `download-schema` pins it in the request URL, and `buildscript.js` reads it back out of the downloaded spec's `info.version` instead of keeping a second hardcoded copy that could drift.

--- a/apps/web/app/character/[characterId]/page.tsx
+++ b/apps/web/app/character/[characterId]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
-import { getCharactersCharacterId } from "@jitaspace/esi-client";
+import { getCharactersDetail } from "@jitaspace/esi-client";
 
 import { PageSkeleton } from "~/components/PageSkeleton";
 import PageClient from "./page.client";
@@ -15,7 +15,7 @@ export async function generateMetadata({
   const id = Number(characterId);
   if (!Number.isSafeInteger(id) || id <= 0) return {};
   try {
-    const res = await getCharactersCharacterId(id);
+    const res = await getCharactersDetail(id);
     const name = res.data.name;
     const portraitUrl = `https://images.evetech.net/characters/${id}/portrait`;
     return {

--- a/apps/web/app/status/page.client.tsx
+++ b/apps/web/app/status/page.client.tsx
@@ -55,10 +55,12 @@ export default function StatusPage({
 
   const [opened, { open, close }] = useDisclosure(false);
 
-  const { data: esiStatus } = useGetMetaStatus(
-    { "X-Compatibility-Date": "2025-12-16" },
-    { query: { refetchInterval: 30 * 1000 } },
-  );
+  // Headers are omitted so the client falls back to the compatibility date the
+  // ESI client was generated against, rather than pinning a copy that silently
+  // goes stale whenever that date is bumped.
+  const { data: esiStatus } = useGetMetaStatus(undefined, {
+    query: { refetchInterval: 30 * 1000 },
+  });
 
   const webLastUpdatedDate: Date | null = useMemo(
     () =>

--- a/apps/web/components/Status/EsiStatusDashboard.tsx
+++ b/apps/web/components/Status/EsiStatusDashboard.tsx
@@ -36,10 +36,12 @@ export function EsiStatusDashboard({
   const [showAllEsiEndpoints, setShowAllEsiEndpoints] =
     useState(initialShowAll);
 
-  const { data: esiStatus } = useGetMetaStatus(
-    { "X-Compatibility-Date": "2025-12-16" },
-    { query: { refetchInterval: 30 * 1000 } },
-  );
+  // Headers are omitted so the client falls back to the compatibility date the
+  // ESI client was generated against, rather than pinning a copy that silently
+  // goes stale whenever that date is bumped.
+  const { data: esiStatus } = useGetMetaStatus(undefined, {
+    query: { refetchInterval: 30 * 1000 },
+  });
 
   // Group routes by first path segment
   const esiStatusByGroup = useMemo(() => {

--- a/apps/web/tests/characterPage.test.tsx
+++ b/apps/web/tests/characterPage.test.tsx
@@ -15,12 +15,10 @@ const mockUseCharacterSkills = jest.fn();
 const mockUseCharacterWalletBalance = jest.fn();
 const mockUseCorporationHistory = jest.fn();
 
-// page.tsx imports getCharactersCharacterId for generateMetadata; page.client
+// page.tsx imports getCharactersDetail for generateMetadata; page.client
 // imports useGetCharactersCharacterIdCorporationhistory for the timeline.
 jest.mock("@jitaspace/esi-client", () => ({
-  getCharactersCharacterId: jest
-    .fn()
-    .mockResolvedValue({ data: { name: "Test" } }),
+  getCharactersDetail: jest.fn().mockResolvedValue({ data: { name: "Test" } }),
   useGetCharactersCharacterIdCorporationhistory: (...args: unknown[]) =>
     mockUseCorporationHistory(...args),
 }));

--- a/apps/web/tests/seoMetadata.test.ts
+++ b/apps/web/tests/seoMetadata.test.ts
@@ -17,13 +17,12 @@ jest.mock("~/app/alliance/[allianceId]/page.client", () => ({
 // ESI-client mocks
 // ---------------------------------------------------------------------------
 
-const mockGetCharactersCharacterId = jest.fn();
+const mockGetCharactersDetail = jest.fn();
 const mockGetCorporationsCorporationId = jest.fn();
 const mockGetAlliancesAllianceId = jest.fn();
 
 jest.mock("@jitaspace/esi-client", () => ({
-  getCharactersCharacterId: (...a: unknown[]) =>
-    mockGetCharactersCharacterId(...a),
+  getCharactersDetail: (...a: unknown[]) => mockGetCharactersDetail(...a),
   getCorporationsCorporationId: (...a: unknown[]) =>
     mockGetCorporationsCorporationId(...a),
   getAlliancesAllianceId: (...a: unknown[]) => mockGetAlliancesAllianceId(...a),
@@ -40,11 +39,11 @@ function rp<T>(obj: T): Promise<T> {
 describe("character/[characterId] generateMetadata", () => {
   beforeEach(() => {
     jest.resetModules();
-    mockGetCharactersCharacterId.mockReset();
+    mockGetCharactersDetail.mockReset();
   });
 
   it("returns name + portrait for a valid character id", async () => {
-    mockGetCharactersCharacterId.mockResolvedValue({
+    mockGetCharactersDetail.mockResolvedValue({
       data: { name: "Jita Trader" },
     });
     const { generateMetadata } =
@@ -91,7 +90,7 @@ describe("character/[characterId] generateMetadata", () => {
   });
 
   it("returns empty object when esi-client throws", async () => {
-    mockGetCharactersCharacterId.mockRejectedValue(new Error("network error"));
+    mockGetCharactersDetail.mockRejectedValue(new Error("network error"));
     const { generateMetadata } =
       await import("~/app/character/[characterId]/page");
     expect(

--- a/packages/background-jobs/helpers/createCorpAndItsRefs.ts
+++ b/packages/background-jobs/helpers/createCorpAndItsRefs.ts
@@ -13,7 +13,7 @@ import pLimit from "p-limit";
 
 import {
   getAlliancesAllianceId,
-  getCharactersCharacterId,
+  getCharactersDetail,
   getCorporationsCorporationId,
   getUniverseBloodlines,
   getUniverseFactions,
@@ -669,7 +669,7 @@ const fetchCharactersFromEsi = (
   Promise.all(
     characterIds.map((characterId) =>
       limit(async () =>
-        getCharactersCharacterId(characterId)
+        getCharactersDetail(characterId)
           .then((res) => res.data)
           .then((character) => ({
             characterId,
@@ -682,7 +682,7 @@ const fetchCharactersFromEsi = (
             name: character.name,
             raceId: character.race_id,
             securityStatus: character.security_status ?? null,
-            title: character.title ?? null,
+            title: character.corporation_title ?? null,
             isDeleted: false,
           }))
           .catch((err) => {

--- a/packages/background-jobs/helpers/mergeEntriesIntoCharactersTable.ts
+++ b/packages/background-jobs/helpers/mergeEntriesIntoCharactersTable.ts
@@ -1,6 +1,6 @@
 import pLimit from "p-limit";
 
-import type { GetCharactersCharacterIdQueryResponse } from "@jitaspace/esi-client";
+import type { GetCharactersDetailQueryResponse } from "@jitaspace/esi-client";
 
 import type { Character } from "../db";
 import { MAX_DB_PARALLELISM } from "../config";
@@ -8,7 +8,7 @@ import { prisma } from "../db";
 import { excludeObjectKeys, updateTable } from "../utils";
 
 export const convertEsiCharacterToDomain = (
-  character: GetCharactersCharacterIdQueryResponse & { characterId: number },
+  character: GetCharactersDetailQueryResponse & { characterId: number },
 ): Omit<Character, "updatedAt" | "createdAt"> => ({
   characterId: character.characterId,
   birthday: new Date(character.birthday),
@@ -20,12 +20,12 @@ export const convertEsiCharacterToDomain = (
   name: character.name,
   raceId: character.race_id,
   securityStatus: character.security_status ?? null,
-  title: character.title ?? null,
+  title: character.corporation_title ?? null,
   isDeleted: false,
 });
 
 export const mergeEsiEntriesIntoCharactersTable = (
-  characters: (GetCharactersCharacterIdQueryResponse & {
+  characters: (GetCharactersDetailQueryResponse & {
     characterId: number;
   })[],
 ) =>

--- a/packages/background-jobs/jobs/scrape/esi/scrapeEsiCorporations.ts
+++ b/packages/background-jobs/jobs/scrape/esi/scrapeEsiCorporations.ts
@@ -2,7 +2,7 @@ import type { LimitFunction } from "p-limit";
 import pLimit from "p-limit";
 
 import {
-  getCharactersCharacterId,
+  getCharactersDetail,
   getCorporationsCorporationId,
 } from "@jitaspace/esi-client";
 
@@ -19,7 +19,7 @@ const fetchCorporationWithId = (corporationId: number) =>
   }));
 
 const fetchCharacterWithId = (characterId: number) =>
-  getCharactersCharacterId(characterId).then((res) => ({
+  getCharactersDetail(characterId).then((res) => ({
     characterId,
     ...res.data,
   }));
@@ -100,7 +100,7 @@ const processCorporationBatch = async (
           name: character.name,
           raceId: character.race_id,
           securityStatus: character.security_status ?? null,
-          title: character.title ?? null,
+          title: character.corporation_title ?? null,
           isDeleted: false,
         })),
       ),

--- a/packages/background-jobs/jobs/scrape/esi/scrapeEsiNpcCorporations.ts
+++ b/packages/background-jobs/jobs/scrape/esi/scrapeEsiNpcCorporations.ts
@@ -1,7 +1,7 @@
 import pLimit from "p-limit";
 
 import {
-  getCharactersCharacterId,
+  getCharactersDetail,
   getCorporationsCorporationId,
   getCorporationsNpccorps,
 } from "@jitaspace/esi-client";
@@ -63,7 +63,7 @@ export const scrapeEsiNpcCorporations = defineJob<
     const characters = await Promise.all(
       characterIds.map((characterId) =>
         limit(async () =>
-          getCharactersCharacterId(characterId).then((res) => ({
+          getCharactersDetail(characterId).then((res) => ({
             characterId,
             ...res.data,
           })),
@@ -126,7 +126,7 @@ export const scrapeEsiNpcCorporations = defineJob<
             name: character.name,
             raceId: character.race_id,
             securityStatus: character.security_status ?? null,
-            title: character.title ?? null,
+            title: character.corporation_title ?? null,
             isDeleted: false,
           })),
         ),

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
@@ -1,6 +1,6 @@
 import pLimit from "p-limit";
 
-import { getCharactersCharacterId } from "@jitaspace/esi-client";
+import { getCharactersDetail } from "@jitaspace/esi-client";
 import {
   getAgentInSpaceById,
   getAllAgentInSpaceIds,
@@ -55,7 +55,7 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
     const characters = await Promise.all(
       agentCharacterIds.map((characterId) =>
         limit(async () =>
-          getCharactersCharacterId(characterId).then((res) => ({
+          getCharactersDetail(characterId).then((res) => ({
             characterId,
             ...res.data,
           })),

--- a/packages/esi-client/README.md
+++ b/packages/esi-client/README.md
@@ -11,10 +11,10 @@ Provides fully typed axios-based API functions and TanStack React Query hooks fo
 ## Usage
 
 ```ts
-import { useGetCharactersCharacterId } from "@jitaspace/esi-client";
+import { useGetCharactersDetail } from "@jitaspace/esi-client";
 
 function CharacterInfo({ characterId }: { characterId: number }) {
-  const { data } = useGetCharactersCharacterId(characterId);
+  const { data } = useGetCharactersDetail(characterId);
   return <div>{data?.data.name}</div>;
 }
 ```

--- a/packages/esi-client/package.json
+++ b/packages/esi-client/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf .turbo node_modules src/generated src/build-data.json",
-    "download-schema": "curl -L \"https://esi.evetech.net/meta/openapi.json?compatibility_date=2025-12-16\" | jq 'del(.paths.\"/route/{origin}/{destination}/\") | (.. | objects | select(.name == \"X-Compatibility-Date\")) .required = false' > swagger.json",
+    "download-schema": "curl -L \"https://esi.evetech.net/meta/openapi.json?compatibility_date=2026-07-17\" | jq 'del(.paths.\"/route/{origin}/{destination}/\") | (.. | objects | select(.name == \"X-Compatibility-Date\")) .required = false' > swagger.json",
     "get-esi-date": "node ./src/buildscript.js",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",

--- a/packages/esi-client/src/buildscript.js
+++ b/packages/esi-client/src/buildscript.js
@@ -64,12 +64,23 @@ const getOperationId = (operation) => {
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
 
-// get the current date in YYYY-MM-DD format
-const esiCurrentDateString = "2025-12-16";
-
 const swaggerPath = join(__dirname, "..", "swagger.json");
 /** @type {unknown} */
 const swaggerData = JSON.parse(readFileSync(swaggerPath, "utf-8"));
+
+// ESI stamps the requested compatibility date into `info.version`, so reading it
+// back guarantees the date the client sends in X-Compatibility-Date matches the
+// spec it was generated from. A second hardcoded copy here would silently drift
+// from the `compatibility_date` in the `download-schema` script.
+const esiCurrentDateString = asRecord(asRecord(swaggerData).info).version;
+if (
+  typeof esiCurrentDateString !== "string" ||
+  !/^\d{4}-\d{2}-\d{2}$/.test(esiCurrentDateString)
+) {
+  throw new Error(
+    `Expected swagger.json info.version to be a YYYY-MM-DD compatibility date, got ${JSON.stringify(esiCurrentDateString)}`,
+  );
+}
 
 /** @type {Record<string, { maxTokens?: number; windowSize?: string }>} */
 const rateLimits = {};

--- a/packages/esi-client/swagger.json
+++ b/packages/esi-client/swagger.json
@@ -63,7 +63,7 @@
         "required": false,
         "schema": {
           "enum": [
-            "2025-12-16"
+            "2026-07-17"
           ],
           "format": "date",
           "type": "string"
@@ -270,6 +270,189 @@
         "format": "int64",
         "type": "integer",
         "x-common-model": "true"
+      },
+      "CharactersAccessListsDetail": {
+        "properties": {
+          "description": {
+            "description": "The Access List's description",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/AccessListID",
+            "description": "The Access List's ID"
+          },
+          "membership": {
+            "$ref": "#/components/schemas/CharactersAccessListsDetailMembership",
+            "description": "The Access List's membership"
+          },
+          "name": {
+            "description": "The Access List's name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "membership"
+        ],
+        "type": "object"
+      },
+      "CharactersAccessListsDetailAllianceentry": {
+        "properties": {
+          "access": {
+            "description": "Alliance's access",
+            "enum": [
+              "Unspecified",
+              "Allowed",
+              "Blocked",
+              "Manager",
+              "Admin"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified access",
+              "Member is allowed",
+              "Member is blocked",
+              "Member is a manager (characters only)",
+              "Member is an admin (characters only)"
+            ]
+          },
+          "alliance_id": {
+            "$ref": "#/components/schemas/AllianceID",
+            "description": "Alliance's ID"
+          }
+        },
+        "required": [
+          "alliance_id",
+          "access"
+        ],
+        "type": "object"
+      },
+      "CharactersAccessListsDetailCharacterentry": {
+        "properties": {
+          "access": {
+            "description": "Character's access",
+            "enum": [
+              "Unspecified",
+              "Allowed",
+              "Blocked",
+              "Manager",
+              "Admin"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified access",
+              "Member is allowed",
+              "Member is blocked",
+              "Member is a manager (characters only)",
+              "Member is an admin (characters only)"
+            ]
+          },
+          "character_id": {
+            "$ref": "#/components/schemas/CharacterID",
+            "description": "Character's ID"
+          }
+        },
+        "required": [
+          "character_id",
+          "access"
+        ],
+        "type": "object"
+      },
+      "CharactersAccessListsDetailCorporationentry": {
+        "properties": {
+          "access": {
+            "description": "Corporation's access",
+            "enum": [
+              "Unspecified",
+              "Allowed",
+              "Blocked",
+              "Manager",
+              "Admin"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified access",
+              "Member is allowed",
+              "Member is blocked",
+              "Member is a manager (characters only)",
+              "Member is an admin (characters only)"
+            ]
+          },
+          "corporation_id": {
+            "$ref": "#/components/schemas/CorporationID",
+            "description": "Corporation's ID"
+          }
+        },
+        "required": [
+          "corporation_id",
+          "access"
+        ],
+        "type": "object"
+      },
+      "CharactersAccessListsDetailMembership": {
+        "properties": {
+          "alliances": {
+            "description": "Alliances in the Access List",
+            "items": {
+              "$ref": "#/components/schemas/CharactersAccessListsDetailAllianceentry"
+            },
+            "type": "array"
+          },
+          "allow_everyone": {
+            "description": "Whether everyone is allowed unless blocked",
+            "type": "boolean"
+          },
+          "characters": {
+            "description": "Characters in the Access List",
+            "items": {
+              "$ref": "#/components/schemas/CharactersAccessListsDetailCharacterentry"
+            },
+            "type": "array"
+          },
+          "corporations": {
+            "description": "Corporations in the Access List",
+            "items": {
+              "$ref": "#/components/schemas/CharactersAccessListsDetailCorporationentry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "allow_everyone",
+          "alliances",
+          "corporations",
+          "characters"
+        ],
+        "type": "object"
+      },
+      "CharactersAccessListsListing": {
+        "properties": {
+          "access_lists": {
+            "description": "List of Access Lists",
+            "items": {
+              "$ref": "#/components/schemas/CharactersAccessListsListingAccesslist"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "access_lists"
+        ],
+        "type": "object"
+      },
+      "CharactersAccessListsListingAccesslist": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/AccessListID",
+            "description": "Access List's ID"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
       },
       "CharactersAffiliationPost": {
         "items": {
@@ -2187,16 +2370,22 @@
                 "EntosisCaptureStarted",
                 "ExpertSystemExpired",
                 "ExpertSystemExpiryImminent",
+                "FWAllianceKickCeoIndividualStandingWarning",
                 "FWAllianceKickMsg",
+                "FWAllianceKickedCeoIndividualStanding",
                 "FWAllianceWarningMsg",
                 "FWCharKickMsg",
                 "FWCharRankGainMsg",
                 "FWCharRankLossMsg",
                 "FWCharWarningMsg",
+                "FWCharacterKickFromCorpIndividualStandingWarning",
+                "FWCharacterKickedFromCorpIndividualStanding",
                 "FWCorpJoinMsg",
                 "FWCorpKickMsg",
                 "FWCorpLeaveMsg",
                 "FWCorpWarningMsg",
+                "FWCorporationKickCeoIndividualStandingWarning",
+                "FWCorporationKickedCeoIndividualStanding",
                 "FacWarCorpJoinRequestMsg",
                 "FacWarCorpJoinWithdrawMsg",
                 "FacWarCorpLeaveRequestMsg",
@@ -2206,6 +2395,7 @@
                 "FacWarLPDisqualifiedKill",
                 "FacWarLPPayoutEvent",
                 "FacWarLPPayoutKill",
+                "FreelanceProjectACLDeleted",
                 "FreelanceProjectClosed",
                 "FreelanceProjectCompleted",
                 "FreelanceProjectCreated",
@@ -3372,6 +3562,8 @@
               "description": "\"The transaction type for the given. transaction. Different transaction types will populate different attributes.\"",
               "enum": [
                 "acceleration_gate_fee",
+                "achievement_category_milestone_reward",
+                "achievement_milestone_reward",
                 "advertisement_listing_fee",
                 "agent_donation",
                 "agent_location_services",
@@ -3380,6 +3572,7 @@
                 "agent_mission_collateral_refunded",
                 "agent_mission_reward",
                 "agent_mission_reward_corporation_tax",
+                "agent_mission_security_tax",
                 "agent_mission_time_bonus_reward",
                 "agent_mission_time_bonus_reward_corporation_tax",
                 "agent_security_services",
@@ -3397,6 +3590,7 @@
                 "bounty_reimbursement",
                 "bounty_surcharge",
                 "brokers_fee",
+                "campaign_objective_isk_reward",
                 "clone_activation",
                 "clone_transfer",
                 "contraband_fine",
@@ -3468,6 +3662,7 @@
                 "gm_cash_transfer",
                 "gm_plex_fee_refund",
                 "industry_job_tax",
+                "industry_security_tax",
                 "infrastructure_hub_maintenance",
                 "inheritance",
                 "insurance",
@@ -3482,6 +3677,7 @@
                 "market_escrow",
                 "market_fine_paid",
                 "market_provider_tax",
+                "market_security_tax",
                 "market_transaction",
                 "medal_creation",
                 "medal_issued",
@@ -3490,6 +3686,7 @@
                 "mission_cost",
                 "mission_expiration",
                 "mission_reward",
+                "npc_bounty_security_tax",
                 "office_rental_fee",
                 "operation_bonus",
                 "opportunity_reward",
@@ -3620,6 +3817,14 @@
       },
       "CharactersDetail": {
         "properties": {
+          "achievement_score": {
+            "description": "Character's achievement score",
+            "examples": [
+              1234
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
           "alliance_id": {
             "$ref": "#/components/schemas/AllianceID",
             "description": "Character's alliance ID"
@@ -3633,9 +3838,17 @@
             "$ref": "#/components/schemas/BloodlineID",
             "description": "Character's bloodline ID"
           },
+          "character_title_id": {
+            "$ref": "#/components/schemas/UUID",
+            "description": "Character's equipped cosmetic title ID"
+          },
           "corporation_id": {
             "$ref": "#/components/schemas/CorporationID",
             "description": "Character's corporation ID"
+          },
+          "corporation_title": {
+            "description": "Character's corporation title",
+            "type": "string"
           },
           "description": {
             "description": "Character's description (biography)",
@@ -3667,12 +3880,11 @@
           },
           "security_status": {
             "description": "Character's security status",
+            "examples": [
+              5
+            ],
             "format": "double",
             "type": "number"
-          },
-          "title": {
-            "description": "Character's corporation title",
-            "type": "string"
           }
         },
         "required": [
@@ -3681,7 +3893,8 @@
           "corporation_id",
           "gender",
           "name",
-          "race_id"
+          "race_id",
+          "achievement_score"
         ],
         "type": "object"
       },
@@ -3742,6 +3955,90 @@
           "state",
           "contributed",
           "last_modified"
+        ],
+        "type": "object"
+      },
+      "CharactersMercenaryTacticalOperationsDetail": {
+        "properties": {
+          "dungeon_type_id": {
+            "$ref": "#/components/schemas/DungeonID",
+            "description": "Operation's dungeon type ID"
+          },
+          "expires": {
+            "description": "Moment the operation will expire",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/UUID",
+            "description": "Operation's ID"
+          },
+          "mercenary_den_id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "ID of Mercenary Den offering this operation"
+          },
+          "state": {
+            "description": "Operation's state",
+            "enum": [
+              "Unspecified",
+              "Available",
+              "Started",
+              "Completed",
+              "Expired",
+              "Removed"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified state",
+              "Not started yet",
+              "Started",
+              "Completed",
+              "Expired",
+              "Removed (e.g. mercenary den removed)"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "mercenary_den_id",
+          "state",
+          "dungeon_type_id",
+          "expires"
+        ],
+        "type": "object"
+      },
+      "CharactersMercenaryTacticalOperationsListing": {
+        "properties": {
+          "operations": {
+            "description": "List of available operations",
+            "items": {
+              "$ref": "#/components/schemas/CharactersMercenaryTacticalOperationsListingOperation"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "operations"
+        ],
+        "type": "object"
+      },
+      "CharactersMercenaryTacticalOperationsListingOperation": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/UUID",
+            "description": "Operation's ID"
+          },
+          "mercenary_den_id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "ID of Mercenary Den offering this operation"
+          }
+        },
+        "required": [
+          "id",
+          "mercenary_den_id"
         ],
         "type": "object"
       },
@@ -3848,6 +4145,233 @@
           "trained_skill_level",
           "active_skill_level",
           "skillpoints_in_skill"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetail": {
+        "properties": {
+          "evolution": {
+            "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetailEvolution",
+            "description": "Mercenary Den's evolution"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Mercenary Den's ID"
+          },
+          "infomorphs": {
+            "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetailInfomorphs",
+            "description": "Mercenary Den's infomorphs"
+          },
+          "reinforcement_timer": {
+            "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetailReinforcementtimer",
+            "description": "Mercenary Den's reinforcement timer (if the structure is reinforced)"
+          },
+          "skyhook": {
+            "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetailSkyhook",
+            "description": "Skyhook the Mercenary Den is attached to"
+          },
+          "state": {
+            "description": "Mercenary Den's state",
+            "enum": [
+              "Unspecified",
+              "Running",
+              "Paused",
+              "Disabled"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified state",
+              "Running",
+              "Paused (e.g. the Mercenary Den is reinforced)",
+              "Disabled (e.g. the character no longer has the skills to operate the Mercenary Den)"
+            ]
+          },
+          "type_id": {
+            "$ref": "#/components/schemas/TypeID",
+            "description": "Mercenary Den's type ID"
+          }
+        },
+        "required": [
+          "id",
+          "skyhook",
+          "state",
+          "type_id",
+          "infomorphs",
+          "evolution"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetailEvolution": {
+        "properties": {
+          "anarchy": {
+            "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetailEvolutionanarchy",
+            "description": "Mercenary Den's anarchy"
+          },
+          "development": {
+            "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetailEvolutiondevelopment",
+            "description": "Mercenary Den's development"
+          }
+        },
+        "required": [
+          "development",
+          "anarchy"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetailEvolutionanarchy": {
+        "properties": {
+          "amount": {
+            "description": "Anarchy's cumulative amount (0-100)",
+            "examples": [
+              0
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "level": {
+            "description": "Anarchy's level",
+            "enum": [
+              "Unspecified",
+              "Level0",
+              "Level1",
+              "Level2",
+              "Level3",
+              "Level4"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified level",
+              "Level 0",
+              "Level 1",
+              "Level 2",
+              "Level 3",
+              "Level 4"
+            ]
+          }
+        },
+        "required": [
+          "amount",
+          "level"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetailEvolutiondevelopment": {
+        "properties": {
+          "amount": {
+            "description": "Development's cumulative amount (0-100)",
+            "examples": [
+              50
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "level": {
+            "description": "Development's level",
+            "enum": [
+              "Unspecified",
+              "Level0",
+              "Level1",
+              "Level2",
+              "Level3",
+              "Level4"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified level",
+              "Level 0",
+              "Level 1",
+              "Level 2",
+              "Level 3",
+              "Level 4"
+            ]
+          }
+        },
+        "required": [
+          "amount",
+          "level"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetailInfomorphs": {
+        "properties": {
+          "amount": {
+            "description": "Amount of infomorphs",
+            "examples": [
+              100
+            ],
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "amount"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetailReinforcementtimer": {
+        "properties": {
+          "end": {
+            "description": "The time when the reinforcement timer will end",
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "end"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensDetailSkyhook": {
+        "properties": {
+          "corporation_id": {
+            "$ref": "#/components/schemas/CorporationID",
+            "description": "Corporation that owns the Skyhook"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Skyhook's ID"
+          },
+          "planet_id": {
+            "$ref": "#/components/schemas/PlanetID",
+            "description": "ID of the planet the Skyhook is anchored on"
+          }
+        },
+        "required": [
+          "id",
+          "planet_id",
+          "corporation_id"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensListing": {
+        "properties": {
+          "mercenary_dens": {
+            "description": "List of Mercenary Dens",
+            "items": {
+              "$ref": "#/components/schemas/CharactersStructuresMercenaryDensListingMercenaryden"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "mercenary_dens"
+        ],
+        "type": "object"
+      },
+      "CharactersStructuresMercenaryDensListingMercenaryden": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Mercenary Den's ID"
+          },
+          "planet_id": {
+            "$ref": "#/components/schemas/PlanetID",
+            "description": "ID of the planet the Skyhook (to which the Mercenary Den is attached) is anchored on"
+          }
+        },
+        "required": [
+          "id",
+          "planet_id"
         ],
         "type": "object"
       },
@@ -5155,7 +5679,7 @@
               "type": "integer"
             },
             "reinforce_exit_start": {
-              "description": "Together with reinforce_exit_end, marks a 2-hour period where this customs office could exit reinforcement mode during the day after initial attack",
+              "description": "Together with reinforce_exit_end, marks a 2-hour or 6-hour (depending on the office type) period where this customs office could exit reinforcement mode during the day after initial attack",
               "format": "int64",
               "type": "integer"
             },
@@ -5178,6 +5702,11 @@
             "terrible_standing_tax_rate": {
               "format": "double",
               "type": "number"
+            },
+            "type_id": {
+              "description": "ID of the type of this customs office",
+              "format": "int64",
+              "type": "integer"
             }
           },
           "required": [
@@ -7537,6 +8066,8 @@
               "description": "\"The transaction type for the given. transaction. Different transaction types will populate different attributes. Note: If you have an existing XML API application that is using ref_types, you will need to know which string ESI ref_type maps to which integer. You can look at the following file to see string->int mappings: https://github.com/ccpgames/eve-glue/blob/master/eve_glue/wallet_journal_ref.py\"",
               "enum": [
                 "acceleration_gate_fee",
+                "achievement_category_milestone_reward",
+                "achievement_milestone_reward",
                 "advertisement_listing_fee",
                 "agent_donation",
                 "agent_location_services",
@@ -7545,6 +8076,7 @@
                 "agent_mission_collateral_refunded",
                 "agent_mission_reward",
                 "agent_mission_reward_corporation_tax",
+                "agent_mission_security_tax",
                 "agent_mission_time_bonus_reward",
                 "agent_mission_time_bonus_reward_corporation_tax",
                 "agent_security_services",
@@ -7562,6 +8094,7 @@
                 "bounty_reimbursement",
                 "bounty_surcharge",
                 "brokers_fee",
+                "campaign_objective_isk_reward",
                 "clone_activation",
                 "clone_transfer",
                 "contraband_fine",
@@ -7633,6 +8166,7 @@
                 "gm_cash_transfer",
                 "gm_plex_fee_refund",
                 "industry_job_tax",
+                "industry_security_tax",
                 "infrastructure_hub_maintenance",
                 "inheritance",
                 "insurance",
@@ -7647,6 +8181,7 @@
                 "market_escrow",
                 "market_fine_paid",
                 "market_provider_tax",
+                "market_security_tax",
                 "market_transaction",
                 "medal_creation",
                 "medal_issued",
@@ -7655,6 +8190,7 @@
                 "mission_cost",
                 "mission_expiration",
                 "mission_reward",
+                "npc_bounty_security_tax",
                 "office_rental_fee",
                 "operation_bonus",
                 "opportunity_reward",
@@ -9810,6 +10346,626 @@
         ],
         "type": "object"
       },
+      "CorporationsStructuresSkyhooksDetail": {
+        "properties": {
+          "effective_workforce": {
+            "description": "Skyhook's effective workforce; this can differ from the Skyhook's normal workforce due to the influence of an attached Mercenary Den",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Skyhook's ID"
+          },
+          "is_active": {
+            "description": "Whether the Skyhook is active and producing workforce/power/reagents",
+            "type": "boolean"
+          },
+          "planet_id": {
+            "$ref": "#/components/schemas/PlanetID",
+            "description": "ID of the planet the Skyhook is anchored on"
+          },
+          "reagents": {
+            "description": "Skyhook's reagents",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSkyhooksDetailReagent"
+            },
+            "type": "array"
+          },
+          "reinforcement_timer": {
+            "$ref": "#/components/schemas/CorporationsStructuresSkyhooksDetailReinforcementtimer",
+            "description": "Skyhook's reinforcement timer (if the structure is reinforced)"
+          },
+          "state": {
+            "description": "Skyhook's state",
+            "enum": [
+              "Unspecified",
+              "ShieldVulnerable",
+              "ArmorReinforced",
+              "ArmorVulnerable",
+              "HullReinforced",
+              "HullVulnerable"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified state",
+              "Skyhook is vulnerable to shield damage",
+              "Skyhook is reinforced against armor damage",
+              "Skyhook is vulnerable to armor damage",
+              "Skyhook is reinforced against hull damage",
+              "Skyhook is vulnerable to hull damage"
+            ]
+          },
+          "theft_vulnerability": {
+            "$ref": "#/components/schemas/CorporationsStructuresSkyhooksDetailTheftvulnerability",
+            "description": "Skyhook's theft vulnerability"
+          }
+        },
+        "required": [
+          "id",
+          "planet_id",
+          "state",
+          "is_active"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSkyhooksDetailReagent": {
+        "properties": {
+          "last_cycle": {
+            "description": "Moment the 'SecureStock'/'UnsecuredStock' value had its last cycle; use SDE to calculate the current values",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "secured_stock": {
+            "description": "Secured stock of the reagent at the time of 'last_cycle'",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "type_id": {
+            "$ref": "#/components/schemas/TypeID",
+            "description": "Reagent's type ID"
+          },
+          "unsecured_stock": {
+            "description": "Unsecured stock of the reagent at the time of 'last_cycle'",
+            "examples": [
+              300
+            ],
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type_id",
+          "secured_stock",
+          "unsecured_stock",
+          "last_cycle"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSkyhooksDetailReinforcementtimer": {
+        "properties": {
+          "end": {
+            "description": "The time when the reinforcement timer will end",
+            "examples": [
+              "2026-02-23T16:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "end"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSkyhooksDetailTheftvulnerability": {
+        "properties": {
+          "end": {
+            "description": "End time of the theft vulnerability window",
+            "examples": [
+              "2026-02-23T16:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "start": {
+            "description": "Start time of the theft vulnerability window",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSkyhooksListing": {
+        "properties": {
+          "skyhooks": {
+            "description": "List of Skyhooks",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSkyhooksListingSkyhook"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "skyhooks"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSkyhooksListingSkyhook": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Skyhook's ID"
+          },
+          "planet_id": {
+            "$ref": "#/components/schemas/PlanetID",
+            "description": "ID of the planet the Skyhook is anchored on"
+          }
+        },
+        "required": [
+          "id",
+          "planet_id"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetail": {
+        "properties": {
+          "fuel_access_list_id": {
+            "$ref": "#/components/schemas/AccessListID",
+            "description": "Access List with who can manage Sovereignty Hub's fuel"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Sovereignty Hub's ID"
+          },
+          "reagent_bay": {
+            "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailReagentbay",
+            "description": "Sovereignty Hub's reagent bay"
+          },
+          "resources": {
+            "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailResources",
+            "description": "Sovereignty Hub's resources"
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "Sovereignty Hub's solar system ID"
+          },
+          "upgrades": {
+            "description": "Sovereignty Hub's installed upgrades",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailUpgrade"
+            },
+            "type": "array"
+          },
+          "vulnerability_window": {
+            "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailVulnerabilitywindow",
+            "description": "Sovereignty Hub's vulnerability window; if omitted, this Sovereignty Hub is part of an active campaign"
+          },
+          "workforce_transport": {
+            "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransport",
+            "description": "Sovereignty Hub's workforce transport settings"
+          }
+        },
+        "required": [
+          "id",
+          "solar_system_id",
+          "upgrades",
+          "reagent_bay",
+          "resources",
+          "workforce_transport"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailReagent": {
+        "properties": {
+          "amount": {
+            "description": "Amount of reagent in the bay at the time of 'last_updated'",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "burning_per_hour": {
+            "description": "Amount of reagent burning per hour",
+            "examples": [
+              10
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "type_id": {
+            "$ref": "#/components/schemas/TypeID",
+            "description": "Reagent's type ID"
+          }
+        },
+        "required": [
+          "type_id",
+          "amount",
+          "burning_per_hour"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailReagentbay": {
+        "properties": {
+          "last_updated": {
+            "description": "Moment the 'amount' value was last updated; use 'burning_per_hour' to calculate the current value",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "reagents": {
+            "description": "Sovereignty Hub's reagents",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailReagent"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "last_updated",
+          "reagents"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailResourcepower": {
+        "properties": {
+          "allocated": {
+            "description": "Allocated power",
+            "examples": [
+              100
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "available": {
+            "description": "Available power",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "available",
+          "allocated"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailResources": {
+        "properties": {
+          "power": {
+            "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailResourcepower",
+            "description": "Sovereignty Hub's power"
+          },
+          "workforce": {
+            "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailResourceworkforce",
+            "description": "Sovereignty Hub's workforce"
+          }
+        },
+        "required": [
+          "power",
+          "workforce"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailResourceworkforce": {
+        "properties": {
+          "allocated": {
+            "description": "Allocated workforce",
+            "examples": [
+              100
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "available": {
+            "description": "Available workforce",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "available",
+          "allocated"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransport": {
+        "properties": {
+          "configuration": {
+            "description": "Configured workforce transport",
+            "oneOf": [
+              {
+                "properties": {
+                  "import": {
+                    "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransportconfigurationimport",
+                    "description": "Workforce is requested to be imported"
+                  }
+                },
+                "title": "import",
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "export": {
+                    "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransportconfigurationexport",
+                    "description": "Workforce is requested to be exported"
+                  }
+                },
+                "title": "export",
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "transit": {
+                    "description": "Workforce is requested to be brought to transit",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "title": "transit",
+                "type": "object"
+              }
+            ]
+          },
+          "state": {
+            "description": "Current state of the workforce transport",
+            "oneOf": [
+              {
+                "properties": {
+                  "import": {
+                    "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransportstateimport",
+                    "description": "Workforce is being imported"
+                  }
+                },
+                "title": "import",
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "export": {
+                    "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransportstateexport",
+                    "description": "Workforce is being exported"
+                  }
+                },
+                "title": "export",
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "transit": {
+                    "description": "Workforce is being brought to transit",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  }
+                },
+                "title": "transit",
+                "type": "object"
+              }
+            ]
+          }
+        },
+        "required": [
+          "configuration",
+          "state"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransportconfigurationexport": {
+        "properties": {
+          "amount": {
+            "description": "Amount to be exported",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "Destination's solar system ID"
+          }
+        },
+        "required": [
+          "amount"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransportconfigurationimport": {
+        "properties": {
+          "sources": {
+            "description": "Sources",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransportconfigurationsource"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sources"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransportconfigurationsource": {
+        "properties": {
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "Source's solar system ID"
+          }
+        },
+        "required": [
+          "solar_system_id"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransportstateexport": {
+        "properties": {
+          "amount": {
+            "description": "Amount exported",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "Destination's solar system ID"
+          }
+        },
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransportstateimport": {
+        "properties": {
+          "sources": {
+            "description": "Sources",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetailTransportstateimportsource"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sources"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailTransportstateimportsource": {
+        "properties": {
+          "amount": {
+            "description": "Amount imported",
+            "examples": [
+              1000
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "Source's solar system ID"
+          }
+        },
+        "required": [
+          "solar_system_id",
+          "amount"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailUpgrade": {
+        "properties": {
+          "power_state": {
+            "description": "Upgrade's power state",
+            "enum": [
+              "Unspecified",
+              "Online",
+              "Offline",
+              "Low",
+              "Pending"
+            ],
+            "type": "string",
+            "x-enum-descriptions": [
+              "An unspecified power state",
+              "Online",
+              "Offline",
+              "Not enough fuel/power/workforce",
+              "Waiting for startup cost to be available"
+            ]
+          },
+          "type_id": {
+            "$ref": "#/components/schemas/TypeID",
+            "description": "Upgrade's type ID"
+          }
+        },
+        "required": [
+          "type_id",
+          "power_state"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsDetailVulnerabilitywindow": {
+        "properties": {
+          "end": {
+            "description": "End time of the vulnerability window; if in the past, the Sovereignty Hub is in overtime",
+            "examples": [
+              "2026-02-23T16:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "start": {
+            "description": "Start time of the vulnerability window; if in the past, the Sovereignty Hub is vulnerable right now",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsListing": {
+        "properties": {
+          "sovereignty_hubs": {
+            "description": "List of Sovereignty Hubs",
+            "items": {
+              "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsListingSovereigntyhub"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "sovereignty_hubs"
+        ],
+        "type": "object"
+      },
+      "CorporationsStructuresSovereigntyHubsListingSovereigntyhub": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "Sovereignty Hub's ID"
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "Sovereignty Hub's location"
+          }
+        },
+        "required": [
+          "id",
+          "solar_system_id"
+        ],
+        "type": "object"
+      },
       "Cursor": {
         "properties": {
           "after": {
@@ -10068,7 +11224,6 @@
         "x-common-model": "true"
       },
       "Error": {
-        "additionalProperties": false,
         "properties": {
           "details": {
             "description": "List of individual error details.",
@@ -10088,7 +11243,6 @@
         "type": "object"
       },
       "ErrorDetail": {
-        "additionalProperties": false,
         "properties": {
           "location": {
             "description": "Where the error occurred, e.g. 'body.items[3].tags' or 'path.thing-id'",
@@ -12349,6 +13503,52 @@
         ],
         "type": "object"
       },
+      "MetaName": {
+        "properties": {
+          "current": {
+            "description": "The name ESI is going by today. It was almost certainly something else last time you looked.",
+            "examples": [
+              "EVE Spring Inebriation (ESI)"
+            ],
+            "type": "string"
+          },
+          "history": {
+            "description": "Every name ESI has ever gone by, newest first. It has never once been the same twice.",
+            "items": {
+              "$ref": "#/components/schemas/MetaNameEntry"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "current",
+          "history"
+        ],
+        "type": "object"
+      },
+      "MetaNameEntry": {
+        "properties": {
+          "date": {
+            "description": "The date ESI started insisting on this name (UTC-11).",
+            "examples": [
+              "2026-04-01"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "description": "What those three letters allegedly stood for at the time.",
+            "examples": [
+              "EVE Spring Inebriation (ESI)"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "date",
+          "name"
+        ],
+        "type": "object"
+      },
       "MetaStatus": {
         "properties": {
           "routes": {
@@ -12522,6 +13722,68 @@
         "type": "integer",
         "x-common-model": "true"
       },
+      "SkyhooksRaidable": {
+        "properties": {
+          "skyhooks": {
+            "description": "List of (upcoming) raidable Skyhooks",
+            "items": {
+              "$ref": "#/components/schemas/SkyhooksRaidableVulnerableskyhook"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "skyhooks"
+        ],
+        "type": "object"
+      },
+      "SkyhooksRaidableTheftvulnerability": {
+        "properties": {
+          "end": {
+            "description": "End time of the theft vulnerability window",
+            "examples": [
+              "2026-02-23T16:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "start": {
+            "description": "Start time of the theft vulnerability window",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end"
+        ],
+        "type": "object"
+      },
+      "SkyhooksRaidableVulnerableskyhook": {
+        "properties": {
+          "planet_id": {
+            "$ref": "#/components/schemas/PlanetID",
+            "description": "ID of the planet the Skyhook is anchored on"
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "ID of the solar system the Skyhook is anchored on"
+          },
+          "theft_vulnerability": {
+            "$ref": "#/components/schemas/SkyhooksRaidableTheftvulnerability",
+            "description": "Skyhook's theft vulnerability"
+          }
+        },
+        "required": [
+          "planet_id",
+          "solar_system_id",
+          "theft_vulnerability"
+        ],
+        "type": "object"
+      },
       "SolarSystemID": {
         "examples": [
           30000001
@@ -12618,81 +13880,208 @@
         },
         "type": "array"
       },
-      "SovereigntyMapGet": {
-        "items": {
-          "properties": {
-            "alliance_id": {
-              "format": "int64",
-              "type": "integer"
+      "SovereigntySystems": {
+        "properties": {
+          "solar_systems": {
+            "description": "List of solar systems and their sovereignty owners",
+            "items": {
+              "$ref": "#/components/schemas/SovereigntySystemsSolarsystem"
             },
-            "corporation_id": {
-              "format": "int64",
-              "type": "integer"
-            },
-            "faction_id": {
-              "format": "int64",
-              "type": "integer"
-            },
-            "system_id": {
-              "format": "int64",
-              "type": "integer"
-            }
-          },
-          "required": [
-            "system_id"
-          ],
-          "type": "object"
+            "type": "array"
+          }
         },
-        "type": "array"
+        "required": [
+          "solar_systems"
+        ],
+        "type": "object"
       },
-      "SovereigntyStructuresGet": {
-        "items": {
-          "properties": {
-            "alliance_id": {
-              "description": "The alliance that owns the structure.\n",
-              "format": "int64",
-              "type": "integer"
-            },
-            "solar_system_id": {
-              "description": "Solar system in which the structure is located.\n",
-              "format": "int64",
-              "type": "integer"
-            },
-            "structure_id": {
-              "description": "Unique item ID for this structure.",
-              "format": "int64",
-              "type": "integer"
-            },
-            "structure_type_id": {
-              "description": "A reference to the type of structure this is.\n",
-              "format": "int64",
-              "type": "integer"
-            },
-            "vulnerability_occupancy_level": {
-              "description": "The occupancy level for the next or current vulnerability window. This takes into account all development indexes and capital system bonuses. Also known as Activity Defense Multiplier from in the client. It increases the time that attackers must spend using their entosis links on the structure.\n",
-              "format": "double",
-              "type": "number"
-            },
-            "vulnerable_end_time": {
-              "description": "The time at which the next or current vulnerability window ends. At the end of a vulnerability window the next window is recalculated and locked in along with the vulnerabilityOccupancyLevel. If the structure is not in 100% entosis control of the defender, it will go in to 'overtime' and stay vulnerable for as long as that situation persists. Only once the defenders have 100% entosis control and has the vulnerableEndTime passed does the vulnerability interval expire and a new one is calculated.\n",
-              "format": "date-time",
-              "type": "string"
-            },
-            "vulnerable_start_time": {
-              "description": "The next time at which the structure will become vulnerable. Or the start time of the current window if current time is between this and vulnerableEndTime.\n",
-              "format": "date-time",
-              "type": "string"
-            }
+      "SovereigntySystemsAlliance": {
+        "properties": {
+          "alliance_id": {
+            "$ref": "#/components/schemas/AllianceID",
+            "description": "Alliance that claimed this solar system"
           },
-          "required": [
-            "alliance_id",
-            "solar_system_id",
-            "structure_id",
-            "structure_type_id"
-          ],
-          "type": "object"
+          "claimed_since": {
+            "description": "Time the claim was made",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "corporation_id": {
+            "$ref": "#/components/schemas/CorporationID",
+            "description": "Corporation that claimed this solar system"
+          },
+          "development": {
+            "$ref": "#/components/schemas/SovereigntySystemsDevelopment",
+            "description": "Solar system's development"
+          },
+          "is_capital_system": {
+            "description": "Whether the system is the capital system of the alliance",
+            "examples": [
+              false
+            ],
+            "type": "boolean"
+          },
+          "sovereignty_hub": {
+            "$ref": "#/components/schemas/SovereigntySystemsSovereigntyhub",
+            "description": "Sovereignty Hub holding the claim"
+          }
         },
-        "type": "array"
+        "required": [
+          "alliance_id",
+          "corporation_id",
+          "claimed_since",
+          "sovereignty_hub",
+          "is_capital_system",
+          "development"
+        ],
+        "type": "object"
+      },
+      "SovereigntySystemsDevelopment": {
+        "properties": {
+          "activity_defense_multiplier": {
+            "description": "Current Activity Defense Multiplier",
+            "examples": [
+              1.2
+            ],
+            "format": "double",
+            "type": "number"
+          },
+          "industrial_level": {
+            "description": "Industrial level (0-5) of this solar system",
+            "examples": [
+              0
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "military_level": {
+            "description": "Military level (0-5) of this solar system",
+            "examples": [
+              3
+            ],
+            "format": "int64",
+            "type": "integer"
+          },
+          "strategic_level": {
+            "description": "Strategic level (0-5) of this solar system",
+            "examples": [
+              5
+            ],
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "activity_defense_multiplier",
+          "military_level",
+          "industrial_level",
+          "strategic_level"
+        ],
+        "type": "object"
+      },
+      "SovereigntySystemsFaction": {
+        "properties": {
+          "faction_id": {
+            "$ref": "#/components/schemas/FactionID",
+            "description": "Faction that claimed this solar system"
+          }
+        },
+        "required": [
+          "faction_id"
+        ],
+        "type": "object"
+      },
+      "SovereigntySystemsSolarsystem": {
+        "properties": {
+          "claim": {
+            "description": "Claim on this solar system",
+            "oneOf": [
+              {
+                "properties": {
+                  "faction": {
+                    "$ref": "#/components/schemas/SovereigntySystemsFaction",
+                    "description": "Solar system is claimed by a faction"
+                  }
+                },
+                "title": "faction",
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "alliance": {
+                    "$ref": "#/components/schemas/SovereigntySystemsAlliance",
+                    "description": "Solar system is claimed by an alliance"
+                  }
+                },
+                "title": "alliance",
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "unclaimed": {
+                    "description": "Solar system is unclaimed",
+                    "type": "boolean"
+                  }
+                },
+                "title": "unclaimed",
+                "type": "object"
+              }
+            ]
+          },
+          "solar_system_id": {
+            "$ref": "#/components/schemas/SolarSystemID",
+            "description": "ID of the solar system"
+          }
+        },
+        "required": [
+          "solar_system_id",
+          "claim"
+        ],
+        "type": "object"
+      },
+      "SovereigntySystemsSovereigntyhub": {
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ItemID",
+            "description": "ID of the Sovereignty Hub"
+          },
+          "vulnerability_window": {
+            "$ref": "#/components/schemas/SovereigntySystemsVulnerabilitywindow",
+            "description": "Sovereignty Hub's vulnerability window; if omitted, this Sovereignty Hub is part of an active campaign"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "SovereigntySystemsVulnerabilitywindow": {
+        "properties": {
+          "end": {
+            "description": "End time of the vulnerability window; if in the past, the Sovereignty Hub is in overtime",
+            "examples": [
+              "2026-02-23T16:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "start": {
+            "description": "Start time of the vulnerability window; if in the past, the Sovereignty Hub is vulnerable right now",
+            "examples": [
+              "2026-02-23T12:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end"
+        ],
+        "type": "object"
       },
       "StationID": {
         "examples": [
@@ -14400,8 +15789,8 @@
       "url": "https://developers.eveonline.com/license-agreement"
     },
     "termsOfService": "https://support.eveonline.com/hc/en-us/articles/8414770561948-EVE-Online-Terms-of-Service",
-    "title": "EVE Spring Inebriation (ESI) - tranquility",
-    "version": "2025-12-16"
+    "title": "EVE Swagger Incineration (ESI) - tranquility",
+    "version": "2026-07-17"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -14947,7 +16336,7 @@
     "/characters/{character_id}": {
       "get": {
         "description": "Public information about a character",
-        "operationId": "GetCharactersCharacterId",
+        "operationId": "GetCharactersDetail",
         "parameters": [
           {
             "description": "The ID of the character",
@@ -15014,7 +16403,187 @@
         ],
         "x-cache-age": 86400,
         "x-cache-mode": "event-based",
-        "x-compatibility-date": "2020-01-01"
+        "x-compatibility-date": "2026-06-09"
+      }
+    },
+    "/characters/{character_id}/access-lists": {
+      "get": {
+        "description": "Lists all Access Lists the character is Manager or Admin of.",
+        "operationId": "GetCharactersAccessListsListing",
+        "parameters": [
+          {
+            "description": "The ID of the character",
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CharacterID",
+              "description": "The ID of the character"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharactersAccessListsListing"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-access.read_lists.v1"
+            ]
+          }
+        ],
+        "summary": "List Access Lists",
+        "tags": [
+          "Access List"
+        ],
+        "x-cache-age": 300,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "char-access",
+          "max-tokens": 600,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/characters/{character_id}/access-lists/{access_list_id}": {
+      "get": {
+        "description": "Get the details of an Access List.",
+        "operationId": "GetCharactersAccessListsDetail",
+        "parameters": [
+          {
+            "description": "The ID of the Access List",
+            "in": "path",
+            "name": "access_list_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AccessListID",
+              "description": "The ID of the Access List"
+            }
+          },
+          {
+            "description": "The ID of the character",
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CharacterID",
+              "description": "The ID of the character"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharactersAccessListsDetail"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-access.read_lists.v1"
+            ]
+          }
+        ],
+        "summary": "Get Access List details",
+        "tags": [
+          "Access List"
+        ],
+        "x-cache-age": 300,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "char-access",
+          "max-tokens": 600,
+          "window-size": "15m"
+        }
       }
     },
     "/characters/{character_id}/agents_research": {
@@ -19240,6 +20809,186 @@
         }
       }
     },
+    "/characters/{character_id}/mercenary-tactical-operations": {
+      "get": {
+        "description": "Listing of all Mercenary Tactical Operations for the character.",
+        "operationId": "GetCharactersMercenaryTacticalOperationsListing",
+        "parameters": [
+          {
+            "description": "The ID of the character",
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CharacterID",
+              "description": "The ID of the character"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharactersMercenaryTacticalOperationsListing"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-activities.read_character.v1"
+            ]
+          }
+        ],
+        "summary": "List Mercenary Tactical Operations",
+        "tags": [
+          "Activities"
+        ],
+        "x-cache-age": 300,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "char-activity",
+          "max-tokens": 150,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/characters/{character_id}/mercenary-tactical-operations/{operation_id}": {
+      "get": {
+        "description": "Get the details of a Mercenary Tactical Operation.",
+        "operationId": "GetCharactersMercenaryTacticalOperationsDetail",
+        "parameters": [
+          {
+            "description": "The ID of the operation",
+            "in": "path",
+            "name": "operation_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/UUID",
+              "description": "The ID of the operation"
+            }
+          },
+          {
+            "description": "The ID of the character",
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CharacterID",
+              "description": "The ID of the character"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharactersMercenaryTacticalOperationsDetail"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-activities.read_character.v1"
+            ]
+          }
+        ],
+        "summary": "Get Mercenary Tactical Operation details",
+        "tags": [
+          "Activities"
+        ],
+        "x-cache-age": 300,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "char-activity",
+          "max-tokens": 150,
+          "window-size": "15m"
+        }
+      }
+    },
     "/characters/{character_id}/mining": {
       "get": {
         "description": "Paginated record of all mining done by a character for the past 30 days",
@@ -20559,6 +22308,186 @@
         "x-rate-limit": {
           "group": "char-social",
           "max-tokens": 600,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/characters/{character_id}/structures/mercenary-dens": {
+      "get": {
+        "description": "Listing of all Mercenary Dens.",
+        "operationId": "GetCharactersStructuresMercenaryDensListing",
+        "parameters": [
+          {
+            "description": "The ID of the character",
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CharacterID",
+              "description": "The ID of the character"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharactersStructuresMercenaryDensListing"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-structures.read_character.v1"
+            ]
+          }
+        ],
+        "summary": "List Mercenary Dens",
+        "tags": [
+          "Structures"
+        ],
+        "x-cache-age": 3600,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "char-structure",
+          "max-tokens": 30,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/characters/{character_id}/structures/mercenary-dens/{mercenary_den_id}": {
+      "get": {
+        "description": "Get the details of a Mercenary Den.",
+        "operationId": "GetCharactersStructuresMercenaryDensDetail",
+        "parameters": [
+          {
+            "description": "The ID of the Mercenary Den",
+            "in": "path",
+            "name": "mercenary_den_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ItemID",
+              "description": "The ID of the Mercenary Den"
+            }
+          },
+          {
+            "description": "The ID of the character",
+            "in": "path",
+            "name": "character_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CharacterID",
+              "description": "The ID of the character"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CharactersStructuresMercenaryDensDetail"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-structures.read_character.v1"
+            ]
+          }
+        ],
+        "summary": "Get Mercenary Den details",
+        "tags": [
+          "Structures"
+        ],
+        "x-cache-age": 3600,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "char-structure",
+          "max-tokens": 30,
           "window-size": "15m"
         }
       }
@@ -22418,6 +24347,11 @@
         ],
         "x-cache-age": 600,
         "x-compatibility-date": "2020-01-01",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
         "x-required-roles": [
           "Director"
         ]
@@ -22991,6 +24925,11 @@
         ],
         "x-cache-age": 3600,
         "x-compatibility-date": "2020-01-01",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
         "x-required-roles": [
           "Factory_Manager"
         ]
@@ -25312,6 +27251,11 @@
         ],
         "x-cache-age": 3600,
         "x-compatibility-date": "2020-01-01",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
         "x-required-roles": [
           "Director"
         ]
@@ -25413,6 +27357,11 @@
         ],
         "x-cache-age": 3600,
         "x-compatibility-date": "2020-01-01",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
         "x-required-roles": [
           "Director"
         ]
@@ -25514,6 +27463,380 @@
         ],
         "x-cache-age": 3600,
         "x-compatibility-date": "2020-01-01",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
+        "x-required-roles": [
+          "Station_Manager"
+        ]
+      }
+    },
+    "/corporations/{corporation_id}/structures/skyhooks": {
+      "get": {
+        "description": "Listing of all Skyhooks.",
+        "operationId": "GetCorporationsStructuresSkyhooksListing",
+        "parameters": [
+          {
+            "description": "The ID of the corporation",
+            "in": "path",
+            "name": "corporation_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CorporationID",
+              "description": "The ID of the corporation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorporationsStructuresSkyhooksListing"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-structures.read_corporation.v1"
+            ]
+          }
+        ],
+        "summary": "List Skyhooks",
+        "tags": [
+          "Structures"
+        ],
+        "x-cache-age": 3600,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
+        "x-required-roles": [
+          "Station_Manager"
+        ]
+      }
+    },
+    "/corporations/{corporation_id}/structures/skyhooks/{skyhook_id}": {
+      "get": {
+        "description": "Get the details of a Skyhook.",
+        "operationId": "GetCorporationsStructuresSkyhooksDetail",
+        "parameters": [
+          {
+            "description": "The ID of the Skyhook",
+            "in": "path",
+            "name": "skyhook_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ItemID",
+              "description": "The ID of the Skyhook"
+            }
+          },
+          {
+            "description": "The ID of the corporation",
+            "in": "path",
+            "name": "corporation_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CorporationID",
+              "description": "The ID of the corporation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorporationsStructuresSkyhooksDetail"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-structures.read_corporation.v1"
+            ]
+          }
+        ],
+        "summary": "Get Skyhook details",
+        "tags": [
+          "Structures"
+        ],
+        "x-cache-age": 3600,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
+        "x-required-roles": [
+          "Station_Manager"
+        ]
+      }
+    },
+    "/corporations/{corporation_id}/structures/sovereignty-hubs": {
+      "get": {
+        "description": "Listing of all Sovereignty Hubs.",
+        "operationId": "GetCorporationsStructuresSovereigntyHubsListing",
+        "parameters": [
+          {
+            "description": "The ID of the corporation",
+            "in": "path",
+            "name": "corporation_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CorporationID",
+              "description": "The ID of the corporation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsListing"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-structures.read_corporation.v1"
+            ]
+          }
+        ],
+        "summary": "List Sovereignty Hubs",
+        "tags": [
+          "Structures"
+        ],
+        "x-cache-age": 3600,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/corporations/{corporation_id}/structures/sovereignty-hubs/{sovereignty_hub_id}": {
+      "get": {
+        "description": "Get the details of a Sovereignty Hub.",
+        "operationId": "GetCorporationsStructuresSovereigntyHubsDetail",
+        "parameters": [
+          {
+            "description": "The ID of the Sovereignty Hub",
+            "in": "path",
+            "name": "sovereignty_hub_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ItemID",
+              "description": "The ID of the Sovereignty Hub"
+            }
+          },
+          {
+            "description": "The ID of the corporation",
+            "in": "path",
+            "name": "corporation_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CorporationID",
+              "description": "The ID of the corporation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorporationsStructuresSovereigntyHubsDetail"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2": [
+              "esi-structures.read_corporation.v1"
+            ]
+          }
+        ],
+        "summary": "Get Sovereignty Hub details",
+        "tags": [
+          "Structures"
+        ],
+        "x-cache-age": 3600,
+        "x-cache-mode": "event-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "corp-structure",
+          "max-tokens": 300,
+          "window-size": "15m"
+        },
         "x-required-roles": [
           "Station_Manager"
         ]
@@ -29128,6 +31451,8 @@
         "tags": [
           "Meta"
         ],
+        "x-cache-age": 600,
+        "x-cache-mode": "not-cached",
         "x-compatibility-date": "2025-09-26",
         "x-rate-limit": {
           "group": "meta",
@@ -29194,7 +31519,77 @@
         "tags": [
           "Meta"
         ],
+        "x-cache-age": 600,
+        "x-cache-mode": "not-cached",
         "x-compatibility-date": "2020-01-01",
+        "x-rate-limit": {
+          "group": "meta",
+          "max-tokens": 150,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/meta/name": {
+      "get": {
+        "description": "Get the name ESI is currently going by, plus the full and glorious history of every name it has ever had. The three letters have never once meant the same thing twice.",
+        "operationId": "GetMetaName",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetaName"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get the name of ESI",
+        "tags": [
+          "Meta"
+        ],
+        "x-cache-age": 600,
+        "x-cache-mode": "not-cached",
+        "x-compatibility-date": "2026-07-17",
         "x-rate-limit": {
           "group": "meta",
           "max-tokens": 150,
@@ -29260,6 +31655,7 @@
         "tags": [
           "Meta"
         ],
+        "x-cache-age": 0,
         "x-compatibility-date": "2025-11-06",
         "x-rate-limit": {
           "group": "meta",
@@ -29356,10 +31752,79 @@
         "tags": [
           "Routes"
         ],
+        "x-cache-age": 0,
         "x-compatibility-date": "2025-09-30",
         "x-rate-limit": {
           "group": "routes",
           "max-tokens": 3600,
+          "window-size": "15m"
+        }
+      }
+    },
+    "/skyhooks/raidable": {
+      "get": {
+        "description": "Listing of all Skyhooks that currently or will shortly be raidable.",
+        "operationId": "GetSkyhooksRaidable",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguage"
+          },
+          {
+            "$ref": "#/components/parameters/IfNoneMatch"
+          },
+          {
+            "$ref": "#/components/parameters/CompatibilityDate"
+          },
+          {
+            "$ref": "#/components/parameters/Tenant"
+          },
+          {
+            "$ref": "#/components/parameters/IfModifiedSince"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkyhooksRaidable"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "ETag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "Last-Modified": {
+                "$ref": "#/components/headers/LastModified"
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "List (upcoming) raidable Skyhooks",
+        "tags": [
+          "Activities"
+        ],
+        "x-cache-age": 300,
+        "x-cache-mode": "ttl-based",
+        "x-compatibility-date": "2026-05-19",
+        "x-rate-limit": {
+          "group": "activity",
+          "max-tokens": 30,
           "window-size": "15m"
         }
       }
@@ -29431,10 +31896,10 @@
         }
       }
     },
-    "/sovereignty/map": {
+    "/sovereignty/systems": {
       "get": {
-        "description": "Shows sovereignty information for solar systems",
-        "operationId": "GetSovereigntyMap",
+        "description": "Listing of sovereignty details for all K-space systems in New Eden.",
+        "operationId": "GetSovereigntySystems",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguage"
@@ -29457,7 +31922,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SovereigntyMapGet"
+                  "$ref": "#/components/schemas/SovereigntySystems"
                 }
               }
             },
@@ -29485,79 +31950,13 @@
             "description": "Error"
           }
         },
-        "summary": "List sovereignty of systems",
+        "summary": "List sovereignty details for K-space systems",
         "tags": [
           "Sovereignty"
         ],
-        "x-cache-age": 3600,
-        "x-compatibility-date": "2020-01-01",
-        "x-rate-limit": {
-          "group": "sovereignty",
-          "max-tokens": 600,
-          "window-size": "15m"
-        }
-      }
-    },
-    "/sovereignty/structures": {
-      "get": {
-        "description": "Shows sovereignty data for structures.",
-        "operationId": "GetSovereigntyStructures",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/AcceptLanguage"
-          },
-          {
-            "$ref": "#/components/parameters/IfNoneMatch"
-          },
-          {
-            "$ref": "#/components/parameters/CompatibilityDate"
-          },
-          {
-            "$ref": "#/components/parameters/Tenant"
-          },
-          {
-            "$ref": "#/components/parameters/IfModifiedSince"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SovereigntyStructuresGet"
-                }
-              }
-            },
-            "description": "OK",
-            "headers": {
-              "Cache-Control": {
-                "$ref": "#/components/headers/CacheControl"
-              },
-              "ETag": {
-                "$ref": "#/components/headers/ETag"
-              },
-              "Last-Modified": {
-                "$ref": "#/components/headers/LastModified"
-              }
-            }
-          },
-          "default": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Error"
-          }
-        },
-        "summary": "List sovereignty structures",
-        "tags": [
-          "Sovereignty"
-        ],
-        "x-cache-age": 120,
-        "x-compatibility-date": "2020-01-01",
+        "x-cache-age": 300,
+        "x-cache-mode": "ttl-based",
+        "x-compatibility-date": "2026-05-19",
         "x-rate-limit": {
           "group": "sovereignty",
           "max-tokens": 600,
@@ -32480,6 +34879,12 @@
   ],
   "tags": [
     {
+      "name": "Access List"
+    },
+    {
+      "name": "Activities"
+    },
+    {
       "name": "Alliance"
     },
     {
@@ -32565,6 +34970,9 @@
     },
     {
       "name": "Status"
+    },
+    {
+      "name": "Structures"
     },
     {
       "name": "Universe"

--- a/packages/esi-metadata/src/scopes/endpoints.generated.ts
+++ b/packages/esi-metadata/src/scopes/endpoints.generated.ts
@@ -15,6 +15,12 @@ export const endpointScopes: Record<string, Record<string, ESIScope[]>> = {
   "/alliances/{alliance_id}/corporations/": { get: [] },
   "/alliances/{alliance_id}/icons/": { get: [] },
   "/characters/{character_id}/": { get: [] },
+  "/characters/{character_id}/access-lists/": {
+    get: ["esi-access.read_lists.v1"],
+  },
+  "/characters/{character_id}/access-lists/{access_list_id}/": {
+    get: ["esi-access.read_lists.v1"],
+  },
   "/characters/{character_id}/agents_research/": {
     get: ["esi-characters.read_agents_research.v1"],
   },
@@ -119,6 +125,12 @@ export const endpointScopes: Record<string, Record<string, ESIScope[]>> = {
   "/characters/{character_id}/medals/": {
     get: ["esi-characters.read_medals.v1"],
   },
+  "/characters/{character_id}/mercenary-tactical-operations/": {
+    get: ["esi-activities.read_character.v1"],
+  },
+  "/characters/{character_id}/mercenary-tactical-operations/{operation_id}/": {
+    get: ["esi-activities.read_character.v1"],
+  },
   "/characters/{character_id}/mining/": {
     get: ["esi-industry.read_character_mining.v1"],
   },
@@ -159,6 +171,12 @@ export const endpointScopes: Record<string, Record<string, ESIScope[]>> = {
   "/characters/{character_id}/skills/": { get: ["esi-skills.read_skills.v1"] },
   "/characters/{character_id}/standings/": {
     get: ["esi-characters.read_standings.v1"],
+  },
+  "/characters/{character_id}/structures/mercenary-dens/": {
+    get: ["esi-structures.read_character.v1"],
+  },
+  "/characters/{character_id}/structures/mercenary-dens/{mercenary_den_id}/": {
+    get: ["esi-structures.read_character.v1"],
   },
   "/characters/{character_id}/titles/": {
     get: ["esi-characters.read_titles.v1"],
@@ -298,6 +316,17 @@ export const endpointScopes: Record<string, Record<string, ESIScope[]>> = {
   "/corporations/{corporation_id}/structures/": {
     get: ["esi-corporations.read_structures.v1"],
   },
+  "/corporations/{corporation_id}/structures/skyhooks/": {
+    get: ["esi-structures.read_corporation.v1"],
+  },
+  "/corporations/{corporation_id}/structures/skyhooks/{skyhook_id}/": {
+    get: ["esi-structures.read_corporation.v1"],
+  },
+  "/corporations/{corporation_id}/structures/sovereignty-hubs/": {
+    get: ["esi-structures.read_corporation.v1"],
+  },
+  "/corporations/{corporation_id}/structures/sovereignty-hubs/{sovereignty_hub_id}/":
+    { get: ["esi-structures.read_corporation.v1"] },
   "/corporations/{corporation_id}/titles/": {
     get: ["esi-corporations.read_titles.v1"],
   },
@@ -368,11 +397,12 @@ export const endpointScopes: Record<string, Record<string, ESIScope[]>> = {
   },
   "/meta/changelog/": { get: [] },
   "/meta/compatibility-dates/": { get: [] },
+  "/meta/name/": { get: [] },
   "/meta/status/": { get: [] },
   "/route/{origin_system_id}/{destination_system_id}/": { post: [] },
+  "/skyhooks/raidable/": { get: [] },
   "/sovereignty/campaigns/": { get: [] },
-  "/sovereignty/map/": { get: [] },
-  "/sovereignty/structures/": { get: [] },
+  "/sovereignty/systems/": { get: [] },
   "/status/": { get: [] },
   "/ui/autopilot/waypoint/": { post: ["esi-ui.write_waypoint.v1"] },
   "/ui/openwindow/contract/": { post: ["esi-ui.open_window.v1"] },

--- a/packages/hooks/src/hooks/character/useCharacter.ts
+++ b/packages/hooks/src/hooks/character/useCharacter.ts
@@ -162,7 +162,7 @@ export const useCharacter = (
             description: esiCharacter.data.data.description,
             factionId: esiCharacter.data.data.faction_id,
             securityStatus: esiCharacter.data.data.security_status,
-            title: esiCharacter.data.data.title,
+            title: esiCharacter.data.data.corporation_title,
             ...researchAgentData,
             ...agentInSpaceData,
           }
@@ -195,7 +195,7 @@ export const useCharacter = (
             description: esiCharacter.data.data.description,
             factionId: esiCharacter.data.data.faction_id,
             securityStatus: esiCharacter.data.data.security_status,
-            title: esiCharacter.data.data.title,
+            title: esiCharacter.data.data.corporation_title,
           }
         : null,
     [esiCharacter.data, isNpc],

--- a/packages/hooks/src/hooks/character/useEsiCharacter.ts
+++ b/packages/hooks/src/hooks/character/useEsiCharacter.ts
@@ -1,8 +1,7 @@
 "use client";
 
-import type { GetCharactersCharacterIdQueryResponse } from "@jitaspace/esi-client";
+import type { GetCharactersDetailQueryResponse } from "@jitaspace/esi-client";
 
-export type ESICharacterPublicInformation =
-  GetCharactersCharacterIdQueryResponse;
+export type ESICharacterPublicInformation = GetCharactersDetailQueryResponse;
 
-export { useGetCharactersCharacterId as useEsiCharacter } from "@jitaspace/esi-client";
+export { useGetCharactersDetail as useEsiCharacter } from "@jitaspace/esi-client";

--- a/packages/hooks/src/hooks/sovereignty/index.ts
+++ b/packages/hooks/src/hooks/sovereignty/index.ts
@@ -1,2 +1,2 @@
 export * from "./useSolarSystemSovereignty";
-export * from "./useSovereigntyMap";
+export * from "./useSovereigntySystems";

--- a/packages/hooks/src/hooks/sovereignty/useSolarSystemSovereignty.ts
+++ b/packages/hooks/src/hooks/sovereignty/useSolarSystemSovereignty.ts
@@ -2,18 +2,53 @@
 
 import { useMemo } from "react";
 
-import { useGetSovereigntyMap } from "@jitaspace/esi-client";
+import { useGetSovereigntySystems } from "@jitaspace/esi-client";
 
+export interface SolarSystemSovereignty {
+  system_id: number;
+  alliance_id?: number;
+  corporation_id?: number;
+  faction_id?: number;
+}
 
+/**
+ * Sovereignty owner of a solar system, flattened from the nested claim union
+ * that `/sovereignty/systems` returns.
+ *
+ * Returns `undefined` for systems ESI reports no sovereignty for (such as
+ * wormhole space), and an entry with no owner id for unclaimed K-space.
+ */
+export const useSolarSystemSovereignty = (
+  solarSystemId: number,
+): SolarSystemSovereignty | undefined => {
+  const { data } = useGetSovereigntySystems();
 
+  return useMemo(() => {
+    const system = data?.data.solar_systems.find(
+      (entry) => entry.solar_system_id === solarSystemId,
+    );
 
+    if (!system) {
+      return undefined;
+    }
 
-export const useSolarSystemSovereignty = (solarSystemId: number) => {
-  const { data } = useGetSovereigntyMap();
+    const { claim } = system;
 
-  const solarSystemSovereignty = useMemo(() => {
-    return data?.data.find((sov) => sov.system_id === solarSystemId);
+    if ("alliance" in claim && claim.alliance) {
+      return {
+        system_id: system.solar_system_id,
+        alliance_id: claim.alliance.alliance_id,
+        corporation_id: claim.alliance.corporation_id,
+      };
+    }
+
+    if ("faction" in claim && claim.faction) {
+      return {
+        system_id: system.solar_system_id,
+        faction_id: claim.faction.faction_id,
+      };
+    }
+
+    return { system_id: system.solar_system_id };
   }, [data, solarSystemId]);
-
-  return solarSystemSovereignty;
 };

--- a/packages/hooks/src/hooks/sovereignty/useSolarSystemSovereignty.ts
+++ b/packages/hooks/src/hooks/sovereignty/useSolarSystemSovereignty.ts
@@ -15,8 +15,15 @@ export interface SolarSystemSovereignty {
  * Sovereignty owner of a solar system, flattened from the nested claim union
  * that `/sovereignty/systems` returns.
  *
- * Returns `undefined` for systems ESI reports no sovereignty for (such as
- * wormhole space), and an entry with no owner id for unclaimed K-space.
+ * Returns `undefined` for systems ESI reports no sovereignty for, and an entry
+ * with no owner id for unclaimed K-space.
+ *
+ * Behaviour change (ESI compatibility date 2026-07-17): `/sovereignty/systems`
+ * covers only K-space. The retired `/sovereignty/map` used to report NPC-faction
+ * sovereignty for the five Drifter-hub wormhole systems — Sentinel MZ (EDENCOM),
+ * Liberated Barbican (Minmatar), Sanctified Vidette (Amarr), Conflux Eyrie
+ * (Caldari) and Azdaja Redoubt (Triglavian) — which now resolve to no owner, so
+ * their sovereignty avatar falls back to a star. There is no replacement source.
  */
 export const useSolarSystemSovereignty = (
   solarSystemId: number,

--- a/packages/hooks/src/hooks/sovereignty/useSovereigntyMap.ts
+++ b/packages/hooks/src/hooks/sovereignty/useSovereigntyMap.ts
@@ -1,9 +1,0 @@
-"use client";
-
-import { useGetSovereigntyMap } from "@jitaspace/esi-client";
-
-
-
-
-
-export const useSovereigntyMap = () => useGetSovereigntyMap();

--- a/packages/hooks/src/hooks/sovereignty/useSovereigntySystems.ts
+++ b/packages/hooks/src/hooks/sovereignty/useSovereigntySystems.ts
@@ -1,0 +1,5 @@
+"use client";
+
+import { useGetSovereigntySystems } from "@jitaspace/esi-client";
+
+export const useSovereigntySystems = () => useGetSovereigntySystems();

--- a/packages/hooks/src/hooks/useEsiName.ts
+++ b/packages/hooks/src/hooks/useEsiName.ts
@@ -7,7 +7,7 @@ import { createCache, useCache } from "@react-hook/cache";
 import type { GetCharactersCharacterIdSearchQueryParamsCategoriesEnum } from "@jitaspace/esi-client";
 import {
   getAlliancesAllianceId,
-  getCharactersCharacterId,
+  getCharactersDetail,
   getCorporationsCorporationId,
   getUniverseConstellationsConstellationId,
   getUniverseFactions,
@@ -90,7 +90,7 @@ const resolveNameOfKnownCategory = async (
       );
     case "agent":
     case "character":
-      return getCharactersCharacterId(Number(id), {}, {}).then((data) => {
+      return getCharactersDetail(Number(id), {}, {}).then((data) => {
         return data.data.name;
       });
     case "inventory_type":

--- a/packages/hooks/tests/useCharacter.test.tsx
+++ b/packages/hooks/tests/useCharacter.test.tsx
@@ -60,7 +60,7 @@ const esiCharacterDetail = {
   description: "A short biography",
   faction_id: 500001,
   security_status: 4.2,
-  title: "Fleet Commander",
+  corporation_title: "Fleet Commander",
 };
 
 function querySuccess<T>(data: T) {

--- a/packages/hooks/tests/useSolarSystemSovereignty.test.tsx
+++ b/packages/hooks/tests/useSolarSystemSovereignty.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { renderHook } from "@testing-library/react";
+
+// The generated @jitaspace/esi-client isn't built in this workspace, and
+// @swc/jest does not hoist jest.mock above imports, so the client is mocked here
+// and the hook under test is required lazily.
+
+const mockUseGetSovereigntySystems = jest.fn();
+
+jest.mock("@jitaspace/esi-client", () => ({
+  __esModule: true,
+  useGetSovereigntySystems: (...args: unknown[]) =>
+    mockUseGetSovereigntySystems(...args),
+}));
+
+const { useSolarSystemSovereignty } =
+  require("../src/hooks/sovereignty/useSolarSystemSovereignty") as typeof import("../src/hooks/sovereignty/useSolarSystemSovereignty");
+const { useSovereigntySystems } =
+  require("../src/hooks/sovereignty/useSovereigntySystems") as typeof import("../src/hooks/sovereignty/useSovereigntySystems");
+
+// Shaped exactly like a live GET /sovereignty/systems response: `claim` carries
+// exactly one of faction / alliance / unclaimed.
+const ALLIANCE_SYSTEM = {
+  solar_system_id: 30000208,
+  claim: {
+    alliance: {
+      alliance_id: 99003581,
+      corporation_id: 98599770,
+      claimed_since: "2020-10-08T00:38:16Z",
+      sovereignty_hub: {
+        id: 1034510825648,
+        vulnerability_window: {
+          start: "2026-07-17T09:30:00Z",
+          end: "2026-07-17T12:30:00Z",
+        },
+      },
+      is_capital_system: false,
+      development: {
+        activity_defense_multiplier: 6.0,
+        military_level: 5,
+        industrial_level: 5,
+        strategic_level: 5,
+      },
+    },
+  },
+};
+
+const FACTION_SYSTEM = {
+  solar_system_id: 30000001,
+  claim: { faction: { faction_id: 500007 } },
+};
+
+const UNCLAIMED_SYSTEM = {
+  solar_system_id: 30000326,
+  claim: { unclaimed: true },
+};
+
+function mockSystems() {
+  mockUseGetSovereigntySystems.mockReturnValue({
+    data: {
+      data: {
+        solar_systems: [ALLIANCE_SYSTEM, FACTION_SYSTEM, UNCLAIMED_SYSTEM],
+      },
+    },
+  });
+}
+
+describe("useSolarSystemSovereignty", () => {
+  it("flattens an alliance claim, keeping both the alliance and its holding corporation", () => {
+    mockSystems();
+
+    const { result } = renderHook(() => useSolarSystemSovereignty(30000208));
+
+    expect(result.current).toEqual({
+      system_id: 30000208,
+      alliance_id: 99003581,
+      corporation_id: 98599770,
+    });
+  });
+
+  it("flattens a faction claim", () => {
+    mockSystems();
+
+    const { result } = renderHook(() => useSolarSystemSovereignty(30000001));
+
+    expect(result.current).toEqual({
+      system_id: 30000001,
+      faction_id: 500007,
+    });
+  });
+
+  it("reports an unclaimed system with no owner", () => {
+    mockSystems();
+
+    const { result } = renderHook(() => useSolarSystemSovereignty(30000326));
+
+    expect(result.current).toEqual({ system_id: 30000326 });
+    expect(result.current?.alliance_id).toBeUndefined();
+    expect(result.current?.faction_id).toBeUndefined();
+  });
+
+  it("returns undefined for a system ESI reports no sovereignty for", () => {
+    mockSystems();
+
+    // Wormhole space is absent from the K-space-only listing.
+    const { result } = renderHook(() => useSolarSystemSovereignty(31000001));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns undefined while the query has no data yet", () => {
+    mockUseGetSovereigntySystems.mockReturnValue({ data: undefined });
+
+    const { result } = renderHook(() => useSolarSystemSovereignty(30000208));
+
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe("useSovereigntySystems", () => {
+  it("returns the raw sovereignty listing query", () => {
+    mockSystems();
+
+    const { result } = renderHook(() => useSovereigntySystems());
+
+    expect(result.current.data?.data.solar_systems).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## What

Bumps the ESI OpenAPI compatibility date from `2025-12-16` to `2026-07-17` in `@jitaspace/esi-client`, re-downloads the spec, regenerates the client, and fixes everything the upstream changes broke.

## Why

`2026-07-17` is the latest published ESI compatibility date. The bump surfaced three upstream breaking changes (confirmed against `/meta/changelog` and live ESI) that would otherwise silently break the app.

## Upstream breaking changes handled

- **`GET /characters/{character_id}` operationId renamed** `GetCharactersCharacterId` → `GetCharactersDetail`, which renames every generated symbol (`getCharactersDetail`, `useGetCharactersDetail`, `GetCharactersDetailQueryResponse`, …). Updated all call sites across `hooks`, `background-jobs`, `apps/web`, and the `esi-client` README example.
- **`CharactersDetail.title` renamed to `corporation_title`** (plus new required `achievement_score`, optional `character_title_id`). Live ESI confirms `title` is gone — character titles would have rendered blank. Remapped at the 5 ESI read sites; the JitaSpace domain field and `Character.title` DB column keep their names (renaming those would need a migration and isn't ESI's concern).
- **`/sovereignty/map` and `/sovereignty/structures` removed**, unified into `/sovereignty/systems` with a nested claim union (`{faction} | {alliance} | {unclaimed}`). Rewrote `useSolarSystemSovereignty` to flatten it back to the legacy flat shape so consumers are unchanged, and verified the output is **byte-identical** to the old endpoint for all three claim types against live ESI. Deleted the now-dead `useSovereigntyMap`; `useSovereigntySystems` replaces it.

## Other changes

- **Single source of truth for the date:** only the `download-schema` script URL pins it now. `buildscript.js` derives the date from the downloaded `swagger.json` `info.version` (throwing if it isn't `YYYY-MM-DD`) instead of keeping a second hardcoded copy that could drift.
- **Dropped hardcoded `X-Compatibility-Date: 2025-12-16` literals** in the two status-page components — these became type errors against the now single-value enum header param. They pass `undefined` and inherit the client default, so they can never go stale again.
- Regenerated `esi-metadata` `endpointScopes` (picks up access-lists, mercenary dens, skyhooks, sovereignty hubs, `/meta/name`; drops the two removed sovereignty routes).
- Added a regression-tested unit suite for the sovereignty adapter (was 0% coverage — would have tripped the SonarCloud New Code gate). Mutation-checked: dropping `corporation_id` makes the tests fail.

## ⚠️ User-visible behavior change: five Drifter-hub wormhole systems

The new `/sovereignty/systems` covers **only K-space** (the endpoint description says so; the old `/sovereignty/map` had no such qualifier and CCP's changelog doesn't spell this out). Diffing live data, exactly five J-space systems that carried an **NPC-faction** owner in the old endpoint are now absent, so their sovereignty avatar falls back to a star:

| System | Owner in old `/sovereignty/map` |
|---|---|
| Sentinel MZ | EDENCOM |
| Liberated Barbican | Minmatar Republic |
| Sanctified Vidette | Amarr Empire |
| Conflux Eyrie | Caldari State |
| Azdaja Redoubt | Triglavian Collective |

(Thera is the sixth Drifter hub but was already unowned. These are NPC-faction sovereignties, **not** Drifter-owned — an earlier revision of this description got that wrong.) There is no replacement source, so no data was invented. **Zero K-space systems affected.** This is now recorded durably in the `useSolarSystemSovereignty` adapter comment and in the `@jitaspace/web` changeset, not just here.

## Other reviewer notes

- `useGetSovereigntyMap` / `useSovereigntyMap` are removed; `@jitaspace/hooks` is private and had no other consumers.

## Verification

- Full monorepo `pnpm test` green (16/16 tasks).
- Per-package `type-check` shows **zero new errors** vs a stashed baseline (regenerated from the old spec for an honest diff; the repo carries ~700 pre-existing errors).
- `pnpm lint` 0 errors; pre-commit hook (turbo lint + manypkg) passed.
- Browser-verified against live ESI: character page renders the `corporation_title`, status page shows `2026-07-17` with the up-to-date check, sovereignty avatar resolves to the correct alliance logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)