### PR TITLE
fix(hooks): skip endpoints whose completeness cannot be guaranteed

### DIFF
--- a/.changeset/skip-cursor-paginated-multi-hooks.md
+++ b/.changeset/skip-cursor-paginated-multi-hooks.md
@@ -1,0 +1,9 @@
+---
+"@jitaspace/hooks": patch
+---
+
+Three generated multi-subject hooks were returning only the first page of their collection: `useMultipleCharacterCalendar`, `useMultipleCharacterMail` and `useMultipleCharacterWalletTransactions`. ESI pages those by `from_event`, `last_mail_id` and `from_id` respectively, none of which the OpenAPI spec declares as pagination — `x-pagination: cursor` marks only five unrelated operations — so the generator treated them as ordinary single-request lists and emitted hooks whose names promised every subject's whole collection.
+
+The generator now works from an allowlist: an endpoint is generated only when every query parameter is known not to affect completeness (`page`, which is walked in full, plus the `include_completed` and `labels` filters). Anything unrecognised is assumed to be a cursor and the endpoint is skipped, so a newly added parameter removes a hook — noticeable — instead of silently truncating one.
+
+73 hooks now ship, down from 76. The two industry-jobs hooks are unaffected: `include_completed` is a filter whose default already matches the single-subject hooks.

--- a/packages/hooks/kubb/multiEsiEndpoints.ts
+++ b/packages/hooks/kubb/multiEsiEndpoints.ts
@@ -29,6 +29,31 @@ export interface EsiOperation {
   "x-required-roles"?: string[];
 }
 
+/**
+ * Query parameters known not to affect whether a response is the whole
+ * collection.
+ *
+ * Anything else causes the endpoint to be skipped, because an unrecognised
+ * parameter may be a cursor — and a `useMultipleXXX` that quietly returns the
+ * first page under a name promising every subject's whole collection is worse
+ * than one that does not exist.
+ *
+ * The spec cannot be relied on to say which those are: `x-pagination: cursor`
+ * marks only five operations, while ESI also pages the calendar by
+ * `from_event`, mail by `last_mail_id` and wallet transactions by `from_id`
+ * without declaring any of them. Defaulting to skip means a newly added
+ * parameter makes a hook disappear — noticeable — rather than silently
+ * truncate.
+ */
+const COMPLETENESS_SAFE_QUERY_PARAMS = new Set([
+  // Walked in full by esiPagedQueryOptions.
+  "page",
+  // Filters, not paging. Their defaults are the ones the single-subject hooks
+  // already use, and neither hides part of the collection that default selects.
+  "include_completed",
+  "labels",
+]);
+
 const pascal = (value: string) =>
   value
     .split(/[-_\s]+/)
@@ -139,10 +164,13 @@ export function describeEndpoint(
     return null;
   }
   const queryParams = queryParameters.map((parameter) => parameter.name);
-  // Cursor pagination (after/before/limit) is not the `page` + `x-pages` scheme
-  // esiPagedQueryOptions walks, so these would silently return only the server's
-  // first page under a name that promises every subject's whole collection.
-  if (queryParams.includes("after") || queryParams.includes("before")) {
+  // Anything not vouched for as completeness-safe — every cursor scheme,
+  // declared in the spec or not — is skipped rather than half-fetched.
+  if (
+    queryParams.some(
+      (name) => name == undefined || !COMPLETENESS_SAFE_QUERY_PARAMS.has(name),
+    )
+  ) {
     return null;
   }
 

--- a/packages/hooks/tests/multiEsiEndpoints.test.ts
+++ b/packages/hooks/tests/multiEsiEndpoints.test.ts
@@ -179,18 +179,41 @@ describe("describeEndpoint — what is skipped", () => {
     ).not.toBeNull();
   });
 
-  it("skips cursor-paginated routes", () => {
-    // after/before/limit is not the page + x-pages scheme esiPagedQueryOptions
-    // walks, so these would silently return only the server's first page.
+  it.each([
+    { name: "after/before/limit", params: ["after", "before", "limit"] },
+    // ESI pages these three without declaring it in the spec, so a denylist of
+    // known cursor names would have missed them.
+    { name: "from_event (calendar)", params: ["from_event"] },
+    { name: "last_mail_id (mail)", params: ["labels", "last_mail_id"] },
+    { name: "from_id (wallet transactions)", params: ["from_id"] },
+    { name: "an unrecognised future parameter", params: ["something_new"] },
+  ])("skips routes paged by $name", ({ params }) => {
+    // Only `page` is walked in full. Anything unvouched-for is assumed to be a
+    // cursor, because returning the first page under a name that promises the
+    // whole collection is worse than not existing.
     expect(
-      describeAt("/corporations/{corporation_id}/projects", {
-        parameters: [
-          { name: "after", in: "query" },
-          { name: "before", in: "query" },
-          { name: "limit", in: "query" },
-        ],
+      describeAt("/characters/{character_id}/thing", {
+        parameters: params.map((name) => ({ name, in: "query" })),
       }),
     ).toBeNull();
+  });
+
+  it("keeps routes whose only query params are known filters", () => {
+    // include_completed is a filter, not paging: the default is the one the
+    // single-subject hook already uses.
+    expect(
+      describeAt("/characters/{character_id}/industry/jobs", {
+        parameters: [{ name: "include_completed", in: "query" }],
+      }),
+    ).not.toBeNull();
+    expect(
+      describeAt("/corporations/{corporation_id}/industry/jobs", {
+        parameters: [
+          { name: "include_completed", in: "query" },
+          { name: "page", in: "query" },
+        ],
+      }),
+    ).not.toBeNull();
   });
 
   it("skips operations with no operationId", () => {
@@ -268,8 +291,8 @@ describe("renderEndpoint", () => {
 
   it("leaves a slot for query params when the endpoint takes them", () => {
     const source = renderEndpoint(
-      describeAt("/characters/{character_id}/blueprints", {
-        parameters: [{ name: "something", in: "query" }],
+      describeAt("/characters/{character_id}/industry/jobs", {
+        parameters: [{ name: "include_completed", in: "query" }],
       })!,
     );
 


### PR DESCRIPTION
Found while working the post-merge follow-ups from #685's review.

## Three hooks were silently returning one page

`useMultipleCharacterCalendar`, `useMultipleCharacterMail` and `useMultipleCharacterWalletTransactions` each returned only ESI's first page under a name promising every subject's whole collection — the exact failure the cursor-paginated corporation routes were skipped for.

They slipped through because **the spec does not declare them as paginated**. `x-pagination: cursor` appears on five operations, all unrelated:

```
/corporations/{id}/freelance-jobs, .../participants
/corporations/{id}/projects, .../contributors
/freelance-jobs
```

Meanwhile ESI pages the calendar by `from_event`, mail by `last_mail_id` and wallet transactions by `from_id` — silently. This repo already knows that: `esi-client/kubb.config.ts` declares infinite overrides for exactly those endpoints, and `useCharacterCalendar` / `useCharacterMails` implement the cursor walk by hand.

## The rule was backwards

The previous check looked for `after`/`before`. That is a denylist of the cursor names the spec happens to declare, so it could only ever catch what the spec had already labelled — useless against the three it doesn't.

Inverted to an allowlist. An endpoint is generated only when **every** query parameter is known not to affect completeness:

| Parameter | Why it's safe |
|---|---|
| `page` | walked in full by `esiPagedQueryOptions` |
| `include_completed` | a filter; its default is what the single-subject hooks already use |
| `labels` | a filter, same |

Anything unrecognised is assumed to be a cursor and the endpoint is skipped.

That makes the failure direction safe: a parameter added to the spec now makes a hook **disappear**, which someone notices, rather than quietly truncating one. The trade is a small hand-maintained allowlist — but it is three entries with stated reasons, versus an open-ended denylist that cannot be completed from the spec.

## Effect

**73 hooks, down from 76.** Both industry-jobs hooks are unaffected — `include_completed` is a filter, and the corporation one also has `page`, which is walked.

## Testing

The skip cases are now table-driven and include the three the spec doesn't declare, plus an invented `something_new` to pin the default-to-skip behaviour. A companion test asserts the filter-only endpoints are still generated, so the allowlist cannot quietly swallow them.

185 tests pass, type-check and lint clean, generation reproducible at 73 hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)