### PR TITLE
fix(background-jobs): strip createdAt in the remaining scrape jobs

### DIFF
--- a/packages/background-jobs/jobs/scrape/esi/scrapeEsiTypes.ts
+++ b/packages/background-jobs/jobs/scrape/esi/scrapeEsiTypes.ts
@@ -144,7 +144,7 @@ async function processTypeBatch(
         })
         .then((entries) =>
           entries.map((record) =>
-            excludeObjectKeys(record, ["updatedAt", "isDeleted"]),
+            excludeObjectKeys(record, ["updatedAt", "createdAt", "isDeleted"]),
           ),
         ),
     fetchRemoteEntries: async () =>
@@ -209,7 +209,7 @@ async function processTypeBatch(
         })
         .then((entries) =>
           entries.map((record) =>
-            excludeObjectKeys(record, ["updatedAt", "isDeleted"]),
+            excludeObjectKeys(record, ["updatedAt", "createdAt", "isDeleted"]),
           ),
         ),
     fetchRemoteEntries: async () =>

--- a/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksAgentTypes.ts
+++ b/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksAgentTypes.ts
@@ -38,7 +38,9 @@ export const scrapeHoboleaksAgentTypes = defineJob<
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(

--- a/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksDogmaEffectCategories.ts
+++ b/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksDogmaEffectCategories.ts
@@ -40,7 +40,9 @@ export const scrapeHoboleaksDogmaEffectCategories = defineJob<
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(

--- a/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksDogmaUnits.ts
+++ b/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksDogmaUnits.ts
@@ -46,7 +46,9 @@ export const scrapeHoboleaksDogmaUnits = defineJob<
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
@@ -91,7 +91,9 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(
@@ -165,7 +167,9 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(
@@ -216,7 +220,9 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(
@@ -275,7 +281,9 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: async () =>
         Promise.all(

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeIcons.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeIcons.ts
@@ -46,7 +46,9 @@ export const scrapeSdeIcons = defineJob<ScrapeIconsEventPayload["data"]>({
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: async () =>
         Promise.all(

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeNpcCorporationDivisions.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeNpcCorporationDivisions.ts
@@ -59,7 +59,9 @@ export const scrapeSdeNpcCorporationDivisions = defineJob<
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: async () =>
         Promise.all(

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeRaces.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeRaces.ts
@@ -58,7 +58,7 @@ export const scrapeSdeRaces = defineJob<ScrapeSdeRacesEventPayload["data"]>({
           })
           .then((entries) =>
             entries.map((entry) =>
-              excludeObjectKeys(entry, ["updatedAt", "factionId"]),
+              excludeObjectKeys(entry, ["updatedAt", "createdAt", "factionId"]),
             ),
           ),
       fetchRemoteEntries: async () =>

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeStationServices.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeStationServices.ts
@@ -62,7 +62,9 @@ export const scrapeSdeStationServices = defineJob<
             },
           })
           .then((entries) =>
-            entries.map((entry) => excludeObjectKeys(entry, ["updatedAt"])),
+            entries.map((entry) =>
+              excludeObjectKeys(entry, ["updatedAt", "createdAt"]),
+            ),
           ),
       fetchRemoteEntries: async () =>
         Promise.all(

--- a/packages/background-jobs/tests/scrapeHoboleaksAgentTypes.test.ts
+++ b/packages/background-jobs/tests/scrapeHoboleaksAgentTypes.test.ts
@@ -1,0 +1,96 @@
+import { beforeAll, describe, expect, it, jest } from "@jest/globals";
+
+import type { scrapeHoboleaksAgentTypes as ScrapeHoboleaksAgentTypes } from "../jobs/scrape/hoboleaks/scrapeHoboleaksAgentTypes";
+
+// The job pulls in p-limit (ESM) and a real Prisma client (via ../db, which
+// builds one from the zod-checked env). Stub both so the test exercises only the
+// local-vs-remote diff the job feeds into updateTable.
+// (@swc/jest doesn't hoist jest.mock, and the real modules crash if loaded, so
+// the job is imported lazily in beforeAll — after these mocks are registered.)
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => unknown) => fn(),
+}));
+
+const agentType = {
+  findMany: jest.fn((_args?: unknown) => Promise.resolve<unknown[]>([])),
+  createMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+  update: jest.fn((_args?: unknown) => Promise.resolve({})),
+  updateMany: jest.fn((_args?: unknown) => Promise.resolve({ count: 0 })),
+};
+
+jest.mock("../db", () => ({ prisma: { agentType } }));
+
+let scrapeHoboleaksAgentTypes: typeof ScrapeHoboleaksAgentTypes;
+
+beforeAll(async () => {
+  ({ scrapeHoboleaksAgentTypes } = await import(
+    "../jobs/scrape/hoboleaks/scrapeHoboleaksAgentTypes"
+  ));
+});
+
+/** The upstream Hoboleaks payload: `{ [agentTypeId]: name }`. */
+const mockHoboleaksResponse = (agentTypes: Record<number, string>) => {
+  globalThis.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(agentTypes) }),
+  ) as unknown as typeof globalThis.fetch;
+};
+
+// The record the job derives from that payload — no createdAt/updatedAt.
+const remoteRecord = { agentTypeId: 1, name: "BasicAgent", isDeleted: false };
+
+const runJob = () =>
+  // The handler ignores its context, so an empty one is enough.
+  scrapeHoboleaksAgentTypes.handler({} as never);
+
+describe("scrapeHoboleaksAgentTypes", () => {
+  it("does not update a row whose only difference is the createdAt/updatedAt timestamps", async () => {
+    mockHoboleaksResponse({ 1: "BasicAgent" });
+    // The DB row matches the incoming record but also carries the two
+    // Prisma-managed timestamps, which the local fetch must strip. Leaving
+    // createdAt in made every row compare as "modified" on every run, rewriting
+    // whole tables and churning updatedAt.
+    agentType.findMany.mockResolvedValueOnce([
+      {
+        ...remoteRecord,
+        createdAt: new Date("2017-06-01"),
+        updatedAt: new Date("2017-06-01"),
+      },
+    ]);
+
+    const result = await runJob();
+
+    expect(agentType.update).not.toHaveBeenCalled();
+    expect(agentType.createMany).toHaveBeenCalledWith({ data: [] });
+    expect(result.stats.agentTypeChanges).toMatchObject({
+      created: 0,
+      modified: 0,
+      equal: 1,
+    });
+  });
+
+  it("updates a row when a real field changed", async () => {
+    mockHoboleaksResponse({ 1: "BasicAgent" });
+    agentType.findMany.mockResolvedValueOnce([
+      {
+        ...remoteRecord,
+        name: "OldName",
+        createdAt: new Date("2017-06-01"),
+        updatedAt: new Date("2017-06-01"),
+      },
+    ]);
+
+    const result = await runJob();
+
+    expect(agentType.update).toHaveBeenCalledTimes(1);
+    expect(agentType.update).toHaveBeenCalledWith({
+      data: remoteRecord,
+      where: { agentTypeId: 1 },
+    });
+    expect(result.stats.agentTypeChanges).toMatchObject({
+      created: 0,
+      modified: 1,
+      equal: 0,
+    });
+  });
+});


### PR DESCRIPTION
Finishes the fix started in #652, which corrected the character/corporation merge helpers but left the same bug in the scrape jobs.

## The bug

These jobs fetch full Prisma rows and strip only `updatedAt` before diffing them against remote records that carry no `createdAt` at all.

`recordsAreEqual` iterates the **local** row's keys, so local `createdAt` (a `Date`) vs the remote's missing key (`typeof "object"` vs `typeof "undefined"`) returns `false` — and **every existing row is classified "modified" on every run**. Each run then issues a `prisma.*.update` for every row in these tables:

- write amplification against production CockroachDB
- `@updatedAt` churn on every row, which destroys the change signal these tables rely on
- `CrudStatistics` that permanently report `equal: 0, modified: everything`

## What changed

Strips `createdAt` at the **13 affected call sites across 9 jobs**, matching the convention the other ~30 call sites already use:

| Jobs | Was | Now |
| --- | --- | --- |
| 3 hoboleaks jobs, SDE icons / station services / NPC corp divisions, all 4 tables in `scrapeSdeAgents` | `["updatedAt"]` | `["updatedAt", "createdAt"]` |
| `scrapeSdeRaces` | `["updatedAt", "factionId"]` | `+ "createdAt"` |
| `scrapeEsiTypes` — TypeAttribute & TypeEffect | `["updatedAt", "isDeleted"]` | `+ "createdAt"` |

The last three excluded a *different* extra key, so they don't match a naive grep for `["updatedAt"]` and were easy to miss. **TypeAttribute and TypeEffect are among the largest tables in the schema**, so these were likely the biggest amplifiers of the set.

## Reviewer notes

**`processWarsQueue` is deliberately untouched.** It looks affected but isn't: it uses an explicit `select` that never fetches `createdAt`, backed by `type WarEntry = Omit<War, "updatedAt" | "createdAt">`. An exclusion there would be dead code.

Every site was verified against three things before editing: the model actually has `createdAt`, the local query is an unrestricted `findMany` (so the column is present), and the remote builder emits business fields only.

## Testing

Adds a regression test driving the **real** `scrapeHoboleaksAgentTypes` handler through `updateTable` with a stubbed Prisma client and `fetch`: a row differing only in its timestamps must land in `equal` with no update issued, while a real field change still routes to `modified`.

I confirmed **the test fails without the fix and passes with it**. That mattered here — these jobs had ~0% coverage, so the pre-existing suite passed either way.

- `pnpm test` in `packages/background-jobs`: 12 suites / 55 tests green
- ESLint + Prettier clean
- `tsc --noEmit`: 1 error in `utils/updateTable.ts`, **identical at baseline** with the changes stashed — pre-existing, not introduced here

No changeset: `@jitaspace/background-jobs` is `private: true`, and #652 set the precedent by adding none for the same fix.

## Follow-up worth considering (not in this PR)

This bug class keeps recurring because the invariant — *local key set must equal remote key set* — is hand-maintained at 46 call sites. The dev-only guard in `utils/compareSets.ts` was written to catch exactly this, but it filters `createdAt` out of both key sets, so it is blind to the bug it exists to prevent. Now that all call sites are consistent, dropping `createdAt` from that filter would make future drift fail loudly in development. (Separately, its check `objKeysBefore.every((_, i) => objKeysBefore[i] == objKeysAfter[i])` only iterates the *before* array, so a remote superset slips through silently.) Both are shared-util behaviour changes, so I left them out of this scoped fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)