### PR TITLE
fix(type-check): repair JSX and static-image config across packages

### DIFF
--- a/.changeset/type-check-jsx-in-tsconfig.md
+++ b/.changeset/type-check-jsx-in-tsconfig.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/esi-metadata": patch
+"@jitaspace/db": patch
+---
+
+The `type-check` script no longer passes `--jsx react-jsx` on the command line. Neither package contains JSX or resolves any `.tsx` source, so the flag was a no-op; where the setting is genuinely needed it now lives in the package's `tsconfig.json`, which keeps editors and `tsc` in agreement. No change to emitted output.

--- a/packages/background-jobs-triggerdev/package.json
+++ b/packages/background-jobs-triggerdev/package.json
@@ -12,7 +12,7 @@
     "dev": "pnpm with-env trigger.dev dev",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {

--- a/packages/background-jobs-triggerdev/tsconfig.json
+++ b/packages/background-jobs-triggerdev/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@jitaspace/tsconfig/base.json",
   "compilerOptions": {
     "lib": ["es2022", "dom", "dom.iterable"],
+    "jsx": "react-jsx",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },
   "include": ["."],

--- a/packages/background-jobs/package.json
+++ b/packages/background-jobs/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "prepublishOnly": "pnpm build",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {

--- a/packages/esi-metadata/package.json
+++ b/packages/esi-metadata/package.json
@@ -29,7 +29,7 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "prepublishOnly": "pnpm build",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "test": "jest"
   },
   "dependencies": {},

--- a/packages/eve-components/images.d.ts
+++ b/packages/eve-components/images.d.ts
@@ -1,0 +1,55 @@
+// Ambient declarations for static image imports.
+//
+// Next.js normally injects these into `next-env.d.ts` for the consuming app,
+// but this standalone library is type-checked on its own, so the bundler's
+// static-image imports (e.g. `import icon from "./icon.png"`) would otherwise
+// fail to resolve. Declaring them here as `StaticImageData` (the shape Next's
+// `<Image src>` accepts) keeps those imports precisely typed.
+//
+// This also covers `@jitaspace/eve-icons`, whose `.tsx` sources are pulled into
+// this package's program (it ships raw TypeScript), and which imports a `.png`
+// per icon. Kept in sync with `packages/ui/images.d.ts`.
+
+interface StaticImageData {
+  src: string;
+  height: number;
+  width: number;
+  blurDataURL?: string;
+  blurWidth?: number;
+  blurHeight?: number;
+}
+
+declare module "*.gif" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.png" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.jpg" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.jpeg" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.svg" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.webp" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.avif" {
+  const content: StaticImageData;
+  export default content;
+}

--- a/packages/eve-components/tsconfig.json
+++ b/packages/eve-components/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@jitaspace/tsconfig/base.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },
   "include": ["."],

--- a/packages/eve-data/package.json
+++ b/packages/eve-data/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "prepublish": "pnpm build"
   },
   "dependencies": {},

--- a/packages/eve-icons/images.d.ts
+++ b/packages/eve-icons/images.d.ts
@@ -1,0 +1,54 @@
+// Ambient declarations for static image imports.
+//
+// Next.js normally injects these into `next-env.d.ts` for the consuming app,
+// but this standalone library is type-checked on its own, so the bundler's
+// static-image imports (e.g. `import icon from "./rhea.png"`) would otherwise
+// fail to resolve. Declaring them here as `StaticImageData` (the shape Next's
+// `<Image src>` accepts) keeps those imports precisely typed.
+//
+// Kept in sync with `packages/ui/images.d.ts`, which does the same for the
+// component library.
+
+interface StaticImageData {
+  src: string;
+  height: number;
+  width: number;
+  blurDataURL?: string;
+  blurWidth?: number;
+  blurHeight?: number;
+}
+
+declare module "*.gif" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.png" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.jpg" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.jpeg" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.svg" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.webp" {
+  const content: StaticImageData;
+  export default content;
+}
+
+declare module "*.avif" {
+  const content: StaticImageData;
+  export default content;
+}

--- a/packages/eve-icons/tsconfig.json
+++ b/packages/eve-icons/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@jitaspace/tsconfig/base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },
   "include": [

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "pnpm lint --fix",
     "prepublishOnly": "pnpm build",
     "test": "jest",
-    "type-check": "tsc --jsx react-jsx --noEmit"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@jitaspace/auth-utils": "workspace:*",

--- a/packages/kv/package.json
+++ b/packages/kv/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf .turbo node_modules",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@jitaspace/tsconfig/base.json",
   "compilerOptions": {
-    "jsx": "react",
+    "jsx": "react-jsx",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },
   "include": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "pnpm lint --fix",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "type-check": "tsc --jsx react-jsx --noEmit",
+    "type-check": "tsc --noEmit",
     "prepublish": "pnpm build"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

`pnpm type-check` aborted at `@jitaspace/eve-icons`, so **every package ordered after it was never type-checked at all**. This fixes that blocker and the two other packages whose JSX config had drifted out of step with the rest of the toolchain.

| Package | Before | After |
| --- | ---: | ---: |
| `eve-icons` | 541 | **0** |
| `ui` | 293 | **0** |
| `eve-components` | 894 | **4** |

The full run now reaches all 39 tasks instead of stopping at the first failure.

### `eve-icons` — the original blocker

Two causes: no `jsx` setting at all (so every `.tsx` failed with `TS17004`/`TS6142`), and no module declarations for the 180 `.png` imports its icon components use (`TS2307`).

Fixed properly in the tsconfig rather than by passing `--jsx` on the command line. The image declarations follow the existing `packages/ui/images.d.ts` pattern already in the repo.

### `ui` and `eve-components` — stale `"jsx": "react"`

Both set the legacy classic runtime while their sources use the automatic one, producing 948 × `TS2686` (`'React' refers to a UMD global`).

Worth noting these were only ever wrong for `tsc`: neither package has a build step (Next resolves them through `transpilePackages`), and both jest configs already pin `runtime: "automatic"` via `@swc/jest`. So this makes `tsc` agree with what the bundler and test runner were already doing — no runtime or emit change.

`eve-components` needs its own `images.d.ts` because it pulls `eve-icons`' `.tsx` sources into its own program.

### `--jsx` cleanup

Moved `--jsx react-jsx` off the `type-check` command line and into tsconfig for the 9 packages carrying it, so editors and `tsc` see the same setting. No `--jsx` remains on any CLI in the repo.

I verified each package empirically rather than trusting a file-count heuristic, which caught one case that looks like a no-op but isn't: **`background-jobs-triggerdev` genuinely needs the setting despite having zero `.tsx` files of its own**, because it reaches `@jitaspace/chat`, whose entry point is `index.tsx`. It got the setting in its tsconfig. The other 8 were true no-ops.

## Reviewer notes

- **The 4 remaining `eve-components` errors are real defects** that were buried under ~890 config-noise errors. Being handled separately. The notable one: `SolarSystemSovereigntyAvatar` passes `starId` to `StarAvatar`, which takes `typeId` — the prop is silently dropped and the avatar renders blank.
- **`tiptap-eve` still reports 1907 errors, and every one is in its own `dist/` bundle.** Root cause is systemic and worth knowing about: a package tsconfig declaring its own `exclude` *replaces* the base's `["node_modules","build","dist",".next",".expo"]` rather than extending it. 21 packages do this; `tiptap-eve` is just the one that currently has a `dist/` to trip over. Fixed separately.
- Changeset covers `@jitaspace/db` and `@jitaspace/esi-metadata` (the only two non-private packages touched). The rest are private, and no package here changes emitted output.

## Verification

- `tsc --noEmit` clean in `eve-icons`, `ui`, and all 9 `--jsx` packages via their real `type-check` scripts
- `pnpm lint` → 0 errors across all 26 tasks; `manypkg check` valid
- `ui` 120 tests and `eve-components` 284 tests pass

One caveat if you reproduce locally: stale `node_modules/.cache/.eslintcache` files produced 436 phantom lint errors here (all "type that cannot be resolved"). `find packages apps -path '*/node_modules/.cache/.eslintcache' -delete` clears them. Likewise, run the test task and `coverage/` gets type-checked into hundreds of bogus errors, since most packages don't exclude it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)