### PR TITLE
fix(tiptap-eve): decode EVE's ARGB colors and recognize bookmarkFolder: links

### DIFF
--- a/.changeset/evefont-argb-colors.md
+++ b/.changeset/evefont-argb-colors.md
@@ -1,0 +1,27 @@
+---
+"@jitaspace/tiptap-eve": patch
+"@jitaspace/web": patch
+---
+
+fix(tiptap-eve): decode EVE's `#AARRGGBB` colors and stop pinning body text to white
+
+`fromEveColor` passed any 8-digit `#` hex straight through to CSS. EVE writes
+colors alpha-FIRST, so CSS read them as `#RRGGBBAA` and scrambled the hue — the
+real PLEX description's `#ff3399cc` (opaque EVE blue `#3399cc`) rendered as
+80%-opacity hot pink.
+
+- 8-digit `#` values are now decoded as EVE ARGB, matching the existing `0x`
+  branches. The alpha byte is dropped rather than translated: EVE uses it to dim
+  text against the client's near-black UI, and compositing it against a web
+  background only pushes already-pale text further toward invisible.
+- Pass-through is narrowed to valid CSS hex lengths (3 and 6 digits). 5- and
+  7-digit values previously slipped through and the browser silently dropped the
+  declaration.
+- A decoded near-white color (EVE's `#bfffffff` body text) no longer emits a
+  `color` declaration at all, so the text inherits the theme's foreground. The
+  original EVE color string is still kept on the span, so mail composition
+  round-trips losslessly.
+
+For `@jitaspace/web`: fixed colored text in mail, character bios and item
+descriptions. Some colors were rendered as the wrong hue entirely, and EVE's
+standard body-text color came out white — invisible on the light theme.

--- a/.changeset/evelink-bookmark-folder.md
+++ b/.changeset/evelink-bookmark-folder.md
@@ -1,0 +1,25 @@
+---
+"@jitaspace/tiptap-eve": patch
+"@jitaspace/web": patch
+---
+
+feat(tiptap-eve): recognize `bookmarkFolder:` links in EVE mail
+
+`bookmarkFolder:` was missing from `EveLink`'s protocol allowlist, so TipTap's
+Link extension stripped the mark from a real mail's
+`<a href="bookmarkFolder:7102471">MC Deputy Training</a>`. The label survived as
+bare text, silently losing both its affordance and MailMessageViewer's link
+coloring.
+
+Registered as lowercase `bookmarkfolder`, matching the other schemes — linkifyjs
+v4 throws at editor construction on any non-lowercase name, and matching is
+case-insensitive so the camelCase href in mail content still resolves.
+
+A shared bookmark folder has no web equivalent, so `renderEveHref` leaves the
+href intact and `MailMessageViewer` intercepts the click with an explanatory
+alert, as it does for `shipSkinListing:` and `fleet:`. It takes the internal link
+color, like the similarly client-only `fitting:`.
+
+For `@jitaspace/web`: shared bookmark folder links in mail are now shown as
+links, and clicking one explains that it can only be opened in the EVE Online
+client.

--- a/apps/web/components/EveMail/MailMessageViewer.tsx
+++ b/apps/web/components/EveMail/MailMessageViewer.tsx
@@ -43,7 +43,12 @@ export function MailMessageViewer({
     if (href.startsWith("joinChannel:") || href.startsWith("fleet:")) {
       return channelLinkColor;
     }
-    if (href.startsWith("fitting:")) return internalLinkColor;
+    // bookmarkFolder: has no web route — it is an in-game object reference like
+    // fitting:, so it takes the internal color rather than the external one the
+    // pass-through fallback would otherwise give it.
+    if (href.startsWith("fitting:") || href.startsWith("bookmarkFolder:")) {
+      return internalLinkColor;
+    }
     if (translatedHref.startsWith("/")) return internalLinkColor;
     return externalLinkColor;
   };
@@ -111,6 +116,11 @@ export function MailMessageViewer({
       e.preventDefault();
       globalThis.alert(
         "This is a fleet invite link. Open it in the EVE Online client to join the fleet.",
+      );
+    } else if (href?.startsWith("bookmarkFolder:")) {
+      e.preventDefault();
+      globalThis.alert(
+        "This is a shared bookmark folder. Open it in the EVE Online client to view the bookmarks.",
       );
     }
   };

--- a/apps/web/tests/MailMessageViewer.test.tsx
+++ b/apps/web/tests/MailMessageViewer.test.tsx
@@ -25,7 +25,8 @@ const mockGetHTML = jest.fn(
     ' and <a href="fleet:1021212278338" target="_blank" rel="noopener noreferrer nofollow">Mining Fleet</a>' +
     ' and <a href="helpPointer:neocom.airCareerProgram">Help</a>' +
     ' and <a href="shipSkinListing:fe7ec0c3-2d02-4d3b-9cd4-b41221941951">Skin</a>' +
-    ' and <a href="fitting:33470:31047;1:31011;1::">Stratios Fit</a></p>',
+    ' and <a href="fitting:33470:31047;1:31011;1::">Stratios Fit</a>' +
+    ' and <a href="bookmarkFolder:7102471">MC Deputy Training</a></p>',
 );
 
 jest.mock("@jitaspace/tiptap-eve", () => ({
@@ -180,6 +181,32 @@ describe("MailMessageViewer", () => {
       await user.click(screen.getByRole("link", { name: "Skin" }));
       expect(alertSpy).toHaveBeenCalledTimes(1);
       alertSpy.mockRestore();
+    });
+  });
+
+  describe("bookmarkFolder links", () => {
+    // A shared bookmark folder only exists inside the client, so the link is
+    // rendered (rather than stripped, which is what happened before the scheme
+    // was registered) but resolves to an explanatory alert instead of a route.
+    it("shows an alert when a bookmark folder link is clicked", async () => {
+      const user = userEvent.setup();
+      const alertSpy = jest
+        .spyOn(window, "alert")
+        .mockImplementation(() => undefined);
+      render(<MailMessageViewer content="" />);
+      await user.click(screen.getByRole("link", { name: "MC Deputy Training" }));
+      expect(alertSpy).toHaveBeenCalledWith(
+        expect.stringContaining("EVE Online client"),
+      );
+      alertSpy.mockRestore();
+    });
+
+    it("renders bookmark folder links with the internal link color", () => {
+      render(<MailMessageViewer content="" />);
+      const bookmarkLink = screen.getByRole("link", {
+        name: "MC Deputy Training",
+      });
+      expect(bookmarkLink).toHaveStyle("color: #d98d00");
     });
   });
 

--- a/packages/tiptap-eve/Extensions/EveFont.ts
+++ b/packages/tiptap-eve/Extensions/EveFont.ts
@@ -1,30 +1,69 @@
 import { getMarkAttributes, Mark, mergeAttributes } from "@tiptap/core";
 
+// EVE writes colors alpha-FIRST (ARGB) — the opposite of CSS's #RRGGBBAA. Both
+// notations EVE uses follow that order: `0xAARRGGBB` in mail (<color=0x…>) and
+// `#AARRGGBB` in type descriptions and character bios (<font color="#…">).
+//
+// The alpha byte is dropped rather than translated to an rgba() alpha. EVE uses
+// it to dim text against the client's near-black UI; compositing it against an
+// arbitrary web background instead only pushes already-pale text further toward
+// invisible. Dropping it matches what the `0x` branch has always done.
+const EVE_ARGB = /^(?:0x|#)[0-9a-fA-F]{2}([0-9a-fA-F]{6})$/;
+// 0x0RRGGBB — the single-alpha-digit variant, seen only with the `0x` prefix.
+const EVE_SHORT_ARGB = /^0x[0-9a-fA-F]([0-9a-fA-F]{6})$/;
+// A plain CSS hex color. Only the 3- and 6-digit lengths: 8 digits is claimed by
+// EVE_ARGB above, and 4/5/7 digits are either ambiguous or not valid CSS at all
+// (the browser drops `color:#abcde` silently, which reads as a rendering bug).
+const CSS_HEX = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
 export const fromEveColor = (eveColor: string | null | undefined): string => {
   // A <font> tag may carry no `color` attribute (e.g. `<font size="14">`
   // section headers, which are extremely common in EVE descriptions and mail).
   // TipTap then renders this mark with the attribute's default value of `null`,
-  // so guard against null/undefined/empty before touching `.length`. Without
-  // this, renderHTML throws and crashes the whole MailMessageViewer (e.g. the
-  // Description tab on /type/44992).
+  // so guard against null/undefined/empty. Without this, renderHTML throws and
+  // crashes the whole MailMessageViewer (e.g. the Description tab on /type/44992).
   if (!eveColor) return "";
-  if (eveColor.length === 9 && eveColor.startsWith("0x")) {
-    // 0x0RRGGBB — single-digit alpha prefix, strip "0x0"
-    return `#${eveColor.slice(3)}`;
-  }
-  if (eveColor.length === 10 && eveColor.startsWith("0x")) {
-    // 0xAARRGGBB — two-digit alpha, strip "0xAA"
-    return `#${eveColor.slice(4)}`;
-  }
-  if (/^#[0-9a-fA-F]{3,8}$/.test(eveColor)) {
-    // Already a plain CSS hex color.
-    return eveColor;
-  }
+
+  const argb = EVE_ARGB.exec(eveColor) ?? EVE_SHORT_ARGB.exec(eveColor);
+  if (argb) return `#${argb[1]}`;
+
+  if (CSS_HEX.test(eveColor)) return eveColor;
+
   // Reject anything else. `color` comes from attacker-controlled EVE HTML (other
   // players' mail bodies and character bios); returning it unchanged would let a
   // value like "blue;position:fixed;inset:0;background:url(https://attacker)"
   // break out of the `color:` declaration and inject arbitrary inline CSS.
   return "";
+};
+
+/** Expands `#rgb` to `#rrggbb`. Any other input is returned unchanged. */
+const toSixDigitHex = (hex: string): string =>
+  hex.replace(/^#([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F])$/, "#$1$1$2$2$3$3");
+
+// Channel value at or above which a color counts as EVE's "plain text" white.
+const NEAR_WHITE = 0xe0;
+
+/**
+ * True when a decoded color is EVE's default body-text white.
+ *
+ * EVE's palette is authored for the game client's near-black UI, where a
+ * near-white `<font color>` is not a deliberate highlight — it is just "normal
+ * text" (`#bfffffff` is the standard color of EVE descriptions and mail). Pinning
+ * that to literal white makes the text invisible on JitaSpace's light theme, so
+ * callers drop it and let the surrounding theme's foreground color apply.
+ *
+ * On the dark theme this is a visual no-op: EVE's `#bfffffff` composites to about
+ * rgb(200,200,200) over the app background, which is Mantine's dark text color.
+ */
+export const isEveDefaultTextColor = (cssHex: string): boolean => {
+  const hex = toSixDigitHex(cssHex);
+  if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return false;
+  const rgb = Number.parseInt(hex.slice(1), 16);
+  return (
+    ((rgb >> 16) & 0xff) >= NEAR_WHITE &&
+    ((rgb >> 8) & 0xff) >= NEAR_WHITE &&
+    (rgb & 0xff) >= NEAR_WHITE
+  );
 };
 
 export interface FontColorMarkOptions {
@@ -79,9 +118,14 @@ export const EveFontColor = Mark.create<FontColorMarkOptions>({
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const cssColor = fromEveColor(color);
     if (cssColor) {
-      styles.push(`color:${cssColor}`);
-      // Preserve the ORIGINAL EVE color string on the span only when it passed
-      // validation, so htmlToEveMail can losslessly round-trip composed mail
+      // Emit no `color` declaration for EVE's default body-text white so the
+      // text inherits the theme's foreground instead — see isEveDefaultTextColor.
+      if (!isEveDefaultTextColor(cssColor)) {
+        styles.push(`color:${cssColor}`);
+      }
+      // Preserve the ORIGINAL EVE color string on the span whenever it passed
+      // validation — including the white that is deliberately not rendered — so
+      // htmlToEveMail can losslessly round-trip composed mail
       // (<span color="0x…"> → <color=0x…>). Invalid/attacker values are dropped.
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       safeAttributes.color = color;

--- a/packages/tiptap-eve/Extensions/EveLink.ts
+++ b/packages/tiptap-eve/Extensions/EveLink.ts
@@ -118,5 +118,6 @@ export const EveLink = Link.configure({
     "opportunity",
     "careerprogramnode",
     "fleet",
+    "bookmarkfolder",
   ],
 });

--- a/packages/tiptap-eve/tests/eveEditorRender.test.ts
+++ b/packages/tiptap-eve/tests/eveEditorRender.test.ts
@@ -42,6 +42,41 @@ describe("eveEditorExtensions render round-trip", () => {
     expect(stripWs(html)).toContain("color:rgb(255,0,0)");
   });
 
+  describe("EVE ARGB colors", () => {
+    it("decodes a #AARRGGBB color instead of letting CSS read it as #RRGGBBAA", () => {
+      // From the real PLEX description. EVE means opaque #3399cc; CSS reads the
+      // raw value as rgba(255, 51, 153, 0.8) — hot pink.
+      const html = renderToHtml('<font color="#ff3399cc">TIP</font>');
+      expect(html).toContain("TIP");
+      expect(stripWs(html)).toContain("color:rgb(51,153,204)");
+      expect(stripWs(html)).not.toContain("rgba(255,51,153");
+    });
+
+    it("lets EVE's default body-text white inherit the theme color", () => {
+      // #bfffffff is EVE's standard description/mail text color. Pinned to white
+      // it is invisible on the light theme, so no `color` declaration is emitted.
+      const html = renderToHtml('<font color="#bfffffff">body text</font>');
+      expect(html).toContain("body text");
+      expect(html).not.toContain("color: rgb(255, 255, 255)");
+      expect(html).not.toContain("#bfffffff;");
+    });
+
+    it("still round-trips white through the color attribute for mail composition", () => {
+      // htmlToEveMail reads the original EVE string off the `color` attribute, so
+      // suppressing the CSS declaration must not make composed mail lossy.
+      const html = renderToHtml('<font color="0xbfffffff">body text</font>');
+      expect(html).toContain('color="0xbfffffff"');
+    });
+
+    it("keeps rendering a non-white color alongside a suppressed white one", () => {
+      const html = renderToHtml(
+        '<font color="#bfffffff">plain</font><font color="0x0ff0000">danger</font>',
+      );
+      expect(stripWs(html)).toContain("color:rgb(255,0,0)");
+      expect(html).toContain("plain");
+    });
+  });
+
   it("clamps an oversized font-size to the maximum", () => {
     const html = renderToHtml('<font size="9999">huge</font>');
     expect(html).toContain("huge");

--- a/packages/tiptap-eve/tests/eveEditorRender.test.ts
+++ b/packages/tiptap-eve/tests/eveEditorRender.test.ts
@@ -77,6 +77,17 @@ describe("eveEditorExtensions render round-trip", () => {
     });
   });
 
+  it("keeps a bookmarkFolder: link as an anchor", () => {
+    // Unregistered schemes are dropped by the Link extension: before
+    // `bookmarkfolder` joined EveLink's protocol list, a real mail's
+    // <a href="bookmarkFolder:7102471"> lost its mark and rendered as bare text.
+    const html = renderToHtml(
+      '<a href="bookmarkFolder:7102471">MC Deputy Training</a>',
+    );
+    expect(html).toContain('href="bookmarkFolder:7102471"');
+    expect(html).toContain("MC Deputy Training");
+  });
+
   it("clamps an oversized font-size to the maximum", () => {
     const html = renderToHtml('<font size="9999">huge</font>');
     expect(html).toContain("huge");

--- a/packages/tiptap-eve/tests/eveFont.test.ts
+++ b/packages/tiptap-eve/tests/eveFont.test.ts
@@ -1,4 +1,4 @@
-import { fromEveColor } from "../Extensions/EveFont";
+import { fromEveColor, isEveDefaultTextColor } from "../Extensions/EveFont";
 
 describe("fromEveColor", () => {
   describe("9-character EVE color format (0x0RRGGBB)", () => {
@@ -36,8 +36,24 @@ describe("fromEveColor", () => {
       ["6-char hex", "#ff0000", "#ff0000"],
       ["3-char shorthand hex", "#abc", "#abc"],
       ["6-char hex (aabbcc)", "#aabbcc", "#aabbcc"],
-      ["8-char hex with alpha", "#aabbccdd", "#aabbccdd"],
     ])("passes through %s", (_name, input, expected) => {
+      expect(fromEveColor(input)).toBe(expected);
+    });
+  });
+
+  describe("#-prefixed EVE color format (#AARRGGBB)", () => {
+    // EVE uses the same alpha-FIRST byte order for the `#` notation found in
+    // type descriptions and character bios as it does for `0x` in mail. CSS
+    // reads 8 hex digits as #RRGGBBAA, so handing these through unchanged
+    // scrambles the hue: #ff3399cc (opaque EVE blue #3399cc, from the real PLEX
+    // description) rendered as 80%-opacity hot pink.
+    it.each([
+      ["opaque EVE blue (PLEX description)", "#ff3399cc", "#3399cc"],
+      ["EVE default body text white", "#bfffffff", "#ffffff"],
+      ["opaque red", "#ffff0000", "#ff0000"],
+      ["semi-transparent black", "#80000000", "#000000"],
+      ["uppercase hex digits", "#FFAABBCC", "#AABBCC"],
+    ])("decodes %s", (_name, input, expected) => {
       expect(fromEveColor(input)).toBe(expected);
     });
   });
@@ -77,8 +93,49 @@ describe("fromEveColor", () => {
       ["hex with too many digits", "#0123456789"],
       ["hex with non-hex char", "#gggggg"],
       ["9-char without 0x prefix", "abcdefghi"],
+      // 4/5/7-digit hex is either ambiguous against EVE's ARGB order or not
+      // valid CSS at all — the browser drops the declaration, which surfaces as
+      // a rendering bug rather than a safe fallback.
+      ["4-digit hex", "#abcd"],
+      ["5-digit hex", "#abcde"],
+      ["7-digit hex", "#abcdef0"],
     ])("returns an empty string for %s", (_name, input) => {
       expect(fromEveColor(input)).toBe("");
+    });
+  });
+
+  describe("isEveDefaultTextColor", () => {
+    // EVE authors its palette for the client's near-black UI, so a near-white
+    // <font color> means "normal body text", not "paint this white". Callers
+    // drop it so the text inherits the theme foreground and stays readable on
+    // the light theme, where literal white is invisible.
+    it.each([
+      ["pure white", "#ffffff"],
+      ["3-digit white", "#fff"],
+      ["off-white above the threshold", "#f2f0f0"],
+      ["exactly at the threshold", "#e0e0e0"],
+      ["uppercase white", "#FFFFFF"],
+    ])("treats %s as default text", (_name, input) => {
+      expect(isEveDefaultTextColor(input)).toBe(true);
+    });
+
+    it.each([
+      ["EVE blue", "#3399cc"],
+      ["red", "#ff0000"],
+      ["black", "#000000"],
+      ["just below the threshold on one channel", "#ffdfff"],
+      ["mid grey", "#888888"],
+      ["an empty string", ""],
+    ])("leaves %s alone", (_name, input) => {
+      expect(isEveDefaultTextColor(input)).toBe(false);
+    });
+
+    it("suppresses the color declaration for EVE's #bfffffff body text", () => {
+      // The full path the bug report followed: #bfffffff decodes to white, which
+      // must NOT reach an inline `color:` declaration.
+      const color = fromEveColor("#bfffffff");
+      expect(color).toBe("#ffffff");
+      expect(isEveDefaultTextColor(color)).toBe(true);
     });
   });
 

--- a/packages/tiptap-eve/tests/eveLink.test.ts
+++ b/packages/tiptap-eve/tests/eveLink.test.ts
@@ -179,6 +179,9 @@ describe("renderEveHref", () => {
         "shipSkinListing",
         "shipSkinListing:fe7ec0c3-2d02-4d3b-9cd4-b41221941951",
       ],
+      // A shared bookmark folder has no web equivalent — it only exists inside
+      // the client, so the href stays intact for the alert click handler.
+      ["bookmarkFolder", "bookmarkFolder:7102471"],
     ])("passes %s hrefs through unchanged", (_name, href) => {
       expect(renderEveHref(href)).toBe(href);
     });
@@ -240,6 +243,7 @@ describe("EveLink protocol configuration", () => {
     "opportunity",
     "careerprogramnode",
     "fleet",
+    "bookmarkfolder",
   ];
 
   const EVE_PROTOCOL_SAMPLES: [string, string][] = [
@@ -262,6 +266,7 @@ describe("EveLink protocol configuration", () => {
     ["opportunity", "opportunity:epic_arcs:40"],
     ["careerProgramNode", "careerProgramNode:7:410:None"],
     ["fleet", "fleet:1021212278338"],
+    ["bookmarkFolder", "bookmarkFolder:7102471"],
   ];
 
   it.each(EVE_PROTOCOL_SAMPLES)(
@@ -312,8 +317,10 @@ describe("EveLink registered protocols are linkifyjs-safe (regression)", () => {
   const registered = EveLink.options.protocols as string[];
 
   it("registers at least the known EVE schemes", () => {
-    expect(registered).toEqual(expect.arrayContaining(["showinfo", "fleet"]));
-    expect(registered.length).toBeGreaterThanOrEqual(13);
+    expect(registered).toEqual(
+      expect.arrayContaining(["showinfo", "fleet", "bookmarkfolder"]),
+    );
+    expect(registered.length).toBeGreaterThanOrEqual(14);
   });
 
   it("registers every scheme in all-lowercase form", () => {


### PR DESCRIPTION
## The bug

EVE writes colors **alpha-first** (`#AARRGGBB`). `fromEveColor` passed any 8-digit `#` hex straight through to CSS, which reads 8 digits as `#RRGGBBAA` — so the channels were permuted.

Because EVE's opaque colors are `#ffRRGGBB`, **the blue byte became the alpha**. Every EVE color with blue = `00` rendered fully transparent:

| EVE color | intent | what CSS did |
|---|---|---|
| `#ff00ff00` | opaque green | `rgba(255, 0, 255, 0)` — invisible |
| `#ffffff00` | opaque yellow | `rgba(255, 255, 255, 0)` — invisible |
| `#ffd98d00` | opaque orange | `rgba(255, 217, 141, 0)` — invisible |
| `#ffff0000` | opaque red | `rgba(255, 255, 0, 0)` — invisible |
| `#ff3399cc` | EVE blue `#3399cc` | `rgba(255, 51, 153, 0.8)` — hot pink |
| `#bfffffff` | 75% white body text | `rgb(191, 255, 255)` — pale cyan |

Whole sentences were missing from mail and item descriptions. Reproduced live on `/type/44992` — the real PLEX description's `<font color="#ff3399cc">` computed to `rgba(255, 51, 153, 0.8)`.

On a real corp-recruitment mail, the dark theme dropped "Welcome", "NEVER EAT THE BAIT. (under no circumstances)", "Website:", "Mask Name:", "Bookmarks:", "ASK QUESTIONS!" and more — the mail read as gibberish.

## The fix

**1. Decode `#AARRGGBB` as EVE ARGB**, matching the existing `0x` branches. The alpha byte is dropped rather than translated to an `rgba()` alpha: EVE uses it to dim text against the client's near-black UI, and compositing it against a web background only pushes already-pale text further toward invisible.

**2. Narrow pass-through to valid CSS hex lengths** (3 and 6). 5- and 7-digit values previously slipped through and the browser silently dropped the declaration.

**3. Let EVE's default body-text white inherit the theme.** `#bfffffff` is EVE's standard description/mail color; pinned to literal white it is invisible on the light theme. A decoded near-white now emits no `color` declaration. On the dark theme this is a visual no-op — `#bfffffff` composites to ~`rgb(200,200,200)` over the app background, which is Mantine's dark text color.

The original EVE color string stays on the span even when the declaration is suppressed, so `htmlToEveMail` still round-trips composed mail losslessly.

**4. Register `bookmarkFolder:`.** It was missing from `EveLink`'s allowlist, so TipTap stripped the mark from `<a href="bookmarkFolder:7102471">MC Deputy Training</a>` — the label survived as bare text, losing its affordance and its link color. Registered lowercase (linkifyjs v4 throws on non-lowercase schemes; matching is case-insensitive so the camelCase href still resolves). It has no web equivalent, so the click is intercepted with an explanatory alert like `shipSkinListing:` and `fleet:`, and takes the internal link color like the similarly client-only `fitting:`.

## Verification

Rendered the sample mail through the real pipeline and measured computed styles in the browser on both themes.

Light-theme contrast against white, spans below 3:1 — **30 of 31 before, 21 after**. The remaining 21 are the mail author's genuine colors (saturated yellow at 1.07:1, green at 1.37:1), picked for EVE's black UI and now rendering accurately. Remapping those would override deliberate author intent, so it is deliberately out of scope here.

Bookmark link after the fix: `isAnchor: true`, `href="bookmarkFolder:7102471"`, `rgb(217, 141, 0)`, weight 600.

## Testing

- `@jitaspace/tiptap-eve`: 253 pass. New coverage for ARGB decoding, the newly-rejected hex lengths, `isEveDefaultTextColor`, white round-tripping through the `color` attribute, and the bookmarkFolder anchor. Confirmed the anchor test is not vacuous — removing `bookmarkfolder` from the allowlist makes it fail.
- `@jitaspace/web`: 1019 pass across 133 suites.
- `pnpm lint` clean across the monorepo (0 errors), `tsc --noEmit` clean on `tiptap-eve`.

Note for reviewers: a fresh worktree needs `pnpm db:generate` and a cleared `.eslintcache` before `pnpm lint` reports accurately — stale caches surfaced 434 phantom errors here that had nothing to do with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)