### PR TITLE
ci: raise the Sonar JS/TS analyzer Node heap to 8 GB

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,15 @@
 sonar.projectKey=joaomlneto_jitaspace
 sonar.organization=joaomlneto
 
+# Node heap for the JS/TS analyzer. The default is 4288 MB, which the repo
+# outgrew: every run reports "Miss the cache for 1348 out of 1348" and then dies
+# with "The analysis will stop due to the Node.js process running out of memory
+# (heap size limit 4288 MB)", taking the bridge server with it ("Received
+# Goaway"). That failed the scan — and therefore the quality gate — on every
+# branch from 2026-08-09 onward. The runner has ~16 GB, so 8 GB for Node still
+# leaves ample room for the scanner JVM and the OS.
+sonar.javascript.node.maxspace=8192
+
 sonar.sources=apps/web/app,apps/web/components,packages
 sonar.exclusions=**/node_modules/**,**/.next/**,**/dist/**,**/generated/**,**/*.generated.ts,**/coverage/**,**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/jest.config.ts,**/jest.setup.ts,**/env.ts,**/kubb.config.ts,**/scripts/generate-scopes.ts
 


### PR DESCRIPTION
## The problem

Every SonarCloud run has failed since **2026-08-09** — on `main` as well as unrelated `renovate/*` branches and open PRs. It is not a quality gate failure. The scan aborts before it evaluates anything:

```
INFO  Memory configuration: OS (15989 MB), Node.js (4288 MB).
INFO  Miss the cache for 1348 out of 1348: FILE_CHANGED
ERROR The analysis will stop due to the Node.js process running out of memory (heap size limit 4288 MB)
ERROR Try setting "sonar.javascript.node.maxspace" to a higher value to increase Node.js heap size limit
ERROR The bridge server is unresponsive ...
Caused by: io.grpc.StatusRuntimeException: UNAVAILABLE ... Received Goaway
```

The repo outgrew the analyzer's 4288 MB default. The cache also misses on all 1348 files each run, so every run pays for a full analysis rather than an incremental one.

## The fix

Set the property Sonar's own error message names, in `sonar-project.properties`:

```properties
sonar.javascript.node.maxspace=8192
```

The runner reports ~16 GB, so 8 GB for Node leaves ample headroom for the scanner JVM and the OS. No thresholds or exclusions are changed — this only lets the existing gate run.

## Why this matters beyond a red check

Because the scan dies *before* evaluating, **the quality gate has silently not run on any PR for days.** A PR can look fine while its coverage was never actually measured — the "coverage on New Code" badge on a recent PR turned out to be from an older commit, with the newest code unmeasured. This restores the gate.

## Verification

The honest limit: `8192` is chosen from the reported headroom (16 GB total, 4288 MB default), not from a measured high-water mark — the failure gives a floor, not a required ceiling. **This PR's own SonarCloud run is the test**: if the scan completes here, the value is sufficient. If it still OOMs, the number needs raising again, and that will be visible immediately on this PR rather than inferred.

Locally verified that the change lints clean and touches nothing else (one property plus a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)