### PR TITLE
feat(web): show fittings from every logged-in character

### DIFF
--- a/.changeset/fittings-page-all-characters.md
+++ b/.changeset/fittings-page-all-characters.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": minor
+---
+
+The Fittings page now lists saved fittings from every logged-in character at once, instead of only the currently selected one. A new "Filter by character" dropdown sits next to the ship type filter so you can narrow the list back down to a single character, and each fitting still opens with its own character's data.

--- a/.changeset/fittings-page-all-characters.md
+++ b/.changeset/fittings-page-all-characters.md
@@ -2,4 +2,4 @@
 "@jitaspace/web": minor
 ---
 
-The Fittings page now lists saved fittings from every logged-in character at once, instead of only the currently selected one. A new "Filter by character" dropdown sits next to the ship type filter so you can narrow the list back down to a single character, and each fitting still opens with its own character's data.
+The Fittings page now lists saved fittings from every logged-in character at once, instead of only the currently selected one. A new "Filter by character" dropdown sits next to the ship type filter so you can narrow the list back down to a single character, and each fitting still opens with its own character's data. If a character's session can't be loaded, the page now says so instead of quietly leaving them out of a list that claims to show everyone's.

--- a/apps/web/app/fittings/page.tsx
+++ b/apps/web/app/fittings/page.tsx
@@ -35,7 +35,7 @@ export default function Page() {
   // Every logged-in character that granted the fittings scope, not just the
   // selected one. Each fitting carries the character it belongs to as
   // `subjectId`.
-  const { data: fittings } = useMultipleCharacterFittings();
+  const { data: fittings, errors } = useMultipleCharacterFittings();
 
   const shipTypeIds = useMemo(
     () => [...new Set(fittings.map((fitting) => fitting.ship_type_id))],
@@ -110,6 +110,15 @@ export default function Page() {
             </Text>
           )}
           <Title order={4}>Saved Fittings</Title>
+          {errors.length > 0 && (
+            // Without this a character whose token failed is simply missing
+            // from a list that claims to show everyone's, with nothing to
+            // distinguish "no fittings" from "could not be loaded".
+            <Text c="dimmed" size="sm">
+              Could not load fittings for {errors.length}{" "}
+              {errors.length === 1 ? "character" : "characters"}.
+            </Text>
+          )}
           <Group>
             <EveEntitySelect
               size="xs"

--- a/apps/web/app/fittings/page.tsx
+++ b/apps/web/app/fittings/page.tsx
@@ -15,7 +15,10 @@ import posthog from "posthog-js";
 import type { ESIScope } from "@jitaspace/esi-metadata";
 import { EveEntitySelect } from "@jitaspace/eve-components";
 import { FittingIcon } from "@jitaspace/eve-icons";
-import { useCharacterFittings, useSelectedCharacter } from "@jitaspace/hooks";
+import {
+  useMultipleCharacterFittings,
+  useSelectedCharacter,
+} from "@jitaspace/hooks";
 
 import {
   EsiCharacterShipFittingCard,
@@ -25,22 +28,35 @@ import { ScopeGuard } from "~/components/ScopeGuard";
 
 export default function Page() {
   const [selectedShipType, setSelectedShipType] = useState<string | null>(null);
+  const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(
+    null,
+  );
   const character = useSelectedCharacter();
-  const { data } = useCharacterFittings(character?.characterId);
+  // Every logged-in character that granted the fittings scope, not just the
+  // selected one. Each fitting carries the character it belongs to as
+  // `subjectId`.
+  const { data: fittings } = useMultipleCharacterFittings();
 
   const shipTypeIds = useMemo(
-    () => [...new Set(data?.data.map((fitting) => fitting.ship_type_id) ?? [])],
-    [data?.data],
+    () => [...new Set(fittings.map((fitting) => fitting.ship_type_id))],
+    [fittings],
+  );
+
+  const characterIds = useMemo(
+    () => [...new Set(fittings.map((fitting) => fitting.subjectId))],
+    [fittings],
   );
 
   const filteredFittings = useMemo(
     () =>
-      data?.data.filter(
+      fittings.filter(
         (fit) =>
-          selectedShipType === null ||
-          fit.ship_type_id === Number.parseInt(selectedShipType, 10),
-      ) ?? [],
-    [data?.data, selectedShipType],
+          (selectedShipType === null ||
+            fit.ship_type_id === Number.parseInt(selectedShipType, 10)) &&
+          (selectedCharacterId === null ||
+            fit.subjectId === Number.parseInt(selectedCharacterId, 10)),
+      ),
+    [fittings, selectedShipType, selectedCharacterId],
   );
 
   const requiredScopesForCurrentFit: ESIScope[] = [
@@ -107,16 +123,31 @@ export default function Page() {
               value={selectedShipType}
               onChange={setSelectedShipType}
             />
+            <EveEntitySelect
+              size="xs"
+              label="Filter by character"
+              entityIds={characterIds.map((id) => ({
+                id,
+              }))}
+              searchable
+              allowDeselect
+              clearable
+              value={selectedCharacterId}
+              onChange={setSelectedCharacterId}
+            />
           </Group>
           <Stack gap="xs">
             {filteredFittings.map((fit) => (
               <UnstyledButton
-                key={fit.fitting_id}
+                // fitting_id is only unique within a character, so two
+                // characters can hold the same id.
+                key={`${fit.subjectId}-${fit.fitting_id}`}
                 onClick={() => {
                   posthog.capture("fitting_viewed", {
                     fitting_id: fit.fitting_id,
                     ship_type_id: fit.ship_type_id,
                     fitting_name: fit.name,
+                    character_id: fit.subjectId,
                   });
                   openContextModal({
                     modal: "fitting",
@@ -141,13 +172,11 @@ export default function Page() {
                   });
                 }}
               >
-                {character && (
-                  <EsiCharacterShipFittingCard
-                    characterId={character.characterId}
-                    fittingId={fit.fitting_id}
-                    hideModules
-                  />
-                )}
+                <EsiCharacterShipFittingCard
+                  characterId={fit.subjectId}
+                  fittingId={fit.fitting_id}
+                  hideModules
+                />
               </UnstyledButton>
             ))}
           </Stack>

--- a/apps/web/tests/fittingsPage.test.tsx
+++ b/apps/web/tests/fittingsPage.test.tsx
@@ -99,7 +99,10 @@ describe("Fittings page", () => {
     mockUseSelectedCharacter.mockReset().mockReturnValue(CHARACTER);
     mockUseMultipleCharacterFittings
       .mockReset()
-      .mockReturnValue({ data: [FITTING, OTHER_CHARACTER_FITTING] });
+      .mockReturnValue({
+        data: [FITTING, OTHER_CHARACTER_FITTING],
+        errors: [],
+      });
   });
 
   it("captures current_ship_fitting_viewed and opens the modal", () => {
@@ -165,6 +168,43 @@ describe("Fittings page", () => {
     fireEvent.click(screen.getByTestId("option:Filter by ship type:597"));
 
     expect(screen.getAllByTestId("saved-fit-card")).toHaveLength(1);
+  });
+
+  it("says how many characters failed rather than silently omitting them", () => {
+    // A failed token drops that character's fittings from a list that claims to
+    // show everyone's, so the absence has to be visible.
+    mockUseMultipleCharacterFittings.mockReturnValue({
+      data: [FITTING],
+      errors: [{ subjectId: 90000002, error: new Error("boom") }],
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByText(/could not load fittings for 1 character\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("pluralises when several characters failed", () => {
+    mockUseMultipleCharacterFittings.mockReturnValue({
+      data: [],
+      errors: [
+        { subjectId: 90000001, error: new Error("boom") },
+        { subjectId: 90000002, error: new Error("boom") },
+      ],
+    });
+
+    renderPage();
+
+    expect(
+      screen.getByText(/could not load fittings for 2 characters\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("says nothing when every character loaded", () => {
+    renderPage();
+
+    expect(screen.queryByText(/could not load fittings/i)).toBeNull();
   });
 
   it("renders a character filter alongside the ship type filter", () => {

--- a/apps/web/tests/fittingsPage.test.tsx
+++ b/apps/web/tests/fittingsPage.test.tsx
@@ -13,9 +13,30 @@ jest.mock("@jitaspace/hooks", () => ({
   useMultipleCharacterFittings: () => mockUseMultipleCharacterFittings(),
 }));
 
+// Renders one button per option so tests can actually pick a value: the real
+// component is a Mantine Select, and without a way to fire onChange the filter
+// predicates never run.
 jest.mock("@jitaspace/eve-components", () => ({
-  EveEntitySelect: ({ label }: { label?: string }) => (
-    <div data-testid={`select:${label}`} />
+  EveEntitySelect: ({
+    label,
+    entityIds,
+    onChange,
+  }: {
+    label?: string;
+    entityIds?: { id: number }[];
+    onChange?: (value: string | null) => void;
+  }) => (
+    <div data-testid={`select:${label}`}>
+      {(entityIds ?? []).map(({ id }) => (
+        <button
+          key={id}
+          data-testid={`option:${label}:${id}`}
+          onClick={() => onChange?.(String(id))}
+        >
+          {id}
+        </button>
+      ))}
+    </div>
   ),
 }));
 
@@ -115,6 +136,35 @@ describe("Fittings page", () => {
 
     // Both characters' fittings render even though they share a fitting_id.
     expect(screen.getAllByTestId("saved-fit-card")).toHaveLength(2);
+  });
+
+  it("narrows to one character's fittings when that character is picked", () => {
+    renderPage();
+    expect(screen.getAllByTestId("saved-fit-card")).toHaveLength(2);
+
+    fireEvent.click(screen.getByTestId("option:Filter by character:90000002"));
+
+    expect(screen.getAllByTestId("saved-fit-card")).toHaveLength(1);
+  });
+
+  it("offers one character option per character that owns a fitting", () => {
+    renderPage();
+
+    expect(
+      screen.getByTestId("option:Filter by character:90000001"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("option:Filter by character:90000002"),
+    ).toBeInTheDocument();
+  });
+
+  it("narrows by ship type independently of character", () => {
+    renderPage();
+
+    // 597 belongs only to the second character's fitting.
+    fireEvent.click(screen.getByTestId("option:Filter by ship type:597"));
+
+    expect(screen.getAllByTestId("saved-fit-card")).toHaveLength(1);
   });
 
   it("renders a character filter alongside the ship type filter", () => {

--- a/apps/web/tests/fittingsPage.test.tsx
+++ b/apps/web/tests/fittingsPage.test.tsx
@@ -7,15 +7,16 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { captureMock } from "../__mocks__/posthogMocks";
 
 const mockUseSelectedCharacter = jest.fn();
-const mockUseCharacterFittings = jest.fn();
+const mockUseMultipleCharacterFittings = jest.fn();
 jest.mock("@jitaspace/hooks", () => ({
   useSelectedCharacter: () => mockUseSelectedCharacter(),
-  useCharacterFittings: (...args: unknown[]) =>
-    mockUseCharacterFittings(...args),
+  useMultipleCharacterFittings: () => mockUseMultipleCharacterFittings(),
 }));
 
 jest.mock("@jitaspace/eve-components", () => ({
-  EveEntitySelect: () => <div data-testid="ship-type-select" />,
+  EveEntitySelect: ({ label }: { label?: string }) => (
+    <div data-testid={`select:${label}`} />
+  ),
 }));
 
 jest.mock("@jitaspace/eve-icons", () => ({
@@ -49,6 +50,16 @@ const FITTING = {
   name: "Rifter Roam",
   description: "fast",
   items: [{ type_id: 2456, flag: 27, quantity: 1 }],
+  subjectId: 90000001,
+};
+
+// A second character holding a fitting with the SAME fitting_id: ESI ids are
+// only unique within a character.
+const OTHER_CHARACTER_FITTING = {
+  ...FITTING,
+  name: "Punisher Roam",
+  ship_type_id: 597,
+  subjectId: 90000002,
 };
 
 function renderPage() {
@@ -65,9 +76,9 @@ describe("Fittings page", () => {
     captureMock.mockClear();
     mockOpenContextModal.mockReset();
     mockUseSelectedCharacter.mockReset().mockReturnValue(CHARACTER);
-    mockUseCharacterFittings
+    mockUseMultipleCharacterFittings
       .mockReset()
-      .mockReturnValue({ data: { data: [FITTING] } });
+      .mockReturnValue({ data: [FITTING, OTHER_CHARACTER_FITTING] });
   });
 
   it("captures current_ship_fitting_viewed and opens the modal", () => {
@@ -86,15 +97,34 @@ describe("Fittings page", () => {
   it("captures fitting_viewed for a saved fitting and opens the modal", () => {
     renderPage();
 
-    fireEvent.click(screen.getByTestId("saved-fit-card"));
+    fireEvent.click(screen.getAllByTestId("saved-fit-card")[0]!);
 
     expect(captureMock).toHaveBeenCalledWith("fitting_viewed", {
       fitting_id: 555,
       ship_type_id: 587,
       fitting_name: "Rifter Roam",
+      character_id: 90000001,
     });
     expect(mockOpenContextModal).toHaveBeenCalledWith(
       expect.objectContaining({ modal: "fitting" }),
     );
+  });
+
+  it("lists fittings from every logged-in character", () => {
+    renderPage();
+
+    // Both characters' fittings render even though they share a fitting_id.
+    expect(screen.getAllByTestId("saved-fit-card")).toHaveLength(2);
+  });
+
+  it("renders a character filter alongside the ship type filter", () => {
+    renderPage();
+
+    expect(
+      screen.getByTestId("select:Filter by ship type"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("select:Filter by character"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Stacked on #685 — it uses `useMultipleCharacterFittings`, so this targets that branch rather than `main`. Retarget to `main` once #685 merges.

## Change

The Fittings page queried only the selected character. It now lists saved fittings from every character that granted the fittings scope, with a **Filter by character** select next to the existing ship type filter.

Both filters use `EveEntitySelect`, so the character dropdown resolves names and avatars the same way the ship type one does — no new component, and it stays visually consistent.

Two details worth calling out:

- **Cards render for the owning character**, not the selected one — `EsiCharacterShipFittingCard` now receives `fit.subjectId`. Since it resolves through `useCharacterFitting` → `useCharacterFittings`, which shares a query key with the multi hook, this adds no extra requests.
- **React keys are namespaced by character.** ESI `fitting_id`s are only unique *within* a character, so two characters can legitimately hold the same id; keying on `fitting_id` alone would collide once more than one character is logged in. The key is now `${subjectId}-${fitting_id}`, and a test covers exactly that case.

The **Current Ship Fitting** section still follows the selected character. That is about the ship you are currently flying rather than a saved list, so fanning it out would not mean anything.

## Known limitation (pre-existing, not introduced here)

`ScopeGuard` gates the whole page on the **selected** character's scopes. So if the selected character has not granted `esi-fittings.read_fittings.v1` but another logged-in character has, the page still shows the permissions banner rather than the other character's fittings. That was already the behaviour; it just reads as more of a mismatch now that the page is multi-character. Changing it means touching a component many other pages rely on, so I left it out of this PR — happy to do it separately if you want the guard to pass when *any* character qualifies.

## Testing

`apps/web/tests/fittingsPage.test.tsx` updated for the new hook, plus two new cases:

- fittings from two different characters both render even when they share a `fitting_id`
- both the ship type and character filters are present

`fitting_viewed` now also carries `character_id`, asserted in the existing capture test.

- `apps/web`: 1017 tests pass
- `pnpm lint`: 0 errors

**Not verified in a browser.** The page renders nothing without authenticated EVE SSO sessions, which I cannot create, and the worktree has no `.env` for the dev server. The jest test renders the real page component, so the wiring and both filters are exercised there, but I have not seen this on screen with live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)