### PR TITLE
fix(market): reserve order table height while orders load

### DIFF
--- a/.changeset/market-orders-layout-shift.md
+++ b/.changeset/market-orders-layout-shift.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/hooks": patch
+"@jitaspace/web": patch
+---
+
+Fixed the market page jumping around while it loads. The buy and sell order tables now hold their full height from the start and fill in once, instead of growing a row at a time as each region's orders arrived and pushing the rest of the page down. Switching between items also no longer briefly shows the previous item's orders, and a region that fails to respond no longer silently drops the orders that did load.

--- a/apps/web/app/market/page.client.tsx
+++ b/apps/web/app/market/page.client.tsx
@@ -45,7 +45,7 @@ export default function Page() {
     }
   }, [typeId]);
 
-  const { data } = useTypeMarketOrders(typeId);
+  const { data, isLoading } = useTypeMarketOrders(typeId);
 
   const mergedRegionalOrders = useMemo(() => {
     return Object.values(data).flat();
@@ -84,11 +84,13 @@ export default function Page() {
                 <MarketOrdersDataTable
                   orders={sellOrders}
                   sortPriceDescending={false}
+                  isLoading={isLoading}
                 />
                 <Title order={3}>Buy Orders</Title>
                 <MarketOrdersDataTable
                   orders={buyOrders}
                   sortPriceDescending={true}
+                  isLoading={isLoading}
                 />
               </Stack>
             )}

--- a/apps/web/components/Market/MarketOrdersDataTable.tsx
+++ b/apps/web/components/Market/MarketOrdersDataTable.tsx
@@ -13,10 +13,21 @@ import { SolarSystemSecurityStatusBadge } from "~/components/Badge";
 interface MarketOrdersDataTableProps {
   orders: RegionalMarketOrder[];
   sortPriceDescending: boolean;
+  /**
+   * While loading, and only for as long as `orders` is still empty, the table
+   * renders a full page of skeleton rows instead of collapsing to nothing. That
+   * keeps it at its final height from the first paint, so the orders arriving
+   * later don't push the rest of the page down.
+   */
+  isLoading?: boolean;
 }
 
 export const MarketOrdersDataTable = memo(
-  ({ orders, sortPriceDescending }: MarketOrdersDataTableProps) => {
+  ({
+    orders,
+    sortPriceDescending,
+    isLoading = false,
+  }: MarketOrdersDataTableProps) => {
     const columns = useMemo<MRT_ColumnDef<RegionalMarketOrder>[]>(
       () => [
         {
@@ -145,6 +156,7 @@ export const MarketOrdersDataTable = memo(
       positionPagination: "top",
       enableFacetedValues: true,
       data: orders,
+      state: { isLoading },
       initialState: {
         density: "xs",
         pagination: {

--- a/apps/web/tests/marketPageClient.test.tsx
+++ b/apps/web/tests/marketPageClient.test.tsx
@@ -36,17 +36,20 @@ jest.mock("@jitaspace/ui", () => ({
   ),
 }));
 
-// The data table echoes the orders it receives + its sort direction so we can
-// confirm the page split buy vs sell orders correctly.
+// The data table echoes the orders it receives, its sort direction and whether
+// it was told to show its loading state, so we can confirm the page split buy vs
+// sell orders correctly and reserved the tables' height while they load.
 jest.mock("~/components/Market", () => ({
   MarketOrdersDataTable: ({
     orders,
     sortPriceDescending,
+    isLoading,
   }: {
     orders?: { order_id: number }[];
     sortPriceDescending?: boolean;
+    isLoading?: boolean;
   }) => (
-    <div data-testid="orders-table">
+    <div data-testid="orders-table" data-loading={String(isLoading ?? false)}>
       {`orders:${orders?.length ?? 0} desc:${String(sortPriceDescending)}`}
     </div>
   ),
@@ -78,7 +81,10 @@ describe("Market page (client)", () => {
   beforeEach(() => {
     mockPathname = "/market/34";
     mockUseTypeMarketOrders.mockReset();
-    mockUseTypeMarketOrders.mockReturnValue({ data: ORDERS_BY_REGION });
+    mockUseTypeMarketOrders.mockReturnValue({
+      data: ORDERS_BY_REGION,
+      isLoading: false,
+    });
   });
 
   it("renders the type header and splits regional orders into sell + buy tables", () => {
@@ -99,9 +105,23 @@ describe("Market page (client)", () => {
     expect(screen.getByText("orders:2 desc:true")).toBeInTheDocument();
   });
 
+  it("puts both order tables in their loading state while orders are still arriving", () => {
+    mockUseTypeMarketOrders.mockReturnValue({ data: {}, isLoading: true });
+
+    renderPage();
+
+    // Both tables must reserve their height up front — the buy table sits below
+    // the sell table, so a sell table that grows on arrival pushes it down.
+    const tables = screen.getAllByTestId("orders-table");
+    expect(tables).toHaveLength(2);
+    for (const table of tables) {
+      expect(table).toHaveAttribute("data-loading", "true");
+    }
+  });
+
   it("renders only the header shell when the path has no numeric typeId", () => {
     mockPathname = "/market";
-    mockUseTypeMarketOrders.mockReturnValue({ data: {} });
+    mockUseTypeMarketOrders.mockReturnValue({ data: {}, isLoading: false });
 
     renderPage();
 

--- a/packages/hooks/src/hooks/useTypeMarketOrders.ts
+++ b/packages/hooks/src/hooks/useTypeMarketOrders.ts
@@ -24,53 +24,133 @@ const MARKET_HUB_REGION_IDS = [
   10000042, // Metropolis (Hek)
 ];
 
-/** Hub regions first (in hub order), then every other region. */
-function prioritizeMarketHubs(regionIds: number[]): number[] {
-  const hubs = MARKET_HUB_REGION_IDS.filter((id) => regionIds.includes(id));
-  const rest = regionIds.filter((id) => !MARKET_HUB_REGION_IDS.includes(id));
-  return [...hubs, ...rest];
+type RegionOrders = Record<number, GetMarketsRegionIdOrdersQueryResponse>;
+
+/** Stable empty result, so consumers memoising on `data` don't rerun while idle. */
+const NO_ORDERS: RegionOrders = {};
+
+/** Hub regions (in hub order), separated from every other region. */
+function splitMarketHubs(regionIds: number[]): {
+  hubs: number[];
+  rest: number[];
+} {
+  return {
+    hubs: MARKET_HUB_REGION_IDS.filter((id) => regionIds.includes(id)),
+    rest: regionIds.filter((id) => !MARKET_HUB_REGION_IDS.includes(id)),
+  };
+}
+
+/** Every page of orders for one type in one region. */
+async function fetchRegionOrders(
+  regionId: number,
+  typeId: number,
+): Promise<GetMarketsRegionIdOrdersQueryResponse> {
+  const firstPage = await getMarketsRegionIdOrders(regionId, {
+    page: 1,
+    type_id: typeId,
+    order_type: "all",
+  });
+  const orders = firstPage.data;
+  const xPages: unknown = firstPage.headers["x-pages"];
+  const numPages = typeof xPages === "string" ? Number(xPages) : 0;
+  for (let page = 2; page <= numPages; page++) {
+    const pageResults = await getMarketsRegionIdOrders(regionId, {
+      page,
+      type_id: typeId,
+      order_type: "all",
+    });
+    orders.push(...pageResults.data);
+  }
+  return orders;
+}
+
+/**
+ * Requests a whole batch of regions in parallel, resolving once every one has
+ * settled so the caller can commit them in a single state update. A region that
+ * fails (ESI 5xx, timeout) is left out instead of rejecting the whole batch.
+ */
+async function fetchRegionsOrders(
+  regionIds: number[],
+  typeId: number,
+): Promise<RegionOrders> {
+  const results = await Promise.allSettled(
+    regionIds.map((regionId) => fetchRegionOrders(regionId, typeId)),
+  );
+
+  const orders: RegionOrders = {};
+  results.forEach((result, index) => {
+    const regionId = regionIds[index];
+    if (regionId !== undefined && result.status === "fulfilled") {
+      orders[regionId] = result.value;
+    }
+  });
+  return orders;
+}
+
+interface MarketOrdersState {
+  /** The type `orders` belong to; `undefined` before the first commit. */
+  typeId?: number;
+  /** Whether the hub batch has been committed for `typeId`. */
+  hubsLoaded: boolean;
+  orders: RegionOrders;
 }
 
 export function useTypeMarketOrders(typeId?: number) {
-  const [regionOrders, setRegionOrders] = useState<
-    Record<number, GetMarketsRegionIdOrdersQueryResponse>
-  >([]);
+  const [state, setState] = useState<MarketOrdersState>({
+    hubsLoaded: false,
+    orders: NO_ORDERS,
+  });
   const { data: regions } = useGetUniverseRegions(
     {},
     { query: { enabled: typeId !== undefined } },
   );
+  const regionIds = regions?.data;
 
   useEffect(() => {
     // if no type is selected, there are no orders!
-    if (!typeId) {
-      setRegionOrders({});
-      return;
-    }
+    if (typeId === undefined || regionIds === undefined) return;
 
-    const loadMarketOrdersFromRegion = async (regionId: number) => {
-      const firstPage = await getMarketsRegionIdOrders(regionId, {
-        page: 1,
-        type_id: typeId,
-        order_type: "all",
+    // Read through a function: TypeScript narrows a directly-referenced flag to
+    // `false` and keeps that narrowing across the awaits below, which makes the
+    // cancellation checks look statically dead.
+    let cancelled = false;
+    const isCancelled = () => cancelled;
+    const { hubs, rest } = splitMarketHubs(regionIds);
+
+    // Orders are committed in two batches — the hubs, then the long tail —
+    // rather than one state update per region as it lands. The order tables page
+    // at 20 rows, so per-region commits used to grow them a few rows at a time,
+    // and every one of those steps shifted everything below the table down. That
+    // was the bulk of the market page's Cumulative Layout Shift.
+    void (async () => {
+      const hubOrders = await fetchRegionsOrders(hubs, typeId);
+      if (isCancelled()) return;
+      setState({ typeId, hubsLoaded: true, orders: hubOrders });
+
+      const restOrders = await fetchRegionsOrders(rest, typeId);
+      if (isCancelled()) return;
+      setState({
+        typeId,
+        hubsLoaded: true,
+        orders: { ...hubOrders, ...restOrders },
       });
-      const orders = firstPage.data;
-      const xPages: unknown = firstPage.headers["x-pages"];
-      const numPages = typeof xPages === "string" ? Number(xPages) : 0;
-      for (let page = 2; page <= numPages; page++) {
-        const pageResults = await getMarketsRegionIdOrders(regionId, {
-          page,
-          type_id: typeId,
-          order_type: "all",
-        });
-        orders.push(...pageResults.data);
-      }
-      setRegionOrders((prev) => ({ ...prev, [regionId]: orders }));
+    })();
+
+    // Requests already in flight can't be recalled, but their results must not
+    // land in the next type's order tables.
+    return () => {
+      cancelled = true;
     };
+  }, [typeId, regionIds]);
 
-    prioritizeMarketHubs(regions?.data ?? []).forEach((regionId) => {
-      void loadMarketOrdersFromRegion(regionId);
-    });
-  }, [typeId, regions, setRegionOrders]);
+  // Both values are derived rather than stored, so the very first render after
+  // `typeId` changes already reports "loading" with no orders. A flag flipped
+  // inside the effect would render one frame of empty-but-not-loading table
+  // first, and the skeleton replacing it would be its own layout shift.
+  const isCurrent = state.typeId === typeId;
 
-  return { data: regionOrders };
+  return {
+    data: isCurrent ? state.orders : NO_ORDERS,
+    isLoading: typeId !== undefined && !(isCurrent && state.hubsLoaded),
+  };
 }

--- a/packages/hooks/tests/useTypeMarketOrders.test.ts
+++ b/packages/hooks/tests/useTypeMarketOrders.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 
 import type * as UseTypeMarketOrdersModule from "../src/hooks/useTypeMarketOrders";
 
@@ -38,6 +38,8 @@ const HEIMATAR = 10000030;
 const FILLER_A = 10000069;
 const FILLER_B = 10000001;
 const UNSORTED_REGIONS = [FILLER_A, DOMAIN, FILLER_B, THE_FORGE, HEIMATAR];
+/** The hubs present in UNSORTED_REGIONS, in the order the hook requests them. */
+const HUBS = [THE_FORGE, DOMAIN, HEIMATAR];
 
 describe("useTypeMarketOrders", () => {
   beforeEach(() => {
@@ -88,5 +90,135 @@ describe("useTypeMarketOrders", () => {
     renderHook(() => useTypeMarketOrders(34));
 
     expect(getMarketsRegionIdOrders).not.toHaveBeenCalled();
+  });
+
+  it("reports loading from the very first render until the hub orders land", async () => {
+    useGetUniverseRegions.mockReturnValue({ data: { data: UNSORTED_REGIONS } });
+
+    // Hold every region request open, so the assertions below cannot race a
+    // batch that already resolved.
+    let releaseOrders = (): void => undefined;
+    const held = new Promise<void>((resolve) => {
+      releaseOrders = resolve;
+    });
+    getMarketsRegionIdOrders.mockImplementation(() =>
+      held.then(() => ({ data: [], headers: { "x-pages": "1" } })),
+    );
+
+    const { result } = renderHook(() => useTypeMarketOrders(34));
+
+    // Loading on the first render, before any orders can arrive. The order
+    // tables rely on this to reserve their height instead of rendering empty.
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toEqual({});
+
+    await act(async () => {
+      releaseOrders();
+      await held;
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it("is never loading when no type is selected", () => {
+    useGetUniverseRegions.mockReturnValue({ data: { data: UNSORTED_REGIONS } });
+
+    const { result } = renderHook(() => useTypeMarketOrders(undefined));
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("commits orders in whole batches rather than once per region", async () => {
+    useGetUniverseRegions.mockReturnValue({ data: { data: UNSORTED_REGIONS } });
+
+    // Hold the long-tail regions so the hub batch is observed on its own;
+    // otherwise both batches settle together and React coalesces the renders.
+    let releaseTail = (): void => undefined;
+    const heldTail = new Promise<void>((resolve) => {
+      releaseTail = resolve;
+    });
+    getMarketsRegionIdOrders.mockImplementation((regionId) => {
+      const response = {
+        data: [{ order_id: regionId }],
+        headers: { "x-pages": "1" },
+      };
+      return HUBS.includes(regionId)
+        ? Promise.resolve(response)
+        : heldTail.then(() => response);
+    });
+
+    const seenOrderCounts: number[] = [];
+    const { result } = renderHook(() => {
+      const value = useTypeMarketOrders(34);
+      seenOrderCounts.push(Object.keys(value.data).length);
+      return value;
+    });
+
+    await waitFor(() =>
+      expect(Object.keys(result.current.data)).toHaveLength(HUBS.length),
+    );
+    await act(async () => {
+      releaseTail();
+      await heldTail;
+    });
+    await waitFor(() =>
+      expect(Object.keys(result.current.data)).toHaveLength(
+        UNSORTED_REGIONS.length,
+      ),
+    );
+
+    // The tables only ever see no regions, the 3 hubs, or all 5 — never a
+    // partially-filled batch. Growing them one region at a time is what shifted
+    // everything below the table down the page.
+    const batchSizes = [0, HUBS.length, UNSORTED_REGIONS.length];
+    expect(
+      seenOrderCounts.filter((count) => !batchSizes.includes(count)),
+    ).toEqual([]);
+    expect(seenOrderCounts).toContain(HUBS.length);
+  });
+
+  it("drops regions that fail without losing the rest of the batch", async () => {
+    useGetUniverseRegions.mockReturnValue({ data: { data: UNSORTED_REGIONS } });
+    getMarketsRegionIdOrders.mockImplementation((regionId) =>
+      regionId === DOMAIN
+        ? Promise.reject(new Error("ESI is having a moment"))
+        : Promise.resolve({
+            data: [{ order_id: regionId }],
+            headers: { "x-pages": "1" },
+          }),
+    );
+
+    const { result } = renderHook(() => useTypeMarketOrders(34));
+
+    await waitFor(() =>
+      expect(Object.keys(result.current.data)).toHaveLength(
+        UNSORTED_REGIONS.length - 1,
+      ),
+    );
+    expect(result.current.data[DOMAIN]).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not show one type's orders while the next type is loading", async () => {
+    useGetUniverseRegions.mockReturnValue({ data: { data: UNSORTED_REGIONS } });
+    getMarketsRegionIdOrders.mockImplementation((regionId) =>
+      Promise.resolve({
+        data: [{ order_id: regionId }],
+        headers: { "x-pages": "1" },
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ typeId }: { typeId: number }) => useTypeMarketOrders(typeId),
+      { initialProps: { typeId: 34 } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    rerender({ typeId: 35 });
+
+    // Switching type immediately clears the previous type's orders, so the table
+    // shows skeletons rather than stale rows that would resize on arrival.
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toEqual({});
   });
 });


### PR DESCRIPTION
## Why

Sentry reports **p75 CLS 0.138 on `/market/*`** over 358 pageloads (last 14d) — the worst high-traffic route on the site, and into "needs improvement" territory. The control case is decisive: `/market` (the *same* page component, just with no type selected) sits at **0.0007** across 119 pageloads.

The `cls.source.*` attributes name the culprit directly:

| CLS source element | Pageloads | p75 CLS |
| --- | --- | --- |
| `tr…MRT_TableBodyRow` | 213 | 0.143 |
| *(no source recorded)* | 95 | 0.220 |
| `div…mantine-Group-root.mantine-visible-from-sm` | 48 | 0.001 |
| `div.mrt-bottom-toolbar` | 47 | 0.075 |

On the worst samples (0.54, 0.51, 0.46) all three shift sources are `MRT_TableBodyRow`.

## What changed

Two causes, and both had to be fixed — either alone is insufficient.

**Orders now commit in two batches instead of ~100** — [`useTypeMarketOrders`](packages/hooks/src/hooks/useTypeMarketOrders.ts) fired one `setState` per region as each landed. The tables page at 20 rows, so the body grew a few rows at a time and every step pushed everything below it down. It now resolves the trade hubs together, commits, then does the same for the long tail. The existing hubs-first LCP optimisation is preserved.

**The tables reserve their height** — [`MarketOrdersDataTable`](apps/web/components/Market/MarketOrdersDataTable.tsx) takes `isLoading` and passes it to MRT, which fills the body with a full page of skeleton rows. Verified against MRT's source: it generates `Math.min(pageSize, 20)` blank rows, and `pageSize` here is 20, so the reserved height matches a full page exactly.

Why both are needed: MRT only generates skeleton rows **while `data` is empty** (`(isLoading || showSkeletons) && !data.length`). Without batching, the first region to land would collapse the skeletons and restart the 0→20 ramp.

`isLoading` is derived from committed state rather than stored in a separate flag, so the first render after `typeId` changes already reports loading. A flag flipped inside the effect would render one frame of empty-but-not-loading table, and the skeleton replacing it would be its own layout shift.

Both tables get it: the buy table sits below the sell table, so a growing sell table displaces it.

## Drive-by fixes

Restructuring the fetch surfaced two real bugs, fixed here:

- Switching items no longer briefly shows the previous item's orders — in-flight requests for the old type used to merge into the new type's map.
- A failing region no longer causes an unhandled promise rejection that discards the regions that *did* load (`Promise.allSettled`).

## Reviewer notes

**Scope — what this does not fix.** One shift remains: at hydration the whole type block appears at once, pushing the footer down. That one is structural. [`next.config.mjs:185`](apps/web/next.config.mjs) rewrites every `/market/:typeId` to a single static `/market` shell, so the server cannot know whether to reserve that space, and reserving it unconditionally would regress the `/market` index (currently ~0 CLS). Fixing it properly means server-rendering the route, which would undo a deliberate architecture decision — worth a separate discussion if the numbers don't land where we want.

Also note the 95 pageloads at p75 0.220 with **no** `cls.source` recorded — I can't attribute those, so I can't say whether they share this cause.

**Not verified in a browser.** The dev server boots but the client-side env validation throws and the React app dies with "Application error" — my worktree has no `.env`. I confirmed this is pre-existing by stashing the changes and reloading: unmodified `main` crashes identically. With a real `.env` this is a one-reload check, and worth doing before merge.

## Testing

- `packages/hooks` — 8 tests pass, covering batch commits (never a partially-filled batch), loading on the first render, region failures, and type switching.
- `apps/web` — 31 tests pass, including a new assertion that both tables receive the loading state.
- ESLint: 0 errors across `@jitaspace/hooks` and `@jitaspace/web`. `tsc --noEmit` clean.

Note: `pnpm kubb:generate` was needed locally — some pre-existing lint/type errors in untouched files (e.g. `MarketGroupsNavigation.tsx`) were purely missing codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)