### PR TITLE
feat(web): show assets from every logged-in character

### DIFF
--- a/.changeset/assets-all-characters.md
+++ b/.changeset/assets-all-characters.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": minor
+---
+
+The Assets page now shows every logged-in character's assets at once instead of only the selected one, so items held across alts appear together — a station where two characters both keep things is one location holding everything, rather than one view per character. A "Filter by character" dropdown narrows it back down, and if a character's session can't be loaded the page says so instead of quietly leaving them out of a total that claims to cover everyone.
+
+One trade-off comes with it: assets are paged, and the page now waits for every character's pages before rendering rather than filling in as each page arrives. Expect a longer wait before the table appears, and less waiting overall — the pages are fetched concurrently rather than one after another.

--- a/apps/web/app/assets/character/page.tsx
+++ b/apps/web/app/assets/character/page.tsx
@@ -18,15 +18,14 @@ import {
 } from "@mantine/core";
 import { IconSearch, IconX } from "@tabler/icons-react";
 
-import { CharacterName } from "@jitaspace/eve-components";
+import { EveEntitySelect } from "@jitaspace/eve-components";
 import { AssetsIcon } from "@jitaspace/eve-icons";
 import {
-  useCharacterAssets,
   useEsiNameLookup,
   useMarketPrices,
-  useSelectedCharacter,
+  useMultipleCharacterAssets,
 } from "@jitaspace/hooks";
-import { CharacterAvatar, ISKAmount } from "@jitaspace/ui";
+import { ISKAmount } from "@jitaspace/ui";
 
 import { AssetSearchResults } from "~/components/Assets/AssetSearchResults";
 import { buildAssetTree } from "~/components/Assets/assetTree";
@@ -45,13 +44,40 @@ function Stat({ label, value }: Readonly<{ label: string; value: ReactNode }>) {
 }
 
 export default function Page() {
-  const character = useSelectedCharacter();
-  const { assets, isLoading } = useCharacterAssets(character?.characterId);
+  // Every logged-in character that granted the assets scope, not just the
+  // selected one. Each asset carries its owner as `subjectId`.
+  const {
+    data: allAssets,
+    isPending,
+    errors,
+  } = useMultipleCharacterAssets();
   const { data: marketPrices } = useMarketPrices();
 
+  const [selectedCharacterId, setSelectedCharacterId] = useState<string | null>(
+    null,
+  );
   const [query, setQuery] = useState("");
   const deferredQuery = useDeferredValue(query);
   const isSearching = deferredQuery.trim().length > 0;
+
+  const characterIds = useMemo(
+    () => [...new Set(allAssets.map((asset) => asset.subjectId))],
+    [allAssets],
+  );
+
+  // buildAssetTree keys on item_id and roots on location_id, and EVE item ids
+  // are globally unique — so merging several characters is safe, and a station
+  // holding two characters' items becomes one location rather than two.
+  const assets = useMemo(() => {
+    const owned =
+      selectedCharacterId === null
+        ? allAssets
+        : allAssets.filter(
+            (asset) =>
+              asset.subjectId === Number.parseInt(selectedCharacterId, 10),
+          );
+    return Object.fromEntries(owned.map((asset) => [asset.item_id, asset]));
+  }, [allAssets, selectedCharacterId]);
 
   // Resolve every distinct type name once, in a single batched lookup.
   const typeIds = useMemo(
@@ -88,24 +114,28 @@ export default function Page() {
             <Group gap="md" wrap="nowrap">
               <AssetsIcon width={48} />
               <Title order={1}>Assets</Title>
-              {(isLoading || unresolvedNames > 0) && <Loader size="sm" />}
+              {(isPending || unresolvedNames > 0) && <Loader size="sm" />}
             </Group>
-            {character && (
-              <Group gap="xs" wrap="nowrap">
-                <CharacterAvatar
-                  characterId={character.characterId}
-                  size="sm"
-                  radius="xl"
-                />
-                <CharacterName
-                  characterId={character.characterId}
-                  fw={500}
-                  size="sm"
-                  visibleFrom="xs"
-                />
-              </Group>
-            )}
+            <EveEntitySelect
+              size="xs"
+              label="Filter by character"
+              entityIds={characterIds.map((id) => ({ id }))}
+              searchable
+              allowDeselect
+              clearable
+              value={selectedCharacterId}
+              onChange={setSelectedCharacterId}
+            />
           </Group>
+
+          {errors.length > 0 && (
+            // A failed token drops that character's assets from a total that
+            // claims to cover everyone, so the absence has to be visible.
+            <Text c="dimmed" size="sm">
+              Could not load assets for {errors.length}{" "}
+              {errors.length === 1 ? "character" : "characters"}.
+            </Text>
+          )}
 
           <Paper withBorder radius="md" p="md">
             <SimpleGrid cols={3} spacing="md">
@@ -151,7 +181,7 @@ export default function Page() {
             }
           />
 
-          {isEmpty && isLoading && (
+          {isEmpty && isPending && (
             <Center mih={200}>
               <Group gap="xs">
                 <Loader size="sm" />
@@ -160,11 +190,16 @@ export default function Page() {
             </Center>
           )}
 
-          {isEmpty && !isLoading && (
+          {isEmpty && !isPending && (
             <Center mih={200}>
               <Stack align="center" gap={4}>
                 <AssetsIcon width={40} />
-                <Text c="dimmed">No assets found for this character.</Text>
+                {/* The filter only offers characters that own assets, so a
+                    filtered view is never empty — this is always the
+                    nothing-anywhere case. */}
+                <Text c="dimmed">
+                  No assets found for any of your characters.
+                </Text>
               </Stack>
             </Center>
           )}

--- a/apps/web/tests/characterAssetsPage.test.tsx
+++ b/apps/web/tests/characterAssetsPage.test.tsx
@@ -6,18 +6,27 @@ import { MantineProvider } from "@mantine/core";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 /**
- * Render test for the /assets/character page. The @jitaspace/hooks module is
- * mocked so the page renders with a fixed character + fixture assets; the
- * @jitaspace/ui + @jitaspace/eve-components imports resolve to the jest stubs
- * (whose TypeAnchor renders its children, so resolved item names are assertable
- * text). This covers the header, summary stats, loading/empty states and the
- * search ⇄ location-tree switch.
+ * Render test for the /assets/character page, which shows every logged-in
+ * character's assets. @jitaspace/hooks is mocked so the page renders with
+ * fixture assets tagged by owner; the @jitaspace/ui + @jitaspace/eve-components
+ * imports resolve to the jest stubs (whose TypeAnchor renders its children, so
+ * resolved item names are assertable text). Covers the header, summary stats,
+ * loading/empty states, the search ⇄ location-tree switch, the character
+ * filter, and the per-character failure notice.
  */
 
-const mockUseSelectedCharacter = jest.fn();
-const mockUseCharacterAssets =
+interface TaggedAsset {
+  item_id: number;
+  subjectId: number;
+  [key: string]: unknown;
+}
+const mockUseMultipleCharacterAssets =
   jest.fn<
-    (characterId?: number) => { assets: Record<number, object>; isLoading: boolean }
+    () => {
+      data: TaggedAsset[];
+      isPending: boolean;
+      errors: { subjectId: number; error: Error }[];
+    }
   >();
 const mockUseEsiNameLookup =
   jest.fn<() => Record<string, { value?: { name: string } } | undefined>>();
@@ -25,11 +34,38 @@ const mockUseMarketPrices =
   jest.fn<() => { data: Record<number, { adjusted_price?: number }> }>();
 
 jest.mock("@jitaspace/hooks", () => ({
-  useSelectedCharacter: () => mockUseSelectedCharacter(),
-  useCharacterAssets: (characterId?: number) =>
-    mockUseCharacterAssets(characterId),
+  useMultipleCharacterAssets: () => mockUseMultipleCharacterAssets(),
   useEsiNameLookup: () => mockUseEsiNameLookup(),
   useMarketPrices: () => mockUseMarketPrices(),
+}));
+
+// Keep the shared stub — the asset tree's children need its anchors — and only
+// override the select, so a character can actually be picked here.
+jest.mock("@jitaspace/eve-components", () => ({
+  ...jest.requireActual<Record<string, unknown>>(
+    "../__mocks__/@jitaspace/eve-components",
+  ),
+  EveEntitySelect: ({
+    label,
+    entityIds,
+    onChange,
+  }: {
+    label?: string;
+    entityIds?: { id: number }[];
+    onChange?: (value: string | null) => void;
+  }) => (
+    <div data-testid={`select:${label}`}>
+      {(entityIds ?? []).map(({ id }) => (
+        <button
+          key={id}
+          data-testid={`option:${id}`}
+          onClick={() => onChange?.(String(id))}
+        >
+          {id}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 jest.mock("@jitaspace/eve-icons", () => new Proxy({}, { get: () => () => null }));
@@ -39,14 +75,17 @@ jest.mock("~/components/ScopeGuard", () => ({
   ScopeGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-// A Rifter (with one fitted module) and a Tritanium stack, both in Jita.
+// A Rifter (with one fitted module) belonging to one character, and a Tritanium
+// stack belonging to another — both in Jita, so they share a root location.
 const JITA = 60003760;
 const SHIP = 1001;
-const SAMPLE_ASSETS = {
-  1001: { item_id: SHIP, type_id: 587, quantity: 1, location_id: JITA, location_flag: "Hangar", location_type: "station", is_singleton: true },
-  2001: { item_id: 2001, type_id: 3001, quantity: 1, location_id: SHIP, location_flag: "HiSlot0", location_type: "item", is_singleton: true },
-  1002: { item_id: 1002, type_id: 34, quantity: 500, location_id: JITA, location_flag: "Hangar", location_type: "station", is_singleton: false },
-};
+const MAIN = 123456789;
+const ALT = 987654321;
+const SAMPLE_ASSETS: TaggedAsset[] = [
+  { item_id: SHIP, subjectId: MAIN, type_id: 587, quantity: 1, location_id: JITA, location_flag: "Hangar", location_type: "station", is_singleton: true },
+  { item_id: 2001, subjectId: MAIN, type_id: 3001, quantity: 1, location_id: SHIP, location_flag: "HiSlot0", location_type: "item", is_singleton: true },
+  { item_id: 1002, subjectId: ALT, type_id: 34, quantity: 500, location_id: JITA, location_flag: "Hangar", location_type: "station", is_singleton: false },
+];
 
 function renderPage() {
   const Page = require("~/app/assets/character/page").default;
@@ -59,13 +98,10 @@ function renderPage() {
 
 describe("Character Assets Page", () => {
   beforeEach(() => {
-    mockUseSelectedCharacter.mockReturnValue({
-      characterId: 123456789,
-      accessTokenPayload: { scp: ["esi-assets.read_assets.v1"] },
-    });
-    mockUseCharacterAssets.mockReturnValue({
-      assets: SAMPLE_ASSETS,
-      isLoading: false,
+    mockUseMultipleCharacterAssets.mockReturnValue({
+      data: SAMPLE_ASSETS,
+      isPending: false,
+      errors: [],
     });
     mockUseEsiNameLookup.mockReturnValue({
       "587": { value: { name: "Rifter" } },
@@ -85,9 +121,59 @@ describe("Character Assets Page", () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("passes the selected character id to the assets hook", () => {
+  it("merges characters sharing a location into one root", () => {
     renderPage();
-    expect(mockUseCharacterAssets).toHaveBeenCalledWith(123456789);
+    // Both characters keep things in Jita, so it is one location holding all
+    // three stacks rather than two locations of the same station.
+    expect(screen.getByText("3 items")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("narrows to one character's assets when that character is picked", () => {
+    renderPage();
+    expect(screen.getByText("3 items")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId(`option:${ALT}`));
+
+    // Only the alt's Tritanium stack remains.
+    expect(screen.getByText("1 item")).toBeInTheDocument();
+    expect(screen.queryByText("Rifter")).not.toBeInTheDocument();
+  });
+
+  it("offers one filter option per character that owns assets", () => {
+    renderPage();
+    expect(screen.getByTestId(`option:${MAIN}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`option:${ALT}`)).toBeInTheDocument();
+    // Options come from the assets themselves, which is why a filtered view is
+    // never empty and the empty state only has one wording.
+    expect(screen.getAllByTestId(/^option:/)).toHaveLength(2);
+  });
+
+  it("says how many characters failed rather than omitting them silently", () => {
+    mockUseMultipleCharacterAssets.mockReturnValue({
+      data: SAMPLE_ASSETS,
+      isPending: false,
+      errors: [{ subjectId: ALT, error: new Error("boom") }],
+    });
+    renderPage();
+    expect(
+      screen.getByText(/could not load assets for 1 character\./i),
+    ).toBeInTheDocument();
+  });
+
+  it("pluralises when several characters failed", () => {
+    mockUseMultipleCharacterAssets.mockReturnValue({
+      data: SAMPLE_ASSETS,
+      isPending: false,
+      errors: [
+        { subjectId: MAIN, error: new Error("boom") },
+        { subjectId: ALT, error: new Error("boom") },
+      ],
+    });
+    renderPage();
+    expect(
+      screen.getByText(/could not load assets for 2 characters\./i),
+    ).toBeInTheDocument();
   });
 
   it("auto-expands the sole location so its contents are visible", () => {
@@ -113,16 +199,25 @@ describe("Character Assets Page", () => {
   });
 
   it("shows a loading state while the first assets are still loading", () => {
-    mockUseCharacterAssets.mockReturnValue({ assets: {}, isLoading: true });
+    mockUseMultipleCharacterAssets.mockReturnValue({
+      data: [],
+      isPending: true,
+      errors: [],
+    });
     renderPage();
     expect(screen.getByText("Loading your assets…")).toBeInTheDocument();
   });
 
-  it("shows an empty state when the character owns nothing", () => {
-    mockUseCharacterAssets.mockReturnValue({ assets: {}, isLoading: false });
+  it("shows an empty state when no character owns anything", () => {
+    mockUseMultipleCharacterAssets.mockReturnValue({
+      data: [],
+      isPending: false,
+      errors: [],
+    });
     renderPage();
     expect(
-      screen.getByText(/No assets found for this character/),
+      screen.getByText(/No assets found for any of your characters/),
     ).toBeInTheDocument();
   });
+
 });


### PR DESCRIPTION
The first real adoption of the generated multi-subject hooks. 73 shipped with #685 and #704; until now exactly one was used.

## What changes

`/assets/character` queried only the selected character. It now uses `useMultipleCharacterAssets`, with a **Filter by character** select and a notice naming how many characters failed to load — the same shape as the fittings page.

Merging is safe, and is the point. `buildAssetTree` keys on `item_id` and roots on `location_id`, and EVE item ids are globally unique — so a station where two characters both keep things becomes **one** location holding everything, rather than two copies of the same station. That is the "which alt has my Tritanium" view. Filtering rebuilds the tree from that character's assets alone.

## The trade-off, taken deliberately

Assets are paged, and `esiPagedQueryOptions` resolves only once every page is in. The table no longer fills in progressively — loading is keyed off `isPending` rather than `isLoading` to match.

So the first paint is later, but the total wait is shorter: `esiPagedQueryOptions` fetches pages through a concurrency pool, where the previous infinite+eager approach walked them strictly one at a time. Net, more characters' assets arrive sooner; they just arrive together.

This was the open question from #708 and it is a product call, so it is worth stating plainly rather than burying: the alternative is keeping the page single-character.

## One thing I removed

I first wrote two empty-state wordings, one for "no character owns anything" and one for a filtered view. Coverage refused to move on the second, which is how I noticed it is unreachable: the filter's options are derived from the assets themselves, so filtering to a character always yields at least one asset. Dropped the branch and added a test pinning that premise instead.

## Testing

`characterAssetsPage.test.tsx` rewritten for the multi hook, with fixtures owned by two different characters sharing a location. Covers the merge into one root, narrowing by filter, the option list, the failure notice (singular and plural), and both loading and empty states.

- `apps/web`: 1030 tests pass, page at **100%** on every metric
- `pnpm lint`: 0 errors
- `tsc`: 0 errors

**Not verified in a browser** — the page needs authenticated EVE SSO sessions across several characters, which I cannot create, and this worktree has no `.env`. The test renders the real page component, so the merge, filter and states are exercised there, but nobody has seen this on screen with live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)