### PR TITLE
fix(changesets): retarget two stale @jitaspace/eve-scrape bumps to background-jobs

### DIFF
--- a/.changeset/env-injection-factories.md
+++ b/.changeset/env-injection-factories.md
@@ -2,7 +2,7 @@
 "@jitaspace/db": minor
 "@jitaspace/kv": minor
 "@jitaspace/chat": minor
-"@jitaspace/eve-scrape": patch
+"@jitaspace/background-jobs": patch
 "@jitaspace/web": patch
 ---
 
@@ -17,4 +17,4 @@ instead of singletons:
 - `@jitaspace/chat` — `createChat({ discordBotToken?, discordUpdatesChannelId? })`
 
 Apps build the instance from their own validated env in a thin local shim.
-`eve-scrape` and `web` have been updated accordingly.
+`background-jobs` and `web` have been updated accordingly.

--- a/.changeset/kubb-v4-upgrade.md
+++ b/.changeset/kubb-v4-upgrade.md
@@ -1,6 +1,6 @@
 ---
 "@jitaspace/web": patch
-"@jitaspace/eve-scrape": patch
+"@jitaspace/background-jobs": patch
 ---
 
 Upgrade the Kubb API-client generator from v3 to v4 (`4.38.0`) across all five generated client packages (esi-client, sde-client, evekill-client, evetycoon-client, fuzzworks-market-client). The generated public API is preserved: `enumTypeSuffix: ""` keeps the existing `…Enum` type names (v4 defaults to a `Key` suffix), and the custom ESI client now exports the `Client` type that v4-generated code imports. The obsolete `@kubb/react` dependency was dropped (v4 plugins use `@kubb/react-fabric` internally).


### PR DESCRIPTION
## Problem

`pnpm exec changeset status` fails outright on `main` today:

```
Error: Found changeset env-injection-factories for package @jitaspace/eve-scrape which is not in the workspace
```

`assembleReleasePlan` throws on the first unknown package name, so **both `changeset status` and `changeset version` are broken — a release would fail** until this is resolved.

Two committed changesets still reference `@jitaspace/eve-scrape`, a package that no longer exists:

- `.changeset/env-injection-factories.md` (added in 28b11660, Jun 7)
- `.changeset/kubb-v4-upgrade.md` (added in be72a0bd, Jun 13)

## Why they were missed

`@jitaspace/eve-scrape` was the **Inngest** background-jobs adapter, deleted in 851dd403 ("chore: remove the Inngest background-jobs adapter"). That commit *did* clean up changesets — it deleted two Inngest-only ones and stripped the `eve-scrape` line from `triggerdev-migration.md`, with the commit message explicitly noting the bump "would otherwise break `changeset version`". It just missed these two, both authored days before the Jun 20 removal.

## The fix — retargeted, not dropped

Both entries are retargeted to `@jitaspace/background-jobs`, because that package absorbed the role in each case:

**`env-injection-factories.md`** — conclusive. The env-injection commit ce31b760 created `packages/eve-scrape/{db,kv,chat}.ts`, and the Trigger.dev migration d4751958 moved those exact shims into `packages/background-jobs/` (git records it as `packages/{eve-scrape => background-jobs}/db.ts | 0` — a pure rename). They're there today, calling `createPrismaClient` / `createKv` / `createChat`. The trailing prose line is updated to match.

**`kubb-v4-upgrade.md`** — that commit touched only the five generated client packages plus the lockfile; no `eve-scrape` source at all. So the bump was a pure downstream-consumer acknowledgement, the same role `web: patch` plays there. `background-jobs` now fills that role: it depends on `esi-client`, `sde-client` and `evekill-client`, importing them across 40 files. Dropping the line would have silently lost that record — the generated-client packages are all `private: true` and aren't listed in the frontmatter themselves.

Co-listed packages are untouched (`db`/`kv`/`chat` minor + `web` patch; `web` patch).

## Reviewer notes

- `background-jobs` already takes a **minor** from `triggerdev-migration.md`, so these two `patch` bumps are absorbed version-wise. They still contribute their changelog entries, which is the point of retargeting.
- No changeset is added for this PR — it repairs changeset metadata, not package behaviour.

## Verification

- `pnpm exec changeset status` → **exit 0**, resolves the whole workspace.
- Ran a full `changeset version` end-to-end: it completes, and both entries land in `packages/background-jobs/CHANGELOG.md`. Reverted afterwards.
- Swept every changeset's frontmatter against the workspace package list — these two were the only unknown-package references, so no second failure is waiting behind them.
- Pre-commit hook green: 26/26 `turbo lint` tasks + `manypkg check`.

Unrelated to the diff, but worth knowing for anyone reproducing in a fresh worktree: `pnpm lint` reports ~434 phantom `no-unsafe-*` errors in `apps/web` until `pnpm db:generate` has run, and the results get written to `.eslintcache` — so it keeps replaying them after codegen until that cache is cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)