### PR TITLE
fix(hooks): honour corporationId/allianceId in useAccessToken

### DIFF
--- a/.changeset/access-token-subject-filter.md
+++ b/.changeset/access-token-subject-filter.md
@@ -1,0 +1,9 @@
+---
+"@jitaspace/hooks": patch
+---
+
+`useAccessToken` now honours the `corporationId` and `allianceId` options instead of ignoring them. Corporation- and alliance-scoped ESI routes are authenticated with a character token, so the hook previously returned the first logged-in character holding the required scope — regardless of whether that character was actually a member of the corporation or alliance being queried. It now only considers characters that belong to the requested subject.
+
+Every character that clears the filters can authorise the request equally well, so the first match is used.
+
+The `roles` option remains accepted but unenforced, now documented rather than silently dropped: `CharacterSsoSession.corporationRoles` is initialised empty and never populated, so filtering on it would leave every role-gated endpoint without a token. Call sites keep declaring the roles they need so the check can be enabled in one place once roles are fetched; ESI enforces them server-side meanwhile.

--- a/.changeset/corp-alliance-correct-character-token.md
+++ b/.changeset/corp-alliance-correct-character-token.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed corporation and alliance pages using the wrong character's credentials when you have several characters logged in. Corporation assets, corporation contacts, and alliance contacts could be requested with a character who was not a member of that corporation or alliance, showing another organisation's data or failing outright. These pages now always use a character who actually belongs to the organisation you are viewing, and report that no access is available when none of your logged-in characters do.

--- a/packages/hooks/src/hooks/auth/useAccessToken.ts
+++ b/packages/hooks/src/hooks/auth/useAccessToken.ts
@@ -14,6 +14,24 @@ const TOKEN_UNAVAILABLE = {
   authHeaders: {},
 };
 
+/**
+ * Pick a logged-in character whose token can authorise an ESI request.
+ *
+ * `characterId`, `corporationId` and `allianceId` narrow *which* character is
+ * eligible: corporation- and alliance-scoped ESI routes are still authenticated
+ * with a character token, so the caller has to end up with a character that
+ * actually belongs to the corporation/alliance being queried. Every character
+ * that clears the filters is equally able to authorise the request, so the
+ * first one wins.
+ *
+ * `roles` is accepted but not yet enforced: CharacterSsoSession.corporationRoles
+ * is initialised empty and never populated (useAuthStore still has to fetch and
+ * refresh them), so filtering on it would leave every role-gated endpoint with
+ * no token at all.
+ * Call sites still declare the roles they need, so the check can be switched on
+ * here in one place once roles are actually fetched. ESI enforces them
+ * server-side in the meantime.
+ */
 export const useAccessToken = (options: {
   characterId?: number;
   corporationId?: number;
@@ -25,14 +43,16 @@ export const useAccessToken = (options: {
   accessToken: string | null;
   authHeaders: Record<string, string>;
 } => {
-  const { characterId, scopes } = options;
-  // TODO: Filter by corporationId, allianceId, roles
+  const { characterId, corporationId, allianceId, scopes } = options;
 
   const characters = useAuthStore(
     useShallow((state) =>
       Object.values(state.characters).filter(
         (character) =>
           (characterId == undefined || character.characterId == characterId) &&
+          (corporationId == undefined ||
+            character.corporationId == corporationId) &&
+          (allianceId == undefined || character.allianceId == allianceId) &&
           (scopes ?? []).every((requiredScope) =>
             character.accessTokenPayload.scp.includes(requiredScope),
           ),

--- a/packages/hooks/tests/useAccessToken.test.ts
+++ b/packages/hooks/tests/useAccessToken.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { renderHook } from "@testing-library/react";
+
+import type { ESIScope } from "@jitaspace/esi-metadata";
+
+import type { CharacterSsoSession } from "../src/hooks/auth/useAuthStore";
+
+// @swc/jest does not hoist jest.mock above imports, so the hook and the store it
+// pulls in are required lazily below, after these mocks are registered. The
+// generated ESI client is replaced so axios never loads in the test environment.
+jest.mock("@jitaspace/auth-utils", () => ({
+  __esModule: true,
+  getEveSsoAccessTokenPayload: jest.fn(),
+}));
+jest.mock("@jitaspace/esi-client", () => ({
+  __esModule: true,
+  postCharactersAffiliation: jest.fn(),
+}));
+
+const { useAuthStore } =
+  require("../src/hooks/auth/useAuthStore") as typeof import("../src/hooks/auth/useAuthStore");
+const { useAccessToken } =
+  require("../src/hooks/auth/useAccessToken") as typeof import("../src/hooks/auth/useAccessToken");
+
+const MAIL_SCOPE = "esi-mail.read_mail.v1";
+const CORP_ASSETS_SCOPE = "esi-assets.read_corporation_assets.v1";
+const ALLIANCE_CONTACTS_SCOPE = "esi-alliances.read_contacts.v1";
+
+const character = ({
+  characterId,
+  scopes = [],
+  ...session
+}: { characterId: number; scopes?: ESIScope[] } & Partial<
+  Omit<CharacterSsoSession, "accessTokenPayload">
+>): CharacterSsoSession => ({
+  accessToken: `token-${characterId}`,
+  accessTokenExpirationDate: new Date(0).toString(),
+  refreshToken: `refresh-${characterId}`,
+  characterId,
+  corporationId: 0,
+  corporationRoles: [],
+  ...session,
+  accessTokenPayload: {
+    scp: scopes,
+    sub: `CHARACTER:EVE:${characterId}`,
+    name: `Character ${characterId}`,
+    jti: "",
+    kid: "",
+    azp: "",
+    tenant: "",
+    tier: "",
+    region: "",
+    aud: "",
+    owner: "",
+    exp: 0,
+    iat: 0,
+    iss: "",
+  },
+});
+
+const login = (...sessions: CharacterSsoSession[]) =>
+  useAuthStore.setState({
+    characters: Object.fromEntries(sessions.map((s) => [s.characterId, s])),
+    selectedCharacter: sessions[0]?.characterId ?? null,
+  });
+
+beforeEach(() => {
+  useAuthStore.setState({ characters: {}, selectedCharacter: null });
+});
+
+describe("useAccessToken — character filter", () => {
+  it("returns the requested character's token", () => {
+    login(character({ characterId: 100 }), character({ characterId: 101 }));
+
+    const { result } = renderHook(() => useAccessToken({ characterId: 101 }));
+
+    expect(result.current.accessToken).toBe("token-101");
+    expect(result.current.authHeaders).toEqual({
+      Authorization: "Bearer token-101",
+    });
+  });
+
+  it("returns no token when the character lacks the required scope", () => {
+    login(character({ characterId: 100 }));
+
+    const { result } = renderHook(() =>
+      useAccessToken({ characterId: 100, scopes: [MAIL_SCOPE] }),
+    );
+
+    expect(result.current.character).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+    expect(result.current.authHeaders).toEqual({});
+  });
+});
+
+describe("useAccessToken — corporation filter", () => {
+  it("picks a character that belongs to the requested corporation", () => {
+    // Both characters hold the scope; only 101 is in corporation 2000. Before
+    // corporationId was honoured this returned 100's token — another
+    // corporation's data, or a 403.
+    login(
+      character({
+        characterId: 100,
+        corporationId: 1000,
+        scopes: [CORP_ASSETS_SCOPE],
+      }),
+      character({
+        characterId: 101,
+        corporationId: 2000,
+        scopes: [CORP_ASSETS_SCOPE],
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useAccessToken({ corporationId: 2000, scopes: [CORP_ASSETS_SCOPE] }),
+    );
+
+    expect(result.current.character?.characterId).toBe(101);
+    expect(result.current.accessToken).toBe("token-101");
+  });
+
+  it("returns no token when no logged-in character is in the corporation", () => {
+    login(
+      character({
+        characterId: 100,
+        corporationId: 1000,
+        scopes: [CORP_ASSETS_SCOPE],
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useAccessToken({ corporationId: 2000, scopes: [CORP_ASSETS_SCOPE] }),
+    );
+
+    expect(result.current.accessToken).toBeNull();
+  });
+});
+
+describe("useAccessToken — alliance filter", () => {
+  it("picks a character that belongs to the requested alliance", () => {
+    login(
+      character({
+        characterId: 100,
+        allianceId: 500,
+        scopes: [ALLIANCE_CONTACTS_SCOPE],
+      }),
+      character({
+        characterId: 101,
+        allianceId: 600,
+        scopes: [ALLIANCE_CONTACTS_SCOPE],
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useAccessToken({ allianceId: 600, scopes: [ALLIANCE_CONTACTS_SCOPE] }),
+    );
+
+    expect(result.current.character?.characterId).toBe(101);
+  });
+
+  it("excludes characters that are in no alliance", () => {
+    login(character({ characterId: 100, scopes: [ALLIANCE_CONTACTS_SCOPE] }));
+
+    const { result } = renderHook(() =>
+      useAccessToken({ allianceId: 600, scopes: [ALLIANCE_CONTACTS_SCOPE] }),
+    );
+
+    expect(result.current.accessToken).toBeNull();
+  });
+});
+
+describe("useAccessToken — roles", () => {
+  it("does not yet exclude characters lacking the required roles", () => {
+    // corporationRoles is initialised empty and never populated, so enforcing
+    // `roles` here would leave every role-gated endpoint (corporation assets
+    // asks for Director) with no token at all. This pins that deliberate gap:
+    // turning roles into a filter means populating corporationRoles first.
+    login(
+      character({
+        characterId: 100,
+        corporationId: 1000,
+        corporationRoles: [],
+        scopes: [CORP_ASSETS_SCOPE],
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useAccessToken({
+        corporationId: 1000,
+        scopes: [CORP_ASSETS_SCOPE],
+        roles: ["Director"],
+      }),
+    );
+
+    expect(result.current.accessToken).toBe("token-100");
+  });
+});


### PR DESCRIPTION
## Problem

`useAccessToken` accepts `corporationId`, `allianceId` and `roles`, but destructured only `characterId` and `scopes` — there was a `// TODO: Filter by corporationId, allianceId, roles` sitting right above it.

Corporation- and alliance-scoped ESI routes are still authenticated with a *character* token, so the three call sites that pass those options were silently getting back the first logged-in character holding the required scope — regardless of whether that character was actually a member of the organisation being queried:

- `useCorporationAssets` (also asks for `roles: ["Director"]`)
- `useCorporationContacts`
- `useAllianceContacts`

With one authed character this is invisible. With several, it means another corporation's data or a 403.

## Change

`corporationId` and `allianceId` are now real filters, backed by the affiliation data already stored on `CharacterSsoSession`. Every character that clears the filters can authorise the request equally well, so the first match is used — the diff is two extra predicates in the existing filter.

`roles` stays accepted but unenforced, now documented in a JSDoc block rather than silently dropped. `corporationRoles` is initialised to `[]` in `addCharacter` and never populated (there is a standing `// TODO: Update corporation roles hourly` in `useAuthStore`, unchanged since the multi-character session module landed in Dec 2023), so filtering on it would leave every role-gated endpoint with no token at all. Call sites keep declaring the roles they need, so the check can be switched on in one place once roles are actually fetched. ESI enforces them server-side meanwhile.

The `useShallow` selector still returns store-owned objects only, so snapshot identity stays stable (see `zustandSelectorStability.test.tsx`).

## User-visible effect

Where none of your logged-in characters belong to the organisation being viewed, these pages now report that no access is available instead of showing another organisation's data. That is the intended outcome, but two edge cases are worth flagging, both rooted in affiliation being fetched **once** in `addCharacter` and never refreshed:

- If `postCharactersAffiliation` failed at login, `corporationId` stays `0` and that character matches no corporation until re-authentication.
- A character who changes corporation keeps a stale `corporationId`, so they stop matching their real corporation until re-authentication.

Previously both cases would have used the token anyway — wrongly — so this is still a net correctness improvement, but the failure mode changes from "wrong data" to "no data". `CharacterSsoSession` already carries the vestiges of the intended fix: `corporationRolesExpireOn` is declared but never read or written, and `addCharacter` writes an `affiliationExpirationDate` that is not declared on the interface and never read.

## Testing

New `packages/hooks/tests/useAccessToken.test.ts` — 7 cases covering the character, corporation and alliance filters, plus one pinning the deliberate roles gap so that turning `roles` into a filter forces a conscious decision about populating `corporationRoles` first.

- `packages/hooks`: 43 tests pass, 100% coverage of `useAccessToken.ts`
- `apps/web`: 1015 tests pass, no regressions
- `pnpm type-check`, `pnpm lint` (26/26 tasks) and `manypkg check` clean

## Follow-up

This is step 1 of generalising per-subject ESI hooks (`useMultipleXXX` over characters/corporations/alliances), which needs correct subject→token resolution as its foundation. Populating `corporationRoles` — and refreshing affiliation — are separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)