### PR TITLE
fix(turbo): stop excluding CSS, public/ and next.config.mjs from the build hash

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -63,7 +63,13 @@
     },
     "build": {
       "dependsOn": ["^build", "db:generate", "^db:generate", "kubb:generate"],
-      "inputs": ["**/*.ts", "**/*.tsx", "package.json", "tsconfig.json"],
+      // No `inputs` override: Turbo's default hashes every git-tracked file in
+      // the package, which is what a build actually depends on. The previous
+      // narrowing to ts/tsx/package.json/tsconfig.json silently excluded CSS
+      // modules, `public/`, and next.config.mjs (the CSP, security headers and
+      // redirects) — so a commit touching only those produced an identical hash,
+      // hit the remote cache, and restored a `.next` that predated the change.
+      // Vercel builds through this task, so that shipped to production.
       "outputs": [
         ".next/**",
         "!.next/cache/**",
@@ -78,14 +84,8 @@
     },
     "lint": {
       "dependsOn": ["^topo"],
-      "inputs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "package.json",
-        "tsconfig.json",
-        ".eslintrc*",
-        "eslint.config.*"
-      ],
+      // Unnarrowed for the same reason: ESLint also covers .mjs/.cjs sources
+      // (e.g. apps/web/scripts/*.mjs), which the previous list excluded.
       "outputs": ["node_modules/.cache/.eslintcache"]
     },
     "lint:fix": {},
@@ -123,7 +123,9 @@
       // client is generated, gitignored, and its types are what `@jitaspace/db`
       // and everything downstream is checked against.
       "dependsOn": ["^topo", "db:generate", "^db:generate", "kubb:generate"],
-      "inputs": ["**/*.ts", "**/*.tsx", "package.json", "tsconfig.json"],
+      // Also unnarrowed: the base tsconfig sets `checkJs` and apps/web includes
+      // ".", so .mjs/.cjs files are in the program — a type error in
+      // next.config.mjs would otherwise be masked by a cache hit.
       "outputs": ["node_modules/.cache/tsbuildinfo.json"]
     },
     "deploy": {


### PR DESCRIPTION
The `build` task narrowed `inputs` to `["**/*.ts", "**/*.tsx", "package.json", "tsconfig.json"]`, discarding Turbo's default of hashing every git-tracked file in the package. The excluded files aren't incidental: **CSS modules compile into `.next` chunks**, and **`next.config.mjs` carries the CSP, security headers and redirects**.

So a commit touching only those produced an identical task hash → cache hit → restored a `.next` that predates the change. Remote caching is active in both workflows (`TURBO_TOKEN`/`TURBO_TEAM`) and **Vercel builds through this task** (`apps/web/vercel.json` runs `turbo run build --filter=@jitaspace/web`), so the stale artifact is what gets deployed.

## Measured, not inferred

Editing a file on `main`, then re-running `turbo run build --filter=@jitaspace/web --dry=json`:

| | hash | |
| --- | --- | --- |
| baseline | `8a5a2c14b925e3fb` | 611 files hashed |
| after editing `app/globals.css` | `8a5a2c14b925e3fb` | **unchanged** |
| after editing `next.config.mjs` | `8a5a2c14b925e3fb` | **unchanged** |

0 of apps/web's 28 tracked `.css` files, 0 of the 51 files under `public/`, and `next.config.mjs` appeared in the hashed set.

After removing the override:

| | hash | |
| --- | --- | --- |
| baseline | `fb664edcb0effbc2` | 703 files (28 css, 51 public, next.config) |
| after editing `app/globals.css` | `9d11ac2d20ddd77f` | changed ✅ |
| after editing `next.config.mjs` | `45100fd8c456abe8` | changed ✅ |
| after editing `public/…` | `82088647dd257680` | changed ✅ |

## `type-check` and `lint` too — for their own reasons, not symmetry

- **type-check**: the base tsconfig sets `checkJs` and `apps/web/tsconfig.json` includes `"."`, so `.mjs`/`.cjs` files are in the program. A type error introduced in `next.config.mjs` was maskable by a cache hit — which matters more now that `type-check.yml` is a gate.
- **lint**: ESLint also covers `.mjs` sources such as `apps/web/scripts/*.mjs`, excluded by the old list.

The narrow `inputs` on `db:generate` / `kubb:generate` are deliberate and untouched — those genuinely depend only on a schema or a spec.

## Cost

The build task now invalidates on any tracked file in the package, so README and asset edits will miss the cache where they previously hit it. That's the right trade against deploying an artifact that silently lacks the change — the failure mode is invisible (green CI, successful deploy, missing change) and would be extremely hard to diagnose from the symptom.

## Verification

- `pnpm type-check` — 40/40
- `pnpm lint` — 26/26, manypkg valid
- `CI=1 pnpm build` — 17/17 against a throwaway CockroachDB
- `pnpm test` — 30/30 (one local `WalletTable` timeout under parallel load; passes 6/6 in isolation and in CI)

No changeset: no user-visible change, per the CLAUDE.md policy — though it does mean the *next* CSS or config change actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)