### PR TITLE
fix(web): widen Settings modal so entries no longer crop or wrap

### DIFF
--- a/apps/web/components/Settings/SettingsCard.module.css
+++ b/apps/web/components/Settings/SettingsCard.module.css
@@ -1,12 +1,3 @@
-.card {
-  max-width: 720px;
-  margin-inline: auto;
-}
-
-.title {
-  line-height: 1;
-}
-
 .item {
   padding-top: var(--mantine-spacing-md);
   padding-bottom: var(--mantine-spacing-md);
@@ -21,7 +12,9 @@
   padding: 8px var(--mantine-spacing-sm);
   border-radius: var(--mantine-radius-md);
   border: 1px solid var(--mantine-color-default-border);
-  transition: background-color 150ms ease, border-color 150ms ease;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease;
 }
 
 .control:hover {

--- a/apps/web/components/Settings/SettingsCard.tsx
+++ b/apps/web/components/Settings/SettingsCard.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   Button,
-  Card,
   Group,
   Menu,
   Switch,
@@ -127,200 +126,194 @@ export function SettingsCard() {
       : "Dismissed news banners will reappear at the top of the home page.";
 
   return (
-    <Card withBorder radius="md" p="xl" className={classes.card}>
-      <Text fz="lg" className={classes.title} fw={500}>
-        Configure settings
-      </Text>
+    <Tabs defaultValue="general">
+      <Tabs.List mb="md">
+        <Tabs.Tab value="general" leftSection={<IconSettings size={16} />}>
+          General
+        </Tabs.Tab>
+        <Tabs.Tab value="experimental" leftSection={<IconFlask size={16} />}>
+          Experimental
+        </Tabs.Tab>
+        <Tabs.Tab value="reset" leftSection={<IconRefresh size={16} />}>
+          Reset
+        </Tabs.Tab>
+      </Tabs.List>
 
-      <Tabs defaultValue="general" mt="md">
-        <Tabs.List mb="md">
-          <Tabs.Tab value="general" leftSection={<IconSettings size={16} />}>
-            General
-          </Tabs.Tab>
-          <Tabs.Tab value="experimental" leftSection={<IconFlask size={16} />}>
-            Experimental
-          </Tabs.Tab>
-          <Tabs.Tab value="reset" leftSection={<IconRefresh size={16} />}>
-            Reset
-          </Tabs.Tab>
-        </Tabs.List>
+      <Tabs.Panel value="general">
+        <Text fz="xs" c="dimmed" mt={3} mb="md">
+          Choose the language for ESI requests and the UI theme.
+        </Text>
 
-        <Tabs.Panel value="general">
-          <Text fz="xs" c="dimmed" mt={3} mb="md">
-            Choose the language for ESI requests and the UI theme.
-          </Text>
+        <Group
+          justify="space-between"
+          className={classes.item}
+          wrap="nowrap"
+          gap="xl"
+        >
+          <div>
+            <Text>Language</Text>
+            <Text size="xs" c="dimmed">
+              Used in ESI requests through the `Accept-Language` header
+            </Text>
+          </div>
 
-          <Group
-            justify="space-between"
-            className={classes.item}
-            wrap="nowrap"
-            gap="xl"
+          <Menu
+            onOpen={() => setLanguageMenuOpened(true)}
+            onClose={() => setLanguageMenuOpened(false)}
+            radius="md"
+            width="target"
           >
-            <div>
-              <Text>Language</Text>
-              <Text size="xs" c="dimmed">
-                Used in ESI requests through the `Accept-Language` header
-              </Text>
-            </div>
-
-            <Menu
-              onOpen={() => setLanguageMenuOpened(true)}
-              onClose={() => setLanguageMenuOpened(false)}
-              radius="md"
-              width="target"
-            >
-              <Menu.Target>
-                <UnstyledButton
-                  className={classes.control}
-                  data-expanded={languageMenuOpened || undefined}
-                >
-                  <Group gap="xs">
-                    <ReactCountryFlag
-                      countryCode={selectedLanguage.countryCode}
-                      svg
-                      className={classes.flag}
-                      aria-label={`${selectedLanguage.label} flag`}
-                    />
-                    <span className={classes.label}>
-                      {selectedLanguage.label}
-                    </span>
-                  </Group>
-                  <IconChevronDown
-                    size={16}
-                    className={classes.icon}
-                    stroke={1.5}
+            <Menu.Target>
+              <UnstyledButton
+                className={classes.control}
+                data-expanded={languageMenuOpened || undefined}
+              >
+                <Group gap="xs">
+                  <ReactCountryFlag
+                    countryCode={selectedLanguage.countryCode}
+                    svg
+                    className={classes.flag}
+                    aria-label={`${selectedLanguage.label} flag`}
                   />
-                </UnstyledButton>
-              </Menu.Target>
-              <Menu.Dropdown>{languageItems}</Menu.Dropdown>
-            </Menu>
-          </Group>
+                  <span className={classes.label}>
+                    {selectedLanguage.label}
+                  </span>
+                </Group>
+                <IconChevronDown
+                  size={16}
+                  className={classes.icon}
+                  stroke={1.5}
+                />
+              </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown>{languageItems}</Menu.Dropdown>
+          </Menu>
+        </Group>
 
-          <Group
-            justify="space-between"
-            className={classes.item}
-            wrap="nowrap"
-            gap="xl"
+        <Group
+          justify="space-between"
+          className={classes.item}
+          wrap="nowrap"
+          gap="xl"
+        >
+          <div>
+            <Text>Theme</Text>
+            <Text size="xs" c="dimmed">
+              Choose the global UI theme
+            </Text>
+          </div>
+
+          <Menu
+            onOpen={() => setThemeMenuOpened(true)}
+            onClose={() => setThemeMenuOpened(false)}
+            radius="md"
+            width="target"
           >
-            <div>
-              <Text>Theme</Text>
-              <Text size="xs" c="dimmed">
-                Choose the global UI theme
-              </Text>
-            </div>
+            <Menu.Target>
+              <UnstyledButton
+                className={classes.control}
+                data-expanded={themeMenuOpened || undefined}
+                aria-label="Theme"
+              >
+                <Group gap="xs">
+                  <span className={classes.label}>
+                    {selectedThemeOption.label}
+                  </span>
+                </Group>
+                <IconChevronDown
+                  size={16}
+                  className={classes.icon}
+                  stroke={1.5}
+                />
+              </UnstyledButton>
+            </Menu.Target>
+            <Menu.Dropdown>{themeItems}</Menu.Dropdown>
+          </Menu>
+        </Group>
+      </Tabs.Panel>
 
-            <Menu
-              onOpen={() => setThemeMenuOpened(true)}
-              onClose={() => setThemeMenuOpened(false)}
-              radius="md"
-              width="target"
-            >
-              <Menu.Target>
-                <UnstyledButton
-                  className={classes.control}
-                  data-expanded={themeMenuOpened || undefined}
-                  aria-label="Theme"
-                >
-                  <Group gap="xs">
-                    <span className={classes.label}>
-                      {selectedThemeOption.label}
-                    </span>
-                  </Group>
-                  <IconChevronDown
-                    size={16}
-                    className={classes.icon}
-                    stroke={1.5}
-                  />
-                </UnstyledButton>
-              </Menu.Target>
-              <Menu.Dropdown>{themeItems}</Menu.Dropdown>
-            </Menu>
-          </Group>
-        </Tabs.Panel>
+      <Tabs.Panel value="experimental">
+        <Text fz="xs" c="dimmed" mt={3} mb="md">
+          Try out features that are still in development.
+        </Text>
 
-        <Tabs.Panel value="experimental">
-          <Text fz="xs" c="dimmed" mt={3} mb="md">
-            Try out features that are still in development.
-          </Text>
+        <Group
+          justify="space-between"
+          className={classes.item}
+          wrap="nowrap"
+          gap="xl"
+        >
+          <div>
+            <Text>New data tables</Text>
+            <Text size="xs" c="dimmed">
+              Enable the experimental DataTable components. When on, each table
+              shows an engine selector (TanStack or mantine-datatable). When
+              off, the classic mantine-react-table is used everywhere.
+            </Text>
+          </div>
+          <Switch
+            className={classes.switch}
+            checked={experimentalDataTables}
+            onChange={(event) =>
+              setExperimentalDataTables(event.currentTarget.checked)
+            }
+            aria-label="Enable experimental data tables"
+          />
+        </Group>
 
-          <Group
-            justify="space-between"
-            className={classes.item}
-            wrap="nowrap"
-            gap="xl"
+        <Group
+          justify="space-between"
+          className={classes.item}
+          wrap="nowrap"
+          gap="xl"
+        >
+          <div>
+            <Text>New Active Wars page</Text>
+            <Text size="xs" c="dimmed">
+              Replace the Active Wars table with the redesigned overview —
+              headline stats, aggressor and defender leaderboards, and a
+              filterable list you can switch between rows and a compact table.
+            </Text>
+          </div>
+          <Switch
+            className={classes.switch}
+            checked={experimentalActiveWars}
+            onChange={(event) =>
+              setExperimentalActiveWars(event.currentTarget.checked)
+            }
+            aria-label="Enable the new Active Wars page"
+          />
+        </Group>
+      </Tabs.Panel>
+
+      <Tabs.Panel value="reset">
+        <Text fz="xs" c="dimmed" mt={3} mb="md">
+          Restore things you have dismissed.
+        </Text>
+
+        <Group
+          justify="space-between"
+          className={classes.item}
+          wrap="nowrap"
+          gap="xl"
+        >
+          <div>
+            <Text>Hidden news</Text>
+            <Text size="xs" c="dimmed">
+              {hiddenNewsDescription}
+            </Text>
+          </div>
+
+          <Button
+            variant="default"
+            leftSection={<IconRestore size={16} />}
+            disabled={!newsMounted || hiddenNewsCount === 0}
+            onClick={handleResetHiddenNews}
           >
-            <div>
-              <Text>New data tables</Text>
-              <Text size="xs" c="dimmed">
-                Enable the experimental DataTable components. When on, each table
-                shows an engine selector (TanStack or mantine-datatable). When
-                off, the classic mantine-react-table is used everywhere.
-              </Text>
-            </div>
-            <Switch
-              className={classes.switch}
-              checked={experimentalDataTables}
-              onChange={(event) =>
-                setExperimentalDataTables(event.currentTarget.checked)
-              }
-              aria-label="Enable experimental data tables"
-            />
-          </Group>
-
-          <Group
-            justify="space-between"
-            className={classes.item}
-            wrap="nowrap"
-            gap="xl"
-          >
-            <div>
-              <Text>New Active Wars page</Text>
-              <Text size="xs" c="dimmed">
-                Replace the Active Wars table with the redesigned overview —
-                headline stats, aggressor and defender leaderboards, and a
-                filterable list you can switch between rows and a compact table.
-              </Text>
-            </div>
-            <Switch
-              className={classes.switch}
-              checked={experimentalActiveWars}
-              onChange={(event) =>
-                setExperimentalActiveWars(event.currentTarget.checked)
-              }
-              aria-label="Enable the new Active Wars page"
-            />
-          </Group>
-        </Tabs.Panel>
-
-        <Tabs.Panel value="reset">
-          <Text fz="xs" c="dimmed" mt={3} mb="md">
-            Restore things you have dismissed.
-          </Text>
-
-          <Group
-            justify="space-between"
-            className={classes.item}
-            wrap="nowrap"
-            gap="xl"
-          >
-            <div>
-              <Text>Hidden news</Text>
-              <Text size="xs" c="dimmed">
-                {hiddenNewsDescription}
-              </Text>
-            </div>
-
-            <Button
-              variant="default"
-              leftSection={<IconRestore size={16} />}
-              disabled={!newsMounted || hiddenNewsCount === 0}
-              onClick={handleResetHiddenNews}
-            >
-              Reset hidden news
-            </Button>
-          </Group>
-        </Tabs.Panel>
-      </Tabs>
-    </Card>
+            Reset hidden news
+          </Button>
+        </Group>
+      </Tabs.Panel>
+    </Tabs>
   );
 }

--- a/apps/web/layouts/MainLayout/UserButton.tsx
+++ b/apps/web/layouts/MainLayout/UserButton.tsx
@@ -168,6 +168,7 @@ export default function UserButton({ ...others }: UserButtonProps) {
             openContextModal({
               modal: "settings",
               title: "Settings",
+              size: "xl",
               innerProps: {},
             });
           }}


### PR DESCRIPTION
## What

The **Settings** modal (opened from the user menu) was too narrow, cropping controls and heavily wrapping the setting descriptions.

- Open the modal at `size="xl"` (**780px**) instead of Mantine's default `md` (**440px**).
- Reshape `SettingsCard` to be modal-native: remove the outer `Card` border/padding/`max-width` and the redundant **"Configure settings"** title, so the tabs render directly on the modal surface and use its full width.
- Drop the now-unused `.card` / `.title` CSS rules.

## Why

`SettingsCard` was authored as a full-page card (`max-width: 720px`, its own border, its own title). Rendering that 720px page-card inside a 440px dialog squeezed the two-column rows — cropping the language/theme dropdowns and toggles and wrapping the descriptions across many lines. The card's own title and border also duplicated the modal's existing **"Settings"** title and frame (a "card in a card" look).

## Before → After

| | Before | After |
|---|---|---|
| Modal width | 440px (`md`) | 780px (`xl`) |
| Titles | "Settings" + "Configure settings" | "Settings" only |
| Chrome | modal frame + nested card border | modal frame only |
| Experimental descriptions | wrapped ~5 lines, toggles cropped | ~2 lines, toggles fully visible |

## Reviewer notes

- `SettingsCard` is only consumed by the Settings modal (plus its unit tests); it's not used as a standalone page, so dropping the page-card chrome has no other callers.
- Verified in the local dev preview across all three tabs (General / Experimental / Reset): measured modal content width = 780px, no cropping/wrapping, controls and the "Reset hidden news" button fully visible.
- The bulk of the `SettingsCard.tsx` diff is re-indentation from removing one level of JSX nesting; the substantive changes are the removed `Card` wrapper, title, and import.
- `@jitaspace/web` is a private package, so no changeset is included.
- `pnpm test` (SettingsCard + UserButton suites, 11 tests), `type-check`, and `lint` all pass for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)