### PR TITLE
docs: sync AGENTS.md and copilot-instructions with CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 Turborepo monorepo for an EVE Online companion web application. Two apps (`apps/web`, `apps/cli`) and 20+ shared packages under `packages/`. The main product is `apps/web`, a Next.js 16 app deployed to Vercel. Background jobs run on Trigger.dev (the `background-jobs-triggerdev` adapter); there is no `apps/worker`.
 
-**Tech stack:** Node.js >=24.15.0 · TypeScript 5.9 · Next.js 16 · React 19 · Mantine 8 · TanStack Query 5 · Prisma 7 + PostgreSQL · EVE Online SSO (OAuth2 + PKCE) · Trigger.dev · Turborepo 2 · pnpm 11.3.0
+**Tech stack:** Node.js >=24.15.0 · TypeScript 5.9 · Next.js 16 · React 19 · Mantine 9 · TanStack Query 5 · Prisma 7 + PostgreSQL · EVE Online SSO (OAuth2 + PKCE) · Trigger.dev · Turborepo 2 · pnpm 11.3.0
 
 ---
 
@@ -51,7 +51,7 @@ Turbo's `build` task declares these as dependencies, but always run them explici
 SKIP_ENV_VALIDATION=1 pnpm build   # Build all packages and apps via Turbo
 ```
 
-`build` outputs to `.next/**` (web) and `dist/**` (packages). The web app sets `typescript.ignoreBuildErrors: true` in CI (`apps/web/next.config.mjs`) so TypeScript errors do not fail the Next.js build in CI, but they still fail `pnpm type-check`.
+`build` outputs to `.next/**` (web) and `dist/**` (packages). The web app sets `typescript.ignoreBuildErrors: true` in CI (`apps/web/next.config.mjs`) so TypeScript errors do not fail the Next.js _build_ — the dedicated `type-check.yml` workflow catches them instead, and it is a hard gate: the repo is expected to be green.
 
 ---
 
@@ -77,12 +77,19 @@ pnpm test                          # Jest unit tests across workspaces (generate
 
 ## Continuous Integration
 
-Two GitHub Actions workflows run on every push:
+Three GitHub Actions workflows run on every push:
+
+**Type Check** (`.github/workflows/type-check.yml`):
+
+- Sequence: `pnpm install --frozen-lockfile` → `pnpm type-check`
+- A hard gate — a type error fails the PR. No explicit codegen step: the turbo `type-check` task depends on the Prisma and Kubb generators, so a clean checkout produces them itself.
+- Uses `SKIP_ENV_VALIDATION=1`
 
 **Cypress Tests** (`.github/workflows/cypress.yml`):
 
 - Requires CockroachDB (v24.3.7) and Redis services
-- Sequence: `pnpm install` → push DB schema (`cd packages/db && pnpm exec prisma db push`) → `pnpm build` → start web server → Cypress E2E (parallel, 2 containers)
+- Sequence: `pnpm install` → push DB schema (`cd packages/db && pnpm exec prisma db push`) → `pnpm build` → start web server → run Cypress (parallel, 2 containers)
+- NOT end-to-end coverage: the specs under `apps/web/cypress/e2e/` are still the stock Cypress example suite and target `example.cypress.io`, so this job effectively gates "the build succeeds and the server boots".
 - Uses `SKIP_ENV_VALIDATION=1`
 
 **SonarCloud** (`.github/workflows/sonarcloud.yml`):
@@ -141,4 +148,4 @@ When a new `@jitaspace/*` package exports TypeScript source and needs to be impo
 
 ---
 
-Trust these instructions. Only search the codebase if the information here appears incomplete or incorrect.
+Prefer these instructions over re-deriving the basics, but verify before relying on any specific claim: version numbers, CI gates and "currently broken" statements drift as the repo changes, and this file is not always updated in the same PR. `CLAUDE.md` is the most actively maintained of the three agent docs — if they disagree, believe it, and fix this one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is a concise, actionable guide for automated coding agents (or humans)
 
 Big picture
 
-- Monorepo (Turborepo) containing two apps (apps/web, apps/cli) and many internal packages under `packages/` (db, auth, esi-client, esi-metadata, ui, utils, etc.). Background jobs run on Trigger.dev (the `background-jobs-triggerdev` adapter over the platform-agnostic `background-jobs` package); there is no `apps/worker`. See `CLAUDE.md` for a short overview.
+- Monorepo (Turborepo) containing two apps (apps/web, apps/cli) and many internal packages under `packages/` (db, db-history, auth, esi-client, esi-metadata, ui, eve-components, utils, etc. — `ui` is presentational only; the data-aware EVE components live in `eve-components`). Background jobs run on Trigger.dev (the `background-jobs-triggerdev` adapter over the platform-agnostic `background-jobs` package); there is no `apps/worker`. See `CLAUDE.md` for a short overview.
 - The web app (`apps/web`) is a Next.js 16 app that imports many local packages via `@jitaspace/*`. Local packages are consumed directly in source (see `apps/web/next.config.mjs` → `transpilePackages`).
 - Data layer: Prisma (packages/db) with a large schema at `packages/db/prisma/schema.prisma`. Database client is generated into the package (run `pnpm db:generate`).
 - API clients: generated with Kubb from OpenAPI specs (see `packages/esi-client/kubb.config.ts` and `packages/*-client/*/swagger.json`). Generated code lives under each client package (e.g. `packages/esi-client/src/generated`). Do NOT edit generated files.
@@ -69,7 +69,10 @@ pnpm build
 ```zsh
 pnpm test           # turbo test across workspaces
 pnpm test:watch     # watch mode
-# E2E: apps/web has cypress scripts; root package.json exposes helpers `cypress:run`/`cypress:open` that cd into apps/web
+# Cypress: apps/web has cypress scripts; root package.json exposes `cypress:run`/`cypress:open` that cd into apps/web.
+# NOT E2E coverage — the specs under apps/web/cypress/e2e/ are still the stock Cypress
+# example suite and target example.cypress.io, so CI's Cypress job gates only that the
+# build succeeds and the server boots.
 ```
 
 - Lint & format:

--- a/apps/web/lib/history-cache.ts
+++ b/apps/web/lib/history-cache.ts
@@ -130,6 +130,14 @@ export async function getCachedEntityTimeline(
   entityId: number,
 ): Promise<EntityTimeline | null> {
   "use cache";
+  // Load-bearing beyond freshness: `getEntityTimeline` is the one history reader
+  // left WITHOUT a `checkBotId()` guard, so that `/type/*` can stay out of the
+  // BotID protect list (see instrumentation-client.ts — a protect entry gates
+  // every Server Action on those pages, including the app-wide token refresh).
+  // What makes leaving it open acceptable is that entries here EXPIRE, so an
+  // automated caller's cache footprint has a bounded ceiling. Moving this to
+  // `cacheLife("max")` would remove that ceiling and invalidate the trade —
+  // guard the action, or accept unbounded growth from unauthenticated callers.
   cacheLife("days");
 
   if (!Number.isInteger(entityId)) return null;

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,9 +10,16 @@ overrides:
   "prosemirror-state": "1.4.4"
   "prosemirror-transform": "1.12.0"
   "prosemirror-view": "1.41.8"
-  # next declares optionalDependencies.sharp "^0.34.5"; without this override pnpm
-  # keeps a nested vulnerable copy that Next's image pipeline resolves in preference
-  # to apps/web's own. Covers GHSA-f88m-g3jw-g9cj (libvips memory safety).
+  # Load-bearing, and not for the reason it looks like. next declares
+  # optionalDependencies.sharp "^0.34.5", which is incompatible with apps/web's
+  # "^0.35.3" — so under nodeLinker: hoisted pnpm HOISTS NEXT'S 0.34.5 to the root
+  # and nests apps/web's 0.35.3 under apps/web/node_modules. next resolves the root
+  # copy, i.e. the vulnerable one, and bumping apps/web alone does not protect the
+  # image pipeline. Measured by deleting this override and reinstalling:
+  #   ./node_modules/sharp            -> 0.34.5   (what next loads)
+  #   ./apps/web/node_modules/sharp   -> 0.35.3
+  # With it: one copy at 0.35.3, zero sharp@0.34 entries in the lockfile.
+  # Covers GHSA-f88m-g3jw-g9cj (libvips memory safety).
   # Caret, not an exact pin: an override replaces the importer's own specifier
   # outright, so pinning here would freeze the patch level this exists to raise
   # and a later manifest bump would install nothing.


### PR DESCRIPTION
Follow-up to #676, which corrected CLAUDE.md and left the two sibling docs contradicting it. That is a worse state than before: `CLAUDE.md:9` asks for all three to be kept consistent, and `copilot-instructions.md` closed by telling its reader **not** to verify.

## `.github/copilot-instructions.md`

- **Mantine 8 → 9** — every consumer is on 9.3.0.
- **Three workflows, not two.** Documents `type-check.yml` as a hard gate, and reframes `ignoreBuildErrors` accordingly: it exempts the Next *build*, and the dedicated workflow is what actually catches type errors.
- **Cypress marked as NOT E2E coverage** — the specs are still the stock example suite pointed at `example.cypress.io`, so that job gates "the build succeeds and the server boots".
- **Replaced the closing instruction.** It previously read *"Trust these instructions. Only search the codebase if the information here appears incomplete or incorrect."* That sentence is what makes staleness self-perpetuating — it tells the reader to trust exactly the class of claim that drifts fastest (versions, CI gates, "currently broken"). It now says to verify those, and to believe CLAUDE.md where the docs disagree.

## `AGENTS.md`

- Package map gains `db-history` and `eve-components`, and notes `ui` is presentational only since the split.
- Corrects the "E2E" description of the Cypress scripts.

## Two corrections to #676 itself

**`pnpm-workspace.yaml` — the sharp override comment described the wrong mechanism.** Measured by deleting the override and reinstalling:

```
./node_modules/sharp          -> 0.34.5   ← hoisted; what next resolves
./apps/web/node_modules/sharp -> 0.35.3   ← nested
```

pnpm hoists **next's** `^0.34.5` to the root and nests apps/web's `0.35.3`, so next loads the vulnerable copy and bumping `apps/web` alone does not protect the image pipeline. The old comment claimed the reverse (a nested vulnerable copy) — which would invite someone to delete the override after looking for that copy, not finding it, and concluding it was obsolete. The observed layout is now in the comment. With the override: one copy at 0.35.3, zero `sharp@0.34` lockfile entries.

**`apps/web/lib/history-cache.ts`** — records at the `cacheLife("days")` call why that value is load-bearing. `getEntityTimeline` is the one history reader left unguarded (so `/type/*` can stay out of the BotID protect list), and what makes that acceptable is that its entries *expire*, giving an automated caller a bounded ceiling. Moving it to `cacheLife("max")` would silently invalidate that trade — and this is where someone would make that change, not `instrumentation-client.ts` where the reasoning previously lived alone.

## Verification

Docs-only plus two comments. `prettier --check` clean, `tsc --noEmit` in `apps/web` reports 0 errors, `pnpm install --frozen-lockfile` is a no-op (the YAML still parses), and the pre-commit lint hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)