### PR TITLE
fix(background-jobs): clear the three pre-existing type-check errors

### DIFF
--- a/.changeset/background-jobs-type-check-clean.md
+++ b/.changeset/background-jobs-type-check-clean.md
@@ -1,0 +1,11 @@
+---
+"@jitaspace/background-jobs": patch
+---
+
+Make `@jitaspace/background-jobs` type-check clean.
+
+`recordsAreEqual` was constrained to `T extends Record<string | number | symbol, unknown>`, which Prisma model types can't satisfy — they're interfaces with no index signature. That made passing it to `compareSets` from `updateTable<DbType extends object>` a type error. The constraint is now `object`, with indexing done through a record view; runtime behaviour is unchanged.
+
+`scrapeHoboleaksAgentTypes` now names its result type (`BatchStepResult<"agentTypeChanges">`). `defineJob`'s `Result` generic silently falls back to its `unknown` default once the payload is given explicitly — TypeScript won't infer the remainder of a type argument list — so the handler's return value was untyped and its tests couldn't read `result.stats`.
+
+No functional change.

--- a/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksAgentTypes.ts
+++ b/packages/background-jobs/jobs/scrape/hoboleaks/scrapeHoboleaksAgentTypes.ts
@@ -1,5 +1,6 @@
 import pLimit from "p-limit";
 
+import type { BatchStepResult } from "../../../types";
 import { defineJob } from "../../../core";
 import { prisma } from "../../../db";
 import { excludeObjectKeys, updateTable } from "../../../utils";
@@ -8,8 +9,13 @@ export interface ScrapeAgentTypesEventPayload {
   data: Record<string, never>;
 }
 
+// `defineJob`'s `Result` falls back to its `unknown` default as soon as the
+// payload is given explicitly — TypeScript won't infer the rest of a type
+// argument list. Naming it keeps the handler's return value checked and usable
+// by callers (the tests read `result.stats`).
 export const scrapeHoboleaksAgentTypes = defineJob<
-  ScrapeAgentTypesEventPayload["data"]
+  ScrapeAgentTypesEventPayload["data"],
+  BatchStepResult<"agentTypeChanges">
 >({
   id: "scrape-hoboleaks-agent-types",
   name: "Scrape Agent Types",

--- a/packages/background-jobs/utils/recordsAreEqual.ts
+++ b/packages/background-jobs/utils/recordsAreEqual.ts
@@ -1,19 +1,31 @@
 import Decimal from "decimal.js";
 
-export const recordsAreEqual = <
-  T extends Record<string | number | symbol, unknown>,
->(
+/**
+ * Structural equality over a record's own enumerable keys, with the quirks the
+ * ESI/SDE scrapers need: `Decimal` values compare by value, and floats compare
+ * by their string form so `1.10` and `1.1` don't read as a change.
+ *
+ * `T` is constrained to `object`, not `Record<string, unknown>`: Prisma model
+ * types are interfaces with no index signature, so they don't satisfy the
+ * stricter constraint — which is why passing this to `compareSets` from
+ * `updateTable<DbType extends object>` failed to type-check. Indexing happens
+ * through a record view instead.
+ */
+export const recordsAreEqual = <T extends object>(
   a: T,
   b: T,
   opts?: {
     ignoreKeys?: (keyof T)[];
   },
-): boolean =>
-  Object.keys(a)
+): boolean => {
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+
+  return Object.keys(a)
     .filter((key) => !(opts?.ignoreKeys ?? []).includes(key as keyof T))
     .every((key) => {
-      const aValue: unknown = a[key];
-      const bValue: unknown = b[key];
+      const aValue: unknown = aRecord[key];
+      const bValue: unknown = bRecord[key];
 
       // different types? this shouldn't happen
       if (typeof aValue !== typeof bValue) return false;
@@ -49,3 +61,4 @@ export const recordsAreEqual = <
 
       return aValue == bValue;
     });
+};


### PR DESCRIPTION
## Why

`pnpm type-check` has been failing in `@jitaspace/background-jobs`. Nothing caught it: neither CI workflow runs `type-check` (`cypress.yml` builds, `sonarcloud.yml` tests), and `apps/web` sets `typescript.ignoreBuildErrors: true` so the Next build doesn't either. CLAUDE.md tells contributors to run it locally, which is where this surfaced.

Reproduce on `main` (after `pnpm db:generate` + `pnpm kubb:generate`):

```
cd packages/background-jobs && ../../node_modules/.bin/tsc --jsx react-jsx --noEmit
```

## The two causes

**`utils/recordsAreEqual.ts` — TS2322.** The generic was constrained to `T extends Record<string | number | symbol, unknown>`. Prisma model types are interfaces with no index signature, so they don't satisfy it — which made handing `recordsAreEqual` to `compareSets` from `updateTable<DbType extends object>` a type error:

> Type `'DbType'` is not assignable to type `'Record<string | number | symbol, unknown>'`. Index signature for type `'string'` is missing in type `'{}'`.

Constrained to `object` instead, with indexing done through a record view. Runtime behaviour is identical — same keys, same comparisons. Tightening `updateTable` instead was the wrong direction: every caller passes a Prisma model, so it would have broken all of them.

**`tests/scrapeHoboleaksAgentTypes.test.ts` — TS18046 ×2.** `'result' is of type 'unknown'`. The real cause isn't in the test: `defineJob<Payload, Result>` falls back to `Result = unknown` the moment the payload is passed explicitly, because TypeScript won't infer the remainder of a type argument list once any part of it is given. So `scrapeHoboleaksAgentTypes.handler` was declared as returning `Promise<unknown>`, and the two assertions reading `result.stats` couldn't compile.

Fixed at the source rather than with a cast in the test — the job now names its result as `BatchStepResult<"agentTypeChanges">`, the existing type for exactly this shape. That also checks the handler's return value against its declaration.

### Scope note

The same latent gap applies to all 107 `defineJob<Payload>` call sites — every one of them silently has `Result = unknown`. Only jobs whose result is actually consumed produce an error today, so this fixes the one that does. Making `defineJob` infer `Result` while `Payload` stays explicit needs either currying (`defineJob<P>()({...})`) or dropping the explicit payload, i.e. touching all 107 call sites — well beyond this fix, but worth a follow-up if the pattern spreads.

## Verification

| Check | Result |
|---|---|
| `background-jobs` `tsc --noEmit` | **clean** (was 3 errors) |
| `background-jobs` tests | 55/55 pass |
| `background-jobs` lint | clean |
| monorepo lint + `manypkg check` (pre-commit) | 0 errors |

Baseline confirmed by stashing both edits and re-running against this branch's tree: exactly the 3 errors above, and they're the only ones.

No functional change — `recordsAreEqual` compares the same keys the same way, and the job returns the same object it always did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)