### PR TITLE
fix(web): make the sitemap emit absolute URLs and cover every static-data entity

### DIFF
--- a/.changeset/absolute-sitemap-urls.md
+++ b/.changeset/absolute-sitemap-urls.md
@@ -2,4 +2,4 @@
 "@jitaspace/web": patch
 ---
 
-Fixed the sitemap so search engines can actually find the site. Every URL it listed was written as a relative path, which crawlers discard — so none of the site's pages were being submitted. The sitemap now also covers solar systems, stations, regions, constellations, item groups and categories, dogma attributes and effects, factions, races, bloodlines and LP stores, instead of items alone, and no longer advertises pages that require a logged-in character.
+Fixed the sitemap so search engines can actually find the site. Every URL it listed was written as a relative path, which crawlers discard — so none of the site's pages were being submitted. The sitemap now also covers solar systems, stations, regions, constellations, item groups and categories, factions, races, bloodlines and LP stores, instead of items alone, and no longer advertises pages that require a logged-in character.

--- a/.changeset/absolute-sitemap-urls.md
+++ b/.changeset/absolute-sitemap-urls.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the sitemap so search engines can actually find the site. Every URL it listed was written as a relative path, which crawlers discard — so none of the site's pages were being submitted. The sitemap now also covers solar systems, stations, regions, constellations, item groups and categories, dogma attributes and effects, factions, races, bloodlines and LP stores, instead of items alone, and no longer advertises pages that require a logged-in character.

--- a/.changeset/index-travel-and-ship-scanner.md
+++ b/.changeset/index-travel-and-ship-scanner.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+The route planner and ship scanner can now be found through search engines. Both pages work without logging in, but robots.txt had been telling crawlers to skip them, so they never appeared in Google results. They are now allowed and listed in the sitemap.

--- a/.changeset/sitemap-index.md
+++ b/.changeset/sitemap-index.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Added a sitemap index at `/sitemap.xml`. Search engines look for that address first, and it used to return "not found" — the actual sitemap pages were only reachable if a crawler read robots.txt. The index now lists them all, and robots.txt points at it, so any future sitemap pages are picked up automatically.

--- a/.changeset/sitemap-index.md
+++ b/.changeset/sitemap-index.md
@@ -2,4 +2,4 @@
 "@jitaspace/web": patch
 ---
 
-Added a sitemap index at `/sitemap.xml`. Search engines look for that address first, and it used to return "not found" — the actual sitemap pages were only reachable if a crawler read robots.txt. The index now lists them all, and robots.txt points at it, so any future sitemap pages are picked up automatically.
+Added a sitemap index at `/sitemap.xml`. Search engines look for that address first, and it used to return "not found" — the actual sitemap pages were only reachable if a crawler read robots.txt. The index now lists them all, and robots.txt points at it, so it stays correct as pages are added across deploys.

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 import { CRAWLER_DISALLOWED_PATHS } from "~/config/seo.ts";
-import { SITEMAP_INDEX_URL } from "./sitemap";
+import { FIRST_SITEMAP_PAGE_URL, SITEMAP_INDEX_URL } from "./sitemap";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -10,8 +10,22 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: [...CRAWLER_DISALLOWED_PATHS],
     },
-    // One entry, not the enumerated pages: the index at /sitemap.xml expands to
-    // every /sitemap/{n}.xml, so a new page needs no change here.
-    sitemap: SITEMAP_INDEX_URL,
+    // The index expands to every /sitemap/{n}.xml, so adding a page needs no
+    // change here. Page 0 is listed beside it deliberately, as insurance.
+    //
+    // The index only answers at /sitemap.xml through a `beforeFiles` rewrite in
+    // next.config.mjs, and nothing verifies that end to end: Cypress boots the
+    // server but never requests it, the jest tests call the route handler
+    // directly, and Vercel resolves `beforeFiles` in its own routing layer
+    // rather than Next's. If that rewrite ever fails to survive the Build
+    // Output API, the index 404s — and without this second entry, nothing would
+    // point a crawler at the sitemap at all, which is worse than the broken
+    // state this replaced. Page 0 always serves, so it degrades instead.
+    //
+    // REMOVE THIS ENTRY once https://www.jita.space/sitemap.xml is confirmed
+    // serving <sitemapindex> in production, together with the ordering
+    // assertion in tests/sitemap.test.ts. Until then it is load-bearing; after
+    // that it is only a puzzle.
+    sitemap: [SITEMAP_INDEX_URL, FIRST_SITEMAP_PAGE_URL],
   };
 }

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,17 +1,17 @@
 import type { MetadataRoute } from "next";
 
 import { CRAWLER_DISALLOWED_PATHS } from "~/config/seo.ts";
-import { getSitemapUrls } from "./sitemap";
+import { SITEMAP_INDEX_URL } from "./sitemap";
 
-export default async function robots(): Promise<MetadataRoute.Robots> {
-  const sitemapUrls = await getSitemapUrls();
-
+export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
       allow: "/",
       disallow: [...CRAWLER_DISALLOWED_PATHS],
     },
-    sitemap: sitemapUrls,
+    // One entry, not the enumerated pages: the index at /sitemap.xml expands to
+    // every /sitemap/{n}.xml, so a new page needs no change here.
+    sitemap: SITEMAP_INDEX_URL,
   };
 }

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 
+import { CRAWLER_DISALLOWED_PATHS } from "~/config/seo.ts";
 import { getSitemapUrls } from "./sitemap";
 
 export default async function robots(): Promise<MetadataRoute.Robots> {
@@ -9,21 +10,7 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: [
-        "/assets",
-        "/calendar",
-        "/contacts",
-        "/debug",
-        "/fittings",
-        "/login",
-        "/mail",
-        "/notifications",
-        "/settings",
-        "/ship-scanner",
-        "/skills",
-        "/travel",
-        "/wallet",
-      ],
+      disallow: [...CRAWLER_DISALLOWED_PATHS],
     },
     sitemap: sitemapUrls,
   };

--- a/apps/web/app/sitemap-index.xml/route.ts
+++ b/apps/web/app/sitemap-index.xml/route.ts
@@ -1,0 +1,60 @@
+import { connection } from "next/server";
+
+import { getSitemapUrls, LAST_MODIFIED } from "../sitemap";
+
+/**
+ * The sitemap index, served at `/sitemap.xml` via a `beforeFiles` rewrite in
+ * `next.config.mjs`.
+ *
+ * It cannot live at `app/sitemap.xml/route.ts`: Next reserves `/sitemap.xml`
+ * for the `app/sitemap.ts` metadata convention and fails the whole app with
+ * "Conflicting route and metadata at /sitemap.xml" — even though that reserved
+ * route only ever 404s once `generateSitemaps()` moves the real pages to
+ * `/sitemap/{n}.xml`. The rewrite has to be `beforeFiles` for the same reason:
+ * afterFiles would lose to the reserved route and keep serving the 404.
+ *
+ * Why bother: `/sitemap.xml` is the path crawlers probe unprompted, and until
+ * now it 404'd, so the numbered pages were reachable only via robots.txt.
+ *
+ * Built from the same `getSitemapUrls()` that robots.txt advertises, so index,
+ * robots.txt and the servable pages cannot disagree about how many exist.
+ */
+
+const XML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+// The origin comes from NEXT_PUBLIC_SITE_URL, so it is not structurally
+// guaranteed to be XML-safe even though the paths appended to it are numeric.
+const escapeXml = (value: string) =>
+  value.replace(/[&<>"']/g, (char) => XML_ESCAPES[char] ?? char);
+
+export async function GET(): Promise<Response> {
+  // Request-time, not build-time: the page count comes from the database, which
+  // is unreachable during the CI build. `connection()` is the
+  // `cacheComponents`-blessed opt-out — `export const dynamic` is disallowed.
+  await connection();
+
+  const lastmod = LAST_MODIFIED.toISOString();
+  const entries = (await getSitemapUrls())
+    .map(
+      (url) =>
+        `  <sitemap>\n    <loc>${escapeXml(url)}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </sitemap>`,
+    )
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</sitemapindex>\n`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      // Matches the one-hour URL cache in ./sitemap.ts — the index only changes
+      // when the page count crosses a 50,000-URL boundary.
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -44,6 +44,9 @@ const isDynamicSegment = (name: string) => name.includes("[");
 const isRouteGroup = (name: string) =>
   name.startsWith("(") && name.endsWith(")");
 const isParallelSegment = (name: string) => name.startsWith("@");
+/** `[[...waypoints]]` — matches zero segments, so it also serves its parent. */
+const isOptionalCatchAll = (name: string) =>
+  name.startsWith("[[...") && name.endsWith("]]");
 
 /** A family of database-backed URLs, e.g. every `/system/{solarSystemId}`. */
 interface EntitySource {
@@ -233,8 +236,8 @@ async function collectStaticRoutes(): Promise<string[]> {
 
   async function walk(dir: string, segments: string[]) {
     const entries = await readdir(dir, { withFileTypes: true });
+    const routePath = segments.length === 0 ? "/" : `/${segments.join("/")}`;
     if (entries.some((entry) => entry.isFile() && isPageFile(entry.name))) {
-      const routePath = segments.length === 0 ? "/" : `/${segments.join("/")}`;
       routes.add(routePath);
     }
 
@@ -242,7 +245,21 @@ async function collectStaticRoutes(): Promise<string[]> {
       if (!entry.isDirectory()) continue;
       if (entry.name.startsWith(".")) continue;
       if (entry.name === "node_modules") continue;
-      if (isDynamicSegment(entry.name)) continue;
+      if (isDynamicSegment(entry.name)) {
+        // An optional catch-all matches zero segments, so it also answers its
+        // parent path: `app/travel/[[...waypoints]]/page.tsx` serves `/travel`,
+        // and nothing else in the tree would register that route. Every other
+        // dynamic segment needs an id, which comes from ENTITY_SOURCES instead.
+        if (isOptionalCatchAll(entry.name)) {
+          const nested = await readdir(join(dir, entry.name), {
+            withFileTypes: true,
+          });
+          if (nested.some((e) => e.isFile() && isPageFile(e.name))) {
+            routes.add(routePath);
+          }
+        }
+        continue;
+      }
 
       const nextSegments =
         isRouteGroup(entry.name) || isParallelSegment(entry.name)

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -16,8 +16,10 @@ const LAST_MODIFIED = env.NEXT_PUBLIC_MODIFIED_DATE
 /**
  * `url` without its trailing slashes.
  *
- * Written as a scan rather than a `/\/+$/` replace: that pattern backtracks
- * super-linearly on a run of slashes.
+ * Written as a scan rather than a `/\/+$/` replace only because that pattern is
+ * super-linear in general — on a run of slashes *away* from the end (`"///a"`)
+ * it retries at every position. A trailing run, which is all this function is
+ * ever handed, is the cheap case. The scan sidesteps the rule entirely.
  */
 function stripTrailingSlashes(url: string): string {
   let end = url.length;
@@ -39,8 +41,11 @@ const APP_DIR = join(process.cwd(), "app");
  */
 const URL_CACHE_TTL_MS = 60 * 60 * 1000;
 
-const isPageFile = (name: string) =>
-  name === "page" || name.startsWith("page.");
+// An allow-list, not a `page.` prefix test: `page.client.tsx` and
+// `page.module.css` are not routes, and treating them as one would invent
+// routes for any directory that holds only a client component.
+const PAGE_FILES = ["page.tsx", "page.ts", "page.jsx", "page.js", "page.mdx"];
+const isPageFile = (name: string) => PAGE_FILES.includes(name);
 const isDynamicSegment = (name: string) => name.includes("[");
 const isRouteGroup = (name: string) =>
   name.startsWith("(") && name.endsWith(")");
@@ -69,9 +74,17 @@ interface EntitySource {
  *   hold because someone logged in or a killmail referenced them.
  * - **Map minutiae** — planets, moons and stars, ~90k rows between them whose
  *   pages are a name and a handful of numbers.
+ * - **Dogma attributes and effects** — ~8k pages that each render every type
+ *   carrying the attribute. `/dogma/attribute/4` (mass) is 29.8 MB and takes
+ *   over a minute; the response exceeds the 2 MB `"use cache"` entry limit, so
+ *   its `cacheLife("days")` silently never stores and every hit is a full-table
+ *   join. Several also blow past Google's 15 MB fetch cap. Nothing links to
+ *   them today — `/dogma/attributes` renders its list on the client — so the
+ *   sitemap would be the crawler's way in. Restore these once the pages cap
+ *   their type list.
  *
- * Listing either spends crawl budget without earning impressions, and dilutes
- * the families that do rank.
+ * Listing any of them spends crawl budget without earning impressions, and
+ * dilutes the families that do rank.
  *
  * Order must be totally deterministic, because pagination slices this list and
  * `/sitemap/0.xml` and `/sitemap/1.xml` are separate requests that each rebuild
@@ -87,7 +100,12 @@ const ENTITY_SOURCES: EntitySource[] = [
     ids: async () =>
       (
         await prisma.type.findMany({
-          where: { isDeleted: false },
+          // typeId 0 exists in the table but `/type/0` renders the not-found UI:
+          // the page coerces the segment with `Number()` and treats the falsy 0
+          // as missing. Because that `notFound()` throws inside a <Suspense>
+          // boundary the response is still HTTP 200, so advertising it would
+          // hand crawlers a soft 404 — the very thing `isDeleted` filters out.
+          where: { isDeleted: false, typeId: { gt: 0 } },
           select: { typeId: true },
           orderBy: { typeId: "asc" },
         })
@@ -191,28 +209,6 @@ const ENTITY_SOURCES: EntitySource[] = [
           orderBy: { bloodlineId: "asc" },
         })
       ).map((row) => row.bloodlineId),
-  },
-  {
-    path: "/dogma/attribute",
-    ids: async () =>
-      (
-        await prisma.dogmaAttribute.findMany({
-          where: { isDeleted: false },
-          select: { attributeId: true },
-          orderBy: { attributeId: "asc" },
-        })
-      ).map((row) => row.attributeId),
-  },
-  {
-    path: "/dogma/effect",
-    ids: async () =>
-      (
-        await prisma.dogmaEffect.findMany({
-          where: { isDeleted: false },
-          select: { effectId: true },
-          orderBy: { effectId: "asc" },
-        })
-      ).map((row) => row.effectId),
   },
   {
     // One page per NPC corporation that actually sells something, rather than
@@ -323,23 +319,26 @@ async function getAllUrls(): Promise<string[]> {
           const ids = await source.ids();
           return {
             ok: true,
-            urls: ids.map((id) => `${SITE_URL}${source.path}/${id}`),
+            paths: ids.map((id) => `${source.path}/${id}`),
           };
         } catch (error: unknown) {
           console.error(
             `Failed to collect sitemap ids for ${source.path}.`,
             error,
           );
-          return { ok: false, urls: [] as string[] };
+          return { ok: false, paths: [] as string[] };
         }
       }),
     ),
   ]);
 
-  const urls = [
-    ...staticRoutes.filter(isCrawlable).map((route) => `${SITE_URL}${route}`),
-    ...families.flatMap((family) => family.urls),
-  ];
+  // `isCrawlable` gates entity families as well as static routes. No family
+  // sits under a disallowed prefix today, but the whole point of the shared
+  // list is that a sitemap URL can never contradict robots.txt — enforcing that
+  // in one place beats relying on nobody ever adding one that does.
+  const urls = [...staticRoutes, ...families.flatMap((family) => family.paths)]
+    .filter(isCrawlable)
+    .map((path) => `${SITE_URL}${path}`);
 
   // An empty static-route list means the `app/` walk failed — the real tree
   // always yields at least `/` — so it counts as degraded alongside a failed

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -375,6 +375,15 @@ async function getSitemapCount(): Promise<number> {
  */
 export const SITEMAP_INDEX_URL = `${SITE_URL}/sitemap.xml`;
 
+/**
+ * Page 0, which exists unconditionally: `getSitemapCount()` floors at 1, and
+ * `sitemap()` returns `[]` past the end of the list rather than throwing. So
+ * this URL serves valid XML whatever the database is doing, and — unlike the
+ * rest of the pages — it is a constant, so robots.txt can name it without a
+ * query. See the note in ./robots.ts for why it is named there at all.
+ */
+export const FIRST_SITEMAP_PAGE_URL = `${SITE_URL}/sitemap/0.xml`;
+
 /** Every `/sitemap/{n}.xml` page, i.e. the contents of the index. */
 export async function getSitemapUrls(): Promise<string[]> {
   const count = await getSitemapCount();

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -12,10 +12,22 @@ const LAST_MODIFIED = env.NEXT_PUBLIC_MODIFIED_DATE
   ? new Date(env.NEXT_PUBLIC_MODIFIED_DATE)
   : new Date();
 
+/**
+ * `url` without its trailing slashes.
+ *
+ * Written as a scan rather than a `/\/+$/` replace: that pattern backtracks
+ * super-linearly on a run of slashes.
+ */
+function stripTrailingSlashes(url: string): string {
+  let end = url.length;
+  while (end > 0 && url[end - 1] === "/") end -= 1;
+  return url.slice(0, end);
+}
+
 // The sitemap protocol requires every <loc> to be a fully-qualified URL —
 // relative paths are silently discarded by crawlers. Trailing slashes on the
 // configured origin would double up against the leading slash of each route.
-const SITE_URL = CONFIG.SITE_URL.replace(/\/+$/, "");
+const SITE_URL = stripTrailingSlashes(CONFIG.SITE_URL);
 
 const APP_DIR = join(process.cwd(), "app");
 

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -57,8 +57,13 @@ interface EntitySource {
  * Listing either spends crawl budget without earning impressions, and dilutes
  * the families that do rank.
  *
- * Order is fixed: sitemap pagination slices this list, so reordering reshuffles
- * which URLs land in which `/sitemap/{n}.xml`.
+ * Order must be totally deterministic, because pagination slices this list and
+ * `/sitemap/0.xml` and `/sitemap/1.xml` are separate requests that each rebuild
+ * it — potentially on different instances, from different cache snapshots. Two
+ * things guarantee that: this array's order, and the `orderBy` on every query.
+ * Without the latter the database is free to return rows in any order, so the
+ * two pages could overlap on some URLs and omit others entirely. Do not drop
+ * either.
  */
 const ENTITY_SOURCES: EntitySource[] = [
   {
@@ -68,6 +73,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.type.findMany({
           where: { isDeleted: false },
           select: { typeId: true },
+          orderBy: { typeId: "asc" },
         })
       ).map((row) => row.typeId),
   },
@@ -78,6 +84,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.category.findMany({
           where: { isDeleted: false },
           select: { categoryId: true },
+          orderBy: { categoryId: "asc" },
         })
       ).map((row) => row.categoryId),
   },
@@ -88,6 +95,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.group.findMany({
           where: { isDeleted: false },
           select: { groupId: true },
+          orderBy: { groupId: "asc" },
         })
       ).map((row) => row.groupId),
   },
@@ -98,6 +106,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.region.findMany({
           where: { isDeleted: false },
           select: { regionId: true },
+          orderBy: { regionId: "asc" },
         })
       ).map((row) => row.regionId),
   },
@@ -108,6 +117,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.constellation.findMany({
           where: { isDeleted: false },
           select: { constellationId: true },
+          orderBy: { constellationId: "asc" },
         })
       ).map((row) => row.constellationId),
   },
@@ -118,6 +128,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.solarSystem.findMany({
           where: { isDeleted: false },
           select: { solarSystemId: true },
+          orderBy: { solarSystemId: "asc" },
         })
       ).map((row) => row.solarSystemId),
   },
@@ -128,6 +139,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.station.findMany({
           where: { isDeleted: false },
           select: { stationId: true },
+          orderBy: { stationId: "asc" },
         })
       ).map((row) => row.stationId),
   },
@@ -138,6 +150,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.faction.findMany({
           where: { isDeleted: false },
           select: { factionId: true },
+          orderBy: { factionId: "asc" },
         })
       ).map((row) => row.factionId),
   },
@@ -148,6 +161,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.race.findMany({
           where: { isDeleted: false },
           select: { raceId: true },
+          orderBy: { raceId: "asc" },
         })
       ).map((row) => row.raceId),
   },
@@ -158,6 +172,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.bloodline.findMany({
           where: { isDeleted: false },
           select: { bloodlineId: true },
+          orderBy: { bloodlineId: "asc" },
         })
       ).map((row) => row.bloodlineId),
   },
@@ -168,6 +183,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.dogmaAttribute.findMany({
           where: { isDeleted: false },
           select: { attributeId: true },
+          orderBy: { attributeId: "asc" },
         })
       ).map((row) => row.attributeId),
   },
@@ -178,6 +194,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.dogmaEffect.findMany({
           where: { isDeleted: false },
           select: { effectId: true },
+          orderBy: { effectId: "asc" },
         })
       ).map((row) => row.effectId),
   },
@@ -190,6 +207,7 @@ const ENTITY_SOURCES: EntitySource[] = [
         await prisma.loyaltyStoreOffer.groupBy({
           by: ["corporationId"],
           where: { isDeleted: false },
+          orderBy: { corporationId: "asc" },
         })
       ).map((row) => row.corporationId),
   },
@@ -231,11 +249,14 @@ async function getStaticRoutes(): Promise<string[]> {
   if (cachedStaticRoutes) return cachedStaticRoutes;
   try {
     cachedStaticRoutes = await collectStaticRoutes();
+    return cachedStaticRoutes;
   } catch (error: unknown) {
+    // Deliberately not memoized: caching the empty fallback would drop the
+    // homepage from this instance's sitemap for the rest of its life over one
+    // transient read.
     console.error("Failed to collect static routes for sitemap.", error);
-    cachedStaticRoutes = [];
+    return [];
   }
-  return cachedStaticRoutes;
 }
 
 /**
@@ -276,7 +297,12 @@ async function getAllUrls(): Promise<string[]> {
     ...families.flatMap((family) => family.urls),
   ];
 
-  if (families.every((family) => family.ok)) {
+  // An empty static-route list means the `app/` walk failed — the real tree
+  // always yields at least `/` — so it counts as degraded alongside a failed
+  // family query.
+  const healthy =
+    staticRoutes.length > 0 && families.every((family) => family.ok);
+  if (healthy) {
     cachedUrls = { urls, expiresAt: Date.now() + URL_CACHE_TTL_MS };
   }
   return urls;

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -44,8 +44,14 @@ const URL_CACHE_TTL_MS = 60 * 60 * 1000;
 // An allow-list, not a `page.` prefix test: `page.client.tsx` and
 // `page.module.css` are not routes, and treating them as one would invent
 // routes for any directory that holds only a client component.
-const PAGE_FILES = ["page.tsx", "page.ts", "page.jsx", "page.js", "page.mdx"];
-const isPageFile = (name: string) => PAGE_FILES.includes(name);
+const PAGE_FILES = new Set([
+  "page.tsx",
+  "page.ts",
+  "page.jsx",
+  "page.js",
+  "page.mdx",
+]);
+const isPageFile = (name: string) => PAGE_FILES.has(name);
 const isDynamicSegment = (name: string) => name.includes("[");
 const isRouteGroup = (name: string) =>
   name.startsWith("(") && name.endsWith(")");

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { MetadataRoute } from "next";
 
 import { CONFIG } from "~/config/constants.ts";
+import { isCrawlable } from "~/config/seo.ts";
 import { env } from "~/env";
 import { prisma } from "~/lib/db";
 
@@ -11,9 +12,19 @@ const LAST_MODIFIED = env.NEXT_PUBLIC_MODIFIED_DATE
   ? new Date(env.NEXT_PUBLIC_MODIFIED_DATE)
   : new Date();
 
+// The sitemap protocol requires every <loc> to be a fully-qualified URL —
+// relative paths are silently discarded by crawlers. Trailing slashes on the
+// configured origin would double up against the leading slash of each route.
+const SITE_URL = CONFIG.SITE_URL.replace(/\/+$/, "");
+
 const APP_DIR = join(process.cwd(), "app");
 
-let cachedStaticRoutes: string[] | null = null;
+/**
+ * How long an assembled URL list is reused before the next crawler hit rebuilds
+ * it. The list costs one query per entity family, so without this every request
+ * for every sitemap page re-runs all of them.
+ */
+const URL_CACHE_TTL_MS = 60 * 60 * 1000;
 
 const isPageFile = (name: string) =>
   name === "page" || name.startsWith("page.");
@@ -21,6 +32,171 @@ const isDynamicSegment = (name: string) => name.includes("[");
 const isRouteGroup = (name: string) =>
   name.startsWith("(") && name.endsWith(")");
 const isParallelSegment = (name: string) => name.startsWith("@");
+
+/** A family of database-backed URLs, e.g. every `/system/{solarSystemId}`. */
+interface EntitySource {
+  /** Route prefix the ids hang off — `/system` yields `/system/30000142`. */
+  path: string;
+  /** Resolves the ids to emit. A rejection degrades to an empty family. */
+  ids: () => Promise<number[]>;
+}
+
+/**
+ * The database-backed URL families worth advertising.
+ *
+ * An entity family earns a place here by being bounded in number, stable, and
+ * carrying enough of its own content to stand up as a search result. That rules
+ * out two large groups on purpose:
+ *
+ * - **Player entities** — characters, corporations, alliances, killmails,
+ *   contracts, wars. Unbounded, constantly churning, and mostly rows we only
+ *   hold because someone logged in or a killmail referenced them.
+ * - **Map minutiae** — planets, moons and stars, ~90k rows between them whose
+ *   pages are a name and a handful of numbers.
+ *
+ * Listing either spends crawl budget without earning impressions, and dilutes
+ * the families that do rank.
+ *
+ * Order is fixed: sitemap pagination slices this list, so reordering reshuffles
+ * which URLs land in which `/sitemap/{n}.xml`.
+ */
+const ENTITY_SOURCES: EntitySource[] = [
+  {
+    path: "/type",
+    ids: async () =>
+      (
+        await prisma.type.findMany({
+          where: { isDeleted: false },
+          select: { typeId: true },
+        })
+      ).map((row) => row.typeId),
+  },
+  {
+    path: "/category",
+    ids: async () =>
+      (
+        await prisma.category.findMany({
+          where: { isDeleted: false },
+          select: { categoryId: true },
+        })
+      ).map((row) => row.categoryId),
+  },
+  {
+    path: "/group",
+    ids: async () =>
+      (
+        await prisma.group.findMany({
+          where: { isDeleted: false },
+          select: { groupId: true },
+        })
+      ).map((row) => row.groupId),
+  },
+  {
+    path: "/region",
+    ids: async () =>
+      (
+        await prisma.region.findMany({
+          where: { isDeleted: false },
+          select: { regionId: true },
+        })
+      ).map((row) => row.regionId),
+  },
+  {
+    path: "/constellation",
+    ids: async () =>
+      (
+        await prisma.constellation.findMany({
+          where: { isDeleted: false },
+          select: { constellationId: true },
+        })
+      ).map((row) => row.constellationId),
+  },
+  {
+    path: "/system",
+    ids: async () =>
+      (
+        await prisma.solarSystem.findMany({
+          where: { isDeleted: false },
+          select: { solarSystemId: true },
+        })
+      ).map((row) => row.solarSystemId),
+  },
+  {
+    path: "/station",
+    ids: async () =>
+      (
+        await prisma.station.findMany({
+          where: { isDeleted: false },
+          select: { stationId: true },
+        })
+      ).map((row) => row.stationId),
+  },
+  {
+    path: "/faction",
+    ids: async () =>
+      (
+        await prisma.faction.findMany({
+          where: { isDeleted: false },
+          select: { factionId: true },
+        })
+      ).map((row) => row.factionId),
+  },
+  {
+    path: "/race",
+    ids: async () =>
+      (
+        await prisma.race.findMany({
+          where: { isDeleted: false },
+          select: { raceId: true },
+        })
+      ).map((row) => row.raceId),
+  },
+  {
+    path: "/bloodline",
+    ids: async () =>
+      (
+        await prisma.bloodline.findMany({
+          where: { isDeleted: false },
+          select: { bloodlineId: true },
+        })
+      ).map((row) => row.bloodlineId),
+  },
+  {
+    path: "/dogma/attribute",
+    ids: async () =>
+      (
+        await prisma.dogmaAttribute.findMany({
+          where: { isDeleted: false },
+          select: { attributeId: true },
+        })
+      ).map((row) => row.attributeId),
+  },
+  {
+    path: "/dogma/effect",
+    ids: async () =>
+      (
+        await prisma.dogmaEffect.findMany({
+          where: { isDeleted: false },
+          select: { effectId: true },
+        })
+      ).map((row) => row.effectId),
+  },
+  {
+    // One page per NPC corporation that actually sells something, rather than
+    // per corporation — a corp with no offers renders an empty store.
+    path: "/lp-store",
+    ids: async () =>
+      (
+        await prisma.loyaltyStoreOffer.groupBy({
+          by: ["corporationId"],
+          where: { isDeleted: false },
+        })
+      ).map((row) => row.corporationId),
+  },
+];
+
+let cachedStaticRoutes: string[] | null = null;
+let cachedUrls: { urls: string[]; expiresAt: number } | null = null;
 
 async function collectStaticRoutes(): Promise<string[]> {
   const routes = new Set<string>();
@@ -62,19 +238,48 @@ async function getStaticRoutes(): Promise<string[]> {
   return cachedStaticRoutes;
 }
 
-async function getTypeIdsSafe(): Promise<number[]> {
-  try {
-    return await prisma.type
-      .findMany({
-        select: {
-          typeId: true,
-        },
-      })
-      .then((entries) => entries.map((entry) => entry.typeId));
-  } catch (error: unknown) {
-    console.error("Failed to fetch ESI type IDs for sitemap.", error);
-    return [];
+/**
+ * Every URL the sitemap advertises, absolute and in a stable order.
+ *
+ * A family whose query fails contributes nothing rather than taking the whole
+ * sitemap down with it — a database blip should cost us one section, not the
+ * crawler's entire view of the site. That degraded list is deliberately *not*
+ * cached: serving a truncated sitemap for the next hour because of one refused
+ * connection tells crawlers those URLs are gone.
+ */
+async function getAllUrls(): Promise<string[]> {
+  if (cachedUrls && cachedUrls.expiresAt > Date.now()) return cachedUrls.urls;
+
+  const [staticRoutes, families] = await Promise.all([
+    getStaticRoutes(),
+    Promise.all(
+      ENTITY_SOURCES.map(async (source) => {
+        try {
+          const ids = await source.ids();
+          return {
+            ok: true,
+            urls: ids.map((id) => `${SITE_URL}${source.path}/${id}`),
+          };
+        } catch (error: unknown) {
+          console.error(
+            `Failed to collect sitemap ids for ${source.path}.`,
+            error,
+          );
+          return { ok: false, urls: [] as string[] };
+        }
+      }),
+    ),
+  ]);
+
+  const urls = [
+    ...staticRoutes.filter(isCrawlable).map((route) => `${SITE_URL}${route}`),
+    ...families.flatMap((family) => family.urls),
+  ];
+
+  if (families.every((family) => family.ok)) {
+    cachedUrls = { urls, expiresAt: Date.now() + URL_CACHE_TTL_MS };
   }
+  return urls;
 }
 
 function normalizeId(rawId: string): number {
@@ -83,68 +288,35 @@ function normalizeId(rawId: string): number {
   return Math.floor(parsed);
 }
 
-async function getSitemapIds(): Promise<number[]> {
-  const [staticRoutes, typeIds] = await Promise.all([
-    getStaticRoutes(),
-    getTypeIdsSafe(),
-  ]);
-  const totalUrls = staticRoutes.length + typeIds.length;
-  const totalSitemaps = Math.max(
-    1,
-    Math.ceil(totalUrls / MAX_URLS_PER_SITEMAP),
-  );
-  return Array.from({ length: totalSitemaps }, (_, index) => index);
+/** Number of `/sitemap/{n}.xml` pages needed, never fewer than one. */
+async function getSitemapCount(): Promise<number> {
+  const urls = await getAllUrls();
+  return Math.max(1, Math.ceil(urls.length / MAX_URLS_PER_SITEMAP));
 }
 
 export async function getSitemapUrls(): Promise<string[]> {
-  const ids = await getSitemapIds();
-  return ids.map((id) => `${CONFIG.SITE_URL}/sitemap/${id}.xml`);
+  const count = await getSitemapCount();
+  return Array.from(
+    { length: count },
+    (_, index) => `${SITE_URL}/sitemap/${index}.xml`,
+  );
 }
 
 export async function generateSitemaps(): Promise<{ id: number }[]> {
-  const ids = await getSitemapIds();
-  return ids.map((id) => ({ id }));
+  const count = await getSitemapCount();
+  return Array.from({ length: count }, (_, index) => ({ id: index }));
 }
 
 export default async function sitemap(props: {
   id: Promise<string>;
 }): Promise<MetadataRoute.Sitemap> {
   const pageId = normalizeId(await props.id);
-  const [staticRoutes, typeIds] = await Promise.all([
-    getStaticRoutes(),
-    getTypeIdsSafe(),
-  ]);
+  const urls = await getAllUrls();
 
-  const totalEntries = staticRoutes.length + typeIds.length;
   const start = pageId * MAX_URLS_PER_SITEMAP;
-  if (start >= totalEntries) return [];
+  if (start >= urls.length) return [];
 
-  const end = Math.min(totalEntries, start + MAX_URLS_PER_SITEMAP);
-  const entries: MetadataRoute.Sitemap = [];
-
-  if (start < staticRoutes.length) {
-    const staticSlice = staticRoutes.slice(
-      start,
-      Math.min(end, staticRoutes.length),
-    );
-    for (const route of staticSlice) {
-      entries.push({
-        url: route,
-        lastModified: LAST_MODIFIED,
-      });
-    }
-  }
-
-  if (end > staticRoutes.length) {
-    const typeStart = Math.max(0, start - staticRoutes.length);
-    const typeEnd = Math.min(typeIds.length, end - staticRoutes.length);
-    for (const typeId of typeIds.slice(typeStart, typeEnd)) {
-      entries.push({
-        url: `${CONFIG.SITE_URL}/type/${typeId}`,
-        lastModified: LAST_MODIFIED,
-      });
-    }
-  }
-
-  return entries;
+  return urls
+    .slice(start, start + MAX_URLS_PER_SITEMAP)
+    .map((url) => ({ url, lastModified: LAST_MODIFIED }));
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -9,7 +9,7 @@ import { env } from "~/env";
 import { prisma } from "~/lib/db";
 
 const MAX_URLS_PER_SITEMAP = 50000;
-const LAST_MODIFIED = env.NEXT_PUBLIC_MODIFIED_DATE
+export const LAST_MODIFIED = env.NEXT_PUBLIC_MODIFIED_DATE
   ? new Date(env.NEXT_PUBLIC_MODIFIED_DATE)
   : new Date();
 
@@ -369,6 +369,13 @@ async function getSitemapCount(): Promise<number> {
   return Math.max(1, Math.ceil(urls.length / MAX_URLS_PER_SITEMAP));
 }
 
+/**
+ * The sitemap index — the conventional path crawlers probe unprompted, and the
+ * single entry robots.txt advertises. Serving it is `./sitemap.xml/route.ts`.
+ */
+export const SITEMAP_INDEX_URL = `${SITE_URL}/sitemap.xml`;
+
+/** Every `/sitemap/{n}.xml` page, i.e. the contents of the index. */
 export async function getSitemapUrls(): Promise<string[]> {
   const count = await getSitemapCount();
   return Array.from(

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import type { MetadataRoute } from "next";
+import type { Dirent } from "node:fs";
 
 import { CONFIG } from "~/config/constants.ts";
 import { isCrawlable } from "~/config/seo.ts";
@@ -231,36 +232,50 @@ const ENTITY_SOURCES: EntitySource[] = [
 let cachedStaticRoutes: string[] | null = null;
 let cachedUrls: { urls: string[]; expiresAt: number } | null = null;
 
+const hasPageFile = (entries: Dirent[]) =>
+  entries.some((entry) => entry.isFile() && isPageFile(entry.name));
+
+/** Directories the walk descends into: real path segments only. */
+const isTraversable = (entry: Dirent) =>
+  entry.isDirectory() &&
+  !entry.name.startsWith(".") &&
+  entry.name !== "node_modules" &&
+  !isDynamicSegment(entry.name);
+
+/**
+ * Whether `dir` holds an optional catch-all with a page file.
+ *
+ * Such a segment matches zero segments, so it also answers its parent path:
+ * `app/travel/[[...waypoints]]/page.tsx` serves `/travel`, and nothing else in
+ * the tree registers that route. Every other dynamic segment needs an id, which
+ * comes from ENTITY_SOURCES instead.
+ */
+async function servesParentPath(
+  dir: string,
+  entries: Dirent[],
+): Promise<boolean> {
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !isOptionalCatchAll(entry.name)) continue;
+    const nested = await readdir(join(dir, entry.name), {
+      withFileTypes: true,
+    });
+    if (hasPageFile(nested)) return true;
+  }
+  return false;
+}
+
 async function collectStaticRoutes(): Promise<string[]> {
   const routes = new Set<string>();
 
   async function walk(dir: string, segments: string[]) {
     const entries = await readdir(dir, { withFileTypes: true });
     const routePath = segments.length === 0 ? "/" : `/${segments.join("/")}`;
-    if (entries.some((entry) => entry.isFile() && isPageFile(entry.name))) {
+
+    if (hasPageFile(entries) || (await servesParentPath(dir, entries))) {
       routes.add(routePath);
     }
 
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      if (entry.name.startsWith(".")) continue;
-      if (entry.name === "node_modules") continue;
-      if (isDynamicSegment(entry.name)) {
-        // An optional catch-all matches zero segments, so it also answers its
-        // parent path: `app/travel/[[...waypoints]]/page.tsx` serves `/travel`,
-        // and nothing else in the tree would register that route. Every other
-        // dynamic segment needs an id, which comes from ENTITY_SOURCES instead.
-        if (isOptionalCatchAll(entry.name)) {
-          const nested = await readdir(join(dir, entry.name), {
-            withFileTypes: true,
-          });
-          if (nested.some((e) => e.isFile() && isPageFile(e.name))) {
-            routes.add(routePath);
-          }
-        }
-        continue;
-      }
-
+    for (const entry of entries.filter(isTraversable)) {
       const nextSegments =
         isRouteGroup(entry.name) || isParallelSegment(entry.name)
           ? segments

--- a/apps/web/config/seo.ts
+++ b/apps/web/config/seo.ts
@@ -1,7 +1,5 @@
 /**
- * Route prefixes crawlers are asked to stay out of: pages that only render
- * anything once a character is logged in (a crawler sees an empty shell), plus
- * the debug tooling.
+ * Route prefixes crawlers are asked to stay out of.
  *
  * `robots.ts` publishes these as `Disallow` rules and `sitemap.ts` filters them
  * out of the sitemap. The two must agree: a URL that is advertised in the
@@ -9,6 +7,13 @@
  * reports as an error, and it costs the whole sitemap credibility.
  *
  * Matching is by prefix — `/assets` also covers `/assets/character`.
+ *
+ * Most entries are here because the page renders nothing until a character is
+ * logged in, so a crawler only ever sees an empty shell. Two are not:
+ * `/travel` and `/ship-scanner` are anonymous, server-rendered, cacheable pages
+ * that would rank on their own. They predate this list and are kept blocked to
+ * preserve the existing robots.txt exactly; unblocking them is a deliberate SEO
+ * decision, not a cleanup.
  */
 export const CRAWLER_DISALLOWED_PATHS = [
   "/assets",
@@ -20,8 +25,10 @@ export const CRAWLER_DISALLOWED_PATHS = [
   "/mail",
   "/notifications",
   "/settings",
+  // Anonymous and indexable — blocked only for backwards compatibility.
   "/ship-scanner",
   "/skills",
+  // Anonymous and indexable — blocked only for backwards compatibility.
   "/travel",
   "/wallet",
 ] as const;

--- a/apps/web/config/seo.ts
+++ b/apps/web/config/seo.ts
@@ -1,0 +1,34 @@
+/**
+ * Route prefixes crawlers are asked to stay out of: pages that only render
+ * anything once a character is logged in (a crawler sees an empty shell), plus
+ * the debug tooling.
+ *
+ * `robots.ts` publishes these as `Disallow` rules and `sitemap.ts` filters them
+ * out of the sitemap. The two must agree: a URL that is advertised in the
+ * sitemap *and* disallowed in robots.txt is a contradiction that Search Console
+ * reports as an error, and it costs the whole sitemap credibility.
+ *
+ * Matching is by prefix — `/assets` also covers `/assets/character`.
+ */
+export const CRAWLER_DISALLOWED_PATHS = [
+  "/assets",
+  "/calendar",
+  "/contacts",
+  "/debug",
+  "/fittings",
+  "/login",
+  "/mail",
+  "/notifications",
+  "/settings",
+  "/ship-scanner",
+  "/skills",
+  "/travel",
+  "/wallet",
+] as const;
+
+/** Whether `route` may appear in the sitemap, i.e. robots.txt does not block it. */
+export function isCrawlable(route: string): boolean {
+  return !CRAWLER_DISALLOWED_PATHS.some(
+    (prefix) => route === prefix || route.startsWith(`${prefix}/`),
+  );
+}

--- a/apps/web/config/seo.ts
+++ b/apps/web/config/seo.ts
@@ -8,12 +8,11 @@
  *
  * Matching is by prefix — `/assets` also covers `/assets/character`.
  *
- * Most entries are here because the page renders nothing until a character is
- * logged in, so a crawler only ever sees an empty shell. Two are not:
- * `/travel` and `/ship-scanner` are anonymous, server-rendered, cacheable pages
- * that would rank on their own. They predate this list and are kept blocked to
- * preserve the existing robots.txt exactly; unblocking them is a deliberate SEO
- * decision, not a cleanup.
+ * Every entry is here for the same reason: the page renders nothing until a
+ * character is logged in, so a crawler only ever sees an empty shell. Anything
+ * that renders for an anonymous visitor does not belong here — `/travel` and
+ * `/ship-scanner` used to be listed despite being fully anonymous, cacheable,
+ * server-rendered pages, which kept them out of search for no benefit.
  */
 export const CRAWLER_DISALLOWED_PATHS = [
   "/assets",
@@ -25,11 +24,7 @@ export const CRAWLER_DISALLOWED_PATHS = [
   "/mail",
   "/notifications",
   "/settings",
-  // Anonymous and indexable — blocked only for backwards compatibility.
-  "/ship-scanner",
   "/skills",
-  // Anonymous and indexable — blocked only for backwards compatibility.
-  "/travel",
   "/wallet",
 ] as const;
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -144,47 +144,58 @@ const config = {
     ],
   },
 
-  rewrites: async () => [
-    {
-      // Umami's tracker sends events to `<data-host-url>/api/send`, which
-      // defaults to the cloud collection gateway. The layout sets
-      // `data-host-url="/analytics"` so the beacon is same-origin (kept off
-      // `connect-src`'s third-party list and invisible to ad blockers that
-      // block `*.umami.is`); this rewrite forwards it to the gateway. Must
-      // come BEFORE the catch-all below — that one targets the script host,
-      // which does not serve `/api/send`.
-      source: "/analytics/api/send",
-      destination: "https://gateway.umami.is/api/send", // Umami event gateway
-    },
-    {
-      // Must target `cloud.umami.is` (the canonical script host), NOT
-      // `analytics.umami.is` — the latter 301-redirects to `cloud.umami.is`,
-      // and Next.js forwards that redirect to the browser, which then loads a
-      // cross-origin script that `script-src 'self'` rejects (a CSP violation
-      // even though the proxied URL is same-origin). See JITASPACE-3T.
-      source: "/analytics/:match*",
-      destination: "https://cloud.umami.is/:match*", // Proxy to Umami script
-    },
-    {
-      source: "/ingest/static/:path*",
-      destination: "https://eu-assets.i.posthog.com/static/:path*",
-    },
-    {
-      source: "/ingest/array/:path*",
-      destination: "https://eu-assets.i.posthog.com/array/:path*",
-    },
-    {
-      source: "/ingest/:path*",
-      destination: "https://eu.i.posthog.com/:path*",
-    },
-    {
-      // Serve a single static shell for every /market/<typeId> URL instead of
-      // rendering (and ISR-caching) one page per type id. The browser keeps the
-      // pretty /market/<typeId> URL; the client reads the id from the path.
-      source: "/market/:typeId",
-      destination: "/market",
-    },
-  ],
+  rewrites: async () => ({
+    // `beforeFiles`, because Next reserves `/sitemap.xml` for the
+    // `app/sitemap.ts` metadata convention. With `generateSitemaps()` the real
+    // pages live at `/sitemap/{n}.xml` and that reserved route only 404s, but
+    // it still wins against an `afterFiles` rewrite — and a route handler at
+    // `app/sitemap.xml/` fails the build outright with "Conflicting route and
+    // metadata". This hands the conventional path to the index handler.
+    beforeFiles: [
+      { source: "/sitemap.xml", destination: "/sitemap-index.xml" },
+    ],
+    afterFiles: [
+      {
+        // Umami's tracker sends events to `<data-host-url>/api/send`, which
+        // defaults to the cloud collection gateway. The layout sets
+        // `data-host-url="/analytics"` so the beacon is same-origin (kept off
+        // `connect-src`'s third-party list and invisible to ad blockers that
+        // block `*.umami.is`); this rewrite forwards it to the gateway. Must
+        // come BEFORE the catch-all below — that one targets the script host,
+        // which does not serve `/api/send`.
+        source: "/analytics/api/send",
+        destination: "https://gateway.umami.is/api/send", // Umami event gateway
+      },
+      {
+        // Must target `cloud.umami.is` (the canonical script host), NOT
+        // `analytics.umami.is` — the latter 301-redirects to `cloud.umami.is`,
+        // and Next.js forwards that redirect to the browser, which then loads a
+        // cross-origin script that `script-src 'self'` rejects (a CSP violation
+        // even though the proxied URL is same-origin). See JITASPACE-3T.
+        source: "/analytics/:match*",
+        destination: "https://cloud.umami.is/:match*", // Proxy to Umami script
+      },
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
+      {
+        // Serve a single static shell for every /market/<typeId> URL instead of
+        // rendering (and ISR-caching) one page per type id. The browser keeps the
+        // pretty /market/<typeId> URL; the client reads the id from the path.
+        source: "/market/:typeId",
+        destination: "/market",
+      },
+    ],
+  }),
   skipTrailingSlashRedirect: true,
 
   redirects: async () => [

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -1,0 +1,307 @@
+import { join, relative, sep } from "node:path";
+import type { MetadataRoute } from "next";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+// Not mocked — the sitemap must agree with the very list robots.txt publishes.
+import { CRAWLER_DISALLOWED_PATHS } from "~/config/seo.ts";
+
+// `~/env` is stubbed rather than validated: `~/config/constants` reads
+// NEXT_PUBLIC_SITE_URL at module load, and driving it from a mutable object lets
+// the trailing-slash case re-resolve it after `jest.resetModules()`.
+const mockEnv: Record<string, string | undefined> = {};
+jest.mock("~/env", () => ({ env: mockEnv }));
+
+// A fake `app/` tree — walking the real one would make these assertions move
+// every time a route is added.
+interface Tree {
+  [name: string]: Tree | null;
+}
+const FILE = null;
+
+const APP_TREE: Tree = {
+  "page.tsx": FILE,
+  about: { "page.tsx": FILE },
+  history: { "page.tsx": FILE, build: { "[build]": { "page.tsx": FILE } } },
+  // Route groups and parallel segments contribute no path segment of their own.
+  "(marketing)": { promo: { "page.tsx": FILE } },
+  "@modal": { preview: { "page.tsx": FILE } },
+  // Disallowed: directly, and via a prefix match on a nested route.
+  mail: { "page.tsx": FILE },
+  assets: { character: { "page.tsx": FILE } },
+  // Dynamic segments never become static routes.
+  type: { "[typeId]": { "page.tsx": FILE } },
+  // Directories without a page file are traversed but contribute nothing.
+  components: { "helper.ts": FILE },
+};
+
+const APP_DIR = join(process.cwd(), "app");
+
+function resolveDir(dir: string): Tree {
+  const rel = relative(APP_DIR, dir);
+  let node: Tree = APP_TREE;
+  if (rel === "") return node;
+  for (const segment of rel.split(sep)) {
+    const next = node[segment];
+    if (next == null) throw new Error(`ENOENT: ${dir}`);
+    node = next;
+  }
+  return node;
+}
+
+const mockReaddir = jest.fn((dir: unknown) => {
+  const entries = Object.entries(resolveDir(String(dir)));
+  return Promise.resolve(
+    entries.map(([name, child]) => ({
+      name,
+      isFile: () => child === FILE,
+      isDirectory: () => child !== FILE,
+    })),
+  );
+});
+jest.mock("node:fs/promises", () => ({
+  // The `withFileTypes` option is implied by the fake entries below, so the
+  // mock only ever needs the directory.
+  readdir: (dir: unknown) => mockReaddir(dir),
+}));
+
+// One `findMany` per entity family, keyed by the prisma model accessor the
+// source uses, plus `groupBy` for the loyalty-store corporations.
+const rows = {
+  type: [603, 587],
+  category: [6],
+  group: [25],
+  region: [10000002],
+  constellation: [20000020],
+  solarSystem: [30000142],
+  station: [60003760],
+  faction: [500001],
+  race: [1],
+  bloodline: [1],
+  dogmaAttribute: [9],
+  dogmaEffect: [11],
+};
+
+const idField: Record<keyof typeof rows, string> = {
+  type: "typeId",
+  category: "categoryId",
+  group: "groupId",
+  region: "regionId",
+  constellation: "constellationId",
+  solarSystem: "solarSystemId",
+  station: "stationId",
+  faction: "factionId",
+  race: "raceId",
+  bloodline: "bloodlineId",
+  dogmaAttribute: "attributeId",
+  dogmaEffect: "effectId",
+};
+
+const findManyMocks = {} as Record<
+  keyof typeof rows,
+  jest.Mock<() => Promise<unknown[]>>
+>;
+const mockGroupBy = jest.fn<() => Promise<unknown[]>>();
+
+const prismaStub: Record<string, unknown> = {
+  loyaltyStoreOffer: { groupBy: () => mockGroupBy() },
+};
+for (const model of Object.keys(rows) as (keyof typeof rows)[]) {
+  const fn = jest.fn<() => Promise<unknown[]>>();
+  findManyMocks[model] = fn;
+  prismaStub[model] = { findMany: () => fn() };
+}
+jest.mock("~/lib/db", () => ({ prisma: prismaStub }));
+
+interface SitemapModule {
+  default: (props: { id: Promise<string> }) => Promise<MetadataRoute.Sitemap>;
+  generateSitemaps: () => Promise<{ id: number }[]>;
+  getSitemapUrls: () => Promise<string[]>;
+}
+
+function load(): SitemapModule {
+  return require("~/app/sitemap") as SitemapModule;
+}
+
+/** Every `<loc>` the sitemap would emit, across all of its pages. */
+async function allLocs(mod: SitemapModule): Promise<string[]> {
+  const pages = await mod.generateSitemaps();
+  const locs: string[] = [];
+  for (const { id } of pages) {
+    const entries = await mod.default({ id: Promise.resolve(String(id)) });
+    locs.push(...entries.map((entry) => entry.url));
+  }
+  return locs;
+}
+
+describe("sitemap", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockEnv.NEXT_PUBLIC_SITE_URL = "https://www.jita.space";
+    mockEnv.NEXT_PUBLIC_MODIFIED_DATE = "2026-01-01T00:00:00.000Z";
+    mockReaddir.mockClear();
+    for (const model of Object.keys(rows) as (keyof typeof rows)[]) {
+      findManyMocks[model].mockReset();
+      findManyMocks[model].mockResolvedValue(
+        rows[model].map((id) => ({ [idField[model]]: id })),
+      );
+    }
+    mockGroupBy.mockReset();
+    mockGroupBy.mockResolvedValue([{ corporationId: 1000035 }]);
+  });
+
+  it("emits only absolute URLs", async () => {
+    const locs = await allLocs(load());
+
+    expect(locs.length).toBeGreaterThan(0);
+    for (const loc of locs) {
+      expect(loc.startsWith("https://www.jita.space/")).toBe(true);
+      expect(() => new URL(loc)).not.toThrow();
+    }
+  });
+
+  it("includes crawlable static routes, resolving groups and parallel segments", async () => {
+    const locs = await allLocs(load());
+
+    expect(locs).toContain("https://www.jita.space/");
+    expect(locs).toContain("https://www.jita.space/about");
+    expect(locs).toContain("https://www.jita.space/history");
+    expect(locs).toContain("https://www.jita.space/promo");
+    expect(locs).toContain("https://www.jita.space/preview");
+  });
+
+  it("omits routes robots.txt disallows, including nested ones", async () => {
+    const locs = await allLocs(load());
+
+    expect(locs).not.toContain("https://www.jita.space/mail");
+    expect(locs).not.toContain("https://www.jita.space/assets/character");
+  });
+
+  it("agrees with the robots.txt disallow list", async () => {
+    const locs = await allLocs(load());
+
+    const contradictions = locs.filter((loc) => {
+      const path = new URL(loc).pathname;
+      return CRAWLER_DISALLOWED_PATHS.some(
+        (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+      );
+    });
+    expect(contradictions).toEqual([]);
+  });
+
+  it("never emits a dynamic segment as a literal route", async () => {
+    const locs = await allLocs(load());
+
+    for (const loc of locs) {
+      expect(loc).not.toContain("[");
+    }
+    expect(locs).not.toContain("https://www.jita.space/type");
+  });
+
+  it("emits every database-backed entity family", async () => {
+    const locs = await allLocs(load());
+
+    expect(locs).toEqual(
+      expect.arrayContaining([
+        "https://www.jita.space/type/603",
+        "https://www.jita.space/category/6",
+        "https://www.jita.space/group/25",
+        "https://www.jita.space/region/10000002",
+        "https://www.jita.space/constellation/20000020",
+        "https://www.jita.space/system/30000142",
+        "https://www.jita.space/station/60003760",
+        "https://www.jita.space/faction/500001",
+        "https://www.jita.space/race/1",
+        "https://www.jita.space/bloodline/1",
+        "https://www.jita.space/dogma/attribute/9",
+        "https://www.jita.space/dogma/effect/11",
+        "https://www.jita.space/lp-store/1000035",
+      ]),
+    );
+  });
+
+  it("drops one family rather than the whole sitemap when its query fails", async () => {
+    findManyMocks.station.mockRejectedValue(new Error("connection refused"));
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const locs = await allLocs(load());
+
+    expect(locs).not.toContain("https://www.jita.space/station/60003760");
+    expect(locs).toContain("https://www.jita.space/system/30000142");
+    expect(locs).toContain("https://www.jita.space/");
+    errorSpy.mockRestore();
+  });
+
+  it("does not cache a degraded list once the failing family recovers", async () => {
+    findManyMocks.station.mockRejectedValue(new Error("connection refused"));
+    const errorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const mod = load();
+
+    expect(await allLocs(mod)).not.toContain(
+      "https://www.jita.space/station/60003760",
+    );
+
+    findManyMocks.station.mockResolvedValue([{ stationId: 60003760 }]);
+
+    expect(await allLocs(mod)).toContain(
+      "https://www.jita.space/station/60003760",
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("normalizes a trailing slash on the configured origin", async () => {
+    mockEnv.NEXT_PUBLIC_SITE_URL = "https://www.jita.space/";
+
+    const locs = await allLocs(load());
+
+    expect(locs).toContain("https://www.jita.space/");
+    expect(locs).toContain("https://www.jita.space/type/603");
+    expect(locs.some((loc) => loc.includes("//type"))).toBe(false);
+  });
+
+  it("paginates past the 50k per-file limit without dropping or repeating URLs", async () => {
+    const many = Array.from({ length: 60_000 }, (_, index) => index + 1);
+    findManyMocks.type.mockResolvedValue(many.map((typeId) => ({ typeId })));
+    const mod = load();
+
+    const pages = await mod.generateSitemaps();
+    expect(pages).toEqual([{ id: 0 }, { id: 1 }]);
+
+    const first = await mod.default({ id: Promise.resolve("0") });
+    expect(first).toHaveLength(50_000);
+
+    const locs = await allLocs(mod);
+    expect(new Set(locs).size).toBe(locs.length);
+    expect(locs).toContain("https://www.jita.space/type/60000");
+  });
+
+  it("returns an empty page for an out-of-range or malformed id", async () => {
+    const mod = load();
+
+    expect(await mod.default({ id: Promise.resolve("99") })).toEqual([]);
+    // A malformed id normalizes to page 0 rather than producing a negative slice.
+    expect(
+      (await mod.default({ id: Promise.resolve("nonsense") })).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("advertises one sitemap URL per generated page", async () => {
+    const mod = load();
+
+    expect(await mod.getSitemapUrls()).toEqual([
+      "https://www.jita.space/sitemap/0.xml",
+    ]);
+  });
+
+  it("reuses the assembled list instead of re-querying per sitemap page", async () => {
+    const mod = load();
+
+    await allLocs(mod);
+    await allLocs(mod);
+
+    expect(findManyMocks.type).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -1,3 +1,9 @@
+/**
+ * @jest-environment node
+ *
+ * Node rather than jsdom: none of this touches the DOM, and the sitemap-index
+ * route handler returns a `Response`, which jsdom does not provide.
+ */
 import { join, relative, sep } from "node:path";
 import type { MetadataRoute } from "next";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
@@ -10,6 +16,10 @@ import { CRAWLER_DISALLOWED_PATHS } from "~/config/seo.ts";
 // the trailing-slash case re-resolve it after `jest.resetModules()`.
 const mockEnv: Record<string, string | undefined> = {};
 jest.mock("~/env", () => ({ env: mockEnv }));
+
+// The index route calls `connection()` to stay request-time; in jest there is
+// no request scope, so it resolves to a no-op.
+jest.mock("next/server", () => ({ connection: () => Promise.resolve() }));
 
 // A fake `app/` tree — walking the real one would make these assertions move
 // every time a route is added.
@@ -135,14 +145,22 @@ function load(): SitemapModule {
 }
 
 interface RobotsModule {
-  default: () => Promise<{
+  default: () => {
     rules: { disallow?: string[] };
-    sitemap?: string[];
-  }>;
+    sitemap?: string | string[];
+  };
 }
 
 function loadRobots(): RobotsModule {
   return require("~/app/robots") as RobotsModule;
+}
+
+interface SitemapIndexModule {
+  GET: () => Promise<Response>;
+}
+
+function loadSitemapIndex(): SitemapIndexModule {
+  return require("~/app/sitemap-index.xml/route") as SitemapIndexModule;
 }
 
 /** Every `<loc>` the sitemap would emit, across all of its pages. */
@@ -214,7 +232,7 @@ describe("sitemap", () => {
     // into robots.ts would leave both sides passing while production serves a
     // sitemap/robots contradiction.
     const locs = await allLocs(load());
-    const { rules } = await loadRobots().default();
+    const { rules } = loadRobots().default();
     const disallow = rules.disallow ?? [];
 
     expect(disallow.length).toBeGreaterThan(0);
@@ -227,6 +245,39 @@ describe("sitemap", () => {
       );
     });
     expect(contradictions).toEqual([]);
+  });
+
+  it("advertises the index in robots.txt, and the index lists every page", async () => {
+    // robots.txt names only the index; the index expands to the numbered pages.
+    // Both derive from ./sitemap.ts, so this pins the chain end to end.
+    const xml = await (await loadSitemapIndex().GET()).text();
+    const indexed = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+    const { sitemap: advertised } = loadRobots().default();
+    const pages = await load().generateSitemaps();
+
+    expect(advertised).toBe("https://www.jita.space/sitemap.xml");
+    expect(indexed).toEqual(await load().getSitemapUrls());
+    expect(indexed).toHaveLength(pages.length);
+    expect(xml).toContain("<sitemapindex");
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+  });
+
+  it("paginates the index the same way the sitemap itself paginates", async () => {
+    const many = Array.from({ length: 60_000 }, (_, i) => ({ typeId: i + 1 }));
+    findManyMocks.type.mockResolvedValue(many);
+
+    const xml = await (await loadSitemapIndex().GET()).text();
+    const indexed = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+
+    expect(indexed).toEqual([
+      "https://www.jita.space/sitemap/0.xml",
+      "https://www.jita.space/sitemap/1.xml",
+    ]);
+  });
+
+  it("serves the index as XML", async () => {
+    const res = await loadSitemapIndex().GET();
+    expect(res.headers.get("content-type")).toContain("application/xml");
   });
 
   it("filters soft-deleted rows and orders every family deterministically", async () => {

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -96,21 +96,32 @@ const idField: Record<keyof typeof rows, string> = {
   dogmaEffect: "effectId",
 };
 
-const findManyMocks = {} as Record<
-  keyof typeof rows,
-  jest.Mock<() => Promise<unknown[]>>
->;
-const mockGroupBy = jest.fn<() => Promise<unknown[]>>();
+// The stubs forward their arguments so the suite can assert the `where` and
+// `orderBy` clauses — without that, deleting either from all 13 sources is a
+// mutation no test can see.
+type QueryMock = jest.Mock<(args?: unknown) => Promise<unknown[]>>;
+
+const findManyMocks = {} as Record<keyof typeof rows, QueryMock>;
+const mockGroupBy = jest.fn<(args?: unknown) => Promise<unknown[]>>();
 
 const prismaStub: Record<string, unknown> = {
-  loyaltyStoreOffer: { groupBy: () => mockGroupBy() },
+  loyaltyStoreOffer: { groupBy: (args?: unknown) => mockGroupBy(args) },
 };
 for (const model of Object.keys(rows) as (keyof typeof rows)[]) {
-  const fn = jest.fn<() => Promise<unknown[]>>();
+  const fn: QueryMock = jest.fn<(args?: unknown) => Promise<unknown[]>>();
   findManyMocks[model] = fn;
-  prismaStub[model] = { findMany: () => fn() };
+  prismaStub[model] = { findMany: (args?: unknown) => fn(args) };
 }
 jest.mock("~/lib/db", () => ({ prisma: prismaStub }));
+
+/** The single argument object a stubbed query was called with. */
+function queryArgs(mock: {
+  mock: { calls: (unknown[] | undefined)[] };
+}): Record<string, unknown> {
+  const call = mock.mock.calls[0];
+  if (!call) throw new Error("query was never called");
+  return (call[0] ?? {}) as Record<string, unknown>;
+}
 
 interface SitemapModule {
   default: (props: { id: Promise<string> }) => Promise<MetadataRoute.Sitemap>;
@@ -120,6 +131,17 @@ interface SitemapModule {
 
 function load(): SitemapModule {
   return require("~/app/sitemap") as SitemapModule;
+}
+
+interface RobotsModule {
+  default: () => Promise<{
+    rules: { disallow?: string[] };
+    sitemap?: string[];
+  }>;
+}
+
+function loadRobots(): RobotsModule {
+  return require("~/app/robots") as RobotsModule;
 }
 
 /** Every `<loc>` the sitemap would emit, across all of its pages. */
@@ -176,16 +198,42 @@ describe("sitemap", () => {
     expect(locs).not.toContain("https://www.jita.space/assets/character");
   });
 
-  it("agrees with the robots.txt disallow list", async () => {
+  it("advertises nothing that the robots.txt it ships alongside disallows", async () => {
+    // Cross-checks the sitemap against what `robots.ts` actually emits, not
+    // against the shared constant — otherwise a hardcoded array sneaking back
+    // into robots.ts would leave both sides passing while production serves a
+    // sitemap/robots contradiction.
     const locs = await allLocs(load());
+    const { rules } = await loadRobots().default();
+    const disallow = rules.disallow ?? [];
+
+    expect(disallow.length).toBeGreaterThan(0);
+    expect([...disallow].sort()).toEqual([...CRAWLER_DISALLOWED_PATHS].sort());
 
     const contradictions = locs.filter((loc) => {
       const path = new URL(loc).pathname;
-      return CRAWLER_DISALLOWED_PATHS.some(
+      return disallow.some(
         (prefix) => path === prefix || path.startsWith(`${prefix}/`),
       );
     });
     expect(contradictions).toEqual([]);
+  });
+
+  it("filters soft-deleted rows and orders every family deterministically", async () => {
+    await allLocs(load());
+
+    for (const model of Object.keys(rows) as (keyof typeof rows)[]) {
+      const args = queryArgs(findManyMocks[model]);
+      expect(args.where).toEqual({ isDeleted: false });
+      // Without an explicit order the database may return rows in any order,
+      // which lets the two sitemap pages overlap and drop URLs.
+      expect(args.orderBy).toEqual({ [idField[model]]: "asc" });
+    }
+
+    const groupArgs = queryArgs(mockGroupBy);
+    expect(groupArgs.where).toEqual({ isDeleted: false });
+    expect(groupArgs.by).toEqual(["corporationId"]);
+    expect(groupArgs.orderBy).toEqual({ corporationId: "asc" });
   });
 
   it("never emits a dynamic segment as a literal route", async () => {
@@ -270,11 +318,24 @@ describe("sitemap", () => {
     const pages = await mod.generateSitemaps();
     expect(pages).toEqual([{ id: 0 }, { id: 1 }]);
 
+    // 5 crawlable static routes + 60,000 types + 12 single-row families.
+    const TOTAL = 5 + 60_000 + 12;
     const first = await mod.default({ id: Promise.resolve("0") });
-    expect(first).toHaveLength(50_000);
+    const second = await mod.default({ id: Promise.resolve("1") });
 
-    const locs = await allLocs(mod);
-    expect(new Set(locs).size).toBe(locs.length);
+    // Conservation: every URL lands on exactly one page, none invented.
+    expect(first).toHaveLength(50_000);
+    expect(second).toHaveLength(TOTAL - 50_000);
+
+    const locs = [...first, ...second].map((entry) => entry.url);
+    expect(locs).toHaveLength(TOTAL);
+    expect(new Set(locs).size).toBe(TOTAL);
+
+    // The page boundary is pinned, so a reordering of the assembled list — the
+    // failure the per-query `orderBy` exists to prevent — cannot slip through
+    // on length checks alone.
+    expect(first.at(-1)?.url).toBe("https://www.jita.space/type/49995");
+    expect(second[0]?.url).toBe("https://www.jita.space/type/49996");
     expect(locs).toContain("https://www.jita.space/type/60000");
   });
 

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -300,8 +300,10 @@ describe("sitemap", () => {
     errorSpy.mockRestore();
   });
 
-  it("normalizes a trailing slash on the configured origin", async () => {
-    mockEnv.NEXT_PUBLIC_SITE_URL = "https://www.jita.space/";
+  it("normalizes trailing slashes on the configured origin", async () => {
+    // A run of slashes, not just one — the stripping is a linear scan and this
+    // is the input shape that made the previous regex backtrack.
+    mockEnv.NEXT_PUBLIC_SITE_URL = "https://www.jita.space///";
 
     const locs = await allLocs(load());
 

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -248,14 +248,20 @@ describe("sitemap", () => {
   });
 
   it("advertises the index in robots.txt, and the index lists every page", async () => {
-    // robots.txt names only the index; the index expands to the numbered pages.
-    // Both derive from ./sitemap.ts, so this pins the chain end to end.
+    // robots.txt names the index plus page 0 (see the note in app/robots.ts);
+    // the index expands to the numbered pages. Both derive from ./sitemap.ts,
+    // so this pins the chain end to end. Order matters: the index must come
+    // first, and page 0 is pinned rather than incidental so that removing it
+    // later is a deliberate edit here, not a silent drift.
     const xml = await (await loadSitemapIndex().GET()).text();
     const indexed = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
     const { sitemap: advertised } = loadRobots().default();
     const pages = await load().generateSitemaps();
 
-    expect(advertised).toBe("https://www.jita.space/sitemap.xml");
+    expect(advertised).toEqual([
+      "https://www.jita.space/sitemap.xml",
+      "https://www.jita.space/sitemap/0.xml",
+    ]);
     expect(indexed).toEqual(await load().getSitemapUrls());
     expect(indexed).toHaveLength(pages.length);
     expect(xml).toContain("<sitemapindex");

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -30,6 +30,11 @@ const APP_TREE: Tree = {
   assets: { character: { "page.tsx": FILE } },
   // Dynamic segments never become static routes.
   type: { "[typeId]": { "page.tsx": FILE } },
+  // An optional catch-all matches zero segments, so `/travel` is a real route
+  // even though `travel/` holds no page file of its own.
+  travel: { "[[...waypoints]]": { "page.tsx": FILE } },
+  // A required catch-all does NOT serve its parent — `/docs` is not a route.
+  docs: { "[...slug]": { "page.tsx": FILE } },
   // Directories without a page file are traversed but contribute nothing.
   components: { "helper.ts": FILE },
 };
@@ -191,6 +196,15 @@ describe("sitemap", () => {
     expect(locs).toContain("https://www.jita.space/preview");
   });
 
+  it("registers the parent of an optional catch-all, but not of a required one", async () => {
+    const locs = await allLocs(load());
+
+    // `[[...waypoints]]` matches zero segments, so /travel is a real page.
+    expect(locs).toContain("https://www.jita.space/travel");
+    // `[...slug]` requires at least one segment, so /docs is not.
+    expect(locs).not.toContain("https://www.jita.space/docs");
+  });
+
   it("omits routes robots.txt disallows, including nested ones", async () => {
     const locs = await allLocs(load());
 
@@ -320,8 +334,9 @@ describe("sitemap", () => {
     const pages = await mod.generateSitemaps();
     expect(pages).toEqual([{ id: 0 }, { id: 1 }]);
 
-    // 5 crawlable static routes + 60,000 types + 12 single-row families.
-    const TOTAL = 5 + 60_000 + 12;
+    // 6 crawlable static routes (incl. the optional catch-all's parent)
+    // + 60,000 types + 12 single-row families.
+    const TOTAL = 6 + 60_000 + 12;
     const first = await mod.default({ id: Promise.resolve("0") });
     const second = await mod.default({ id: Promise.resolve("1") });
 
@@ -336,8 +351,8 @@ describe("sitemap", () => {
     // The page boundary is pinned, so a reordering of the assembled list — the
     // failure the per-query `orderBy` exists to prevent — cannot slip through
     // on length checks alone.
-    expect(first.at(-1)?.url).toBe("https://www.jita.space/type/49995");
-    expect(second[0]?.url).toBe("https://www.jita.space/type/49996");
+    expect(first.at(-1)?.url).toBe("https://www.jita.space/type/49994");
+    expect(second[0]?.url).toBe("https://www.jita.space/type/49995");
     expect(locs).toContain("https://www.jita.space/type/60000");
   });
 

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -82,8 +82,6 @@ const rows = {
   faction: [500001],
   race: [1],
   bloodline: [1],
-  dogmaAttribute: [9],
-  dogmaEffect: [11],
 };
 
 const idField: Record<keyof typeof rows, string> = {
@@ -97,8 +95,6 @@ const idField: Record<keyof typeof rows, string> = {
   faction: "factionId",
   race: "raceId",
   bloodline: "bloodlineId",
-  dogmaAttribute: "attributeId",
-  dogmaEffect: "effectId",
 };
 
 // The stubs forward their arguments so the suite can assert the `where` and
@@ -238,7 +234,13 @@ describe("sitemap", () => {
 
     for (const model of Object.keys(rows) as (keyof typeof rows)[]) {
       const args = queryArgs(findManyMocks[model]);
-      expect(args.where).toEqual({ isDeleted: false });
+      // `/type` additionally excludes typeId 0, whose page renders the
+      // not-found UI behind an HTTP 200 — a soft 404 if advertised.
+      expect(args.where).toEqual(
+        model === "type"
+          ? { isDeleted: false, typeId: { gt: 0 } }
+          : { isDeleted: false },
+      );
       // Without an explicit order the database may return rows in any order,
       // which lets the two sitemap pages overlap and drop URLs.
       expect(args.orderBy).toEqual({ [idField[model]]: "asc" });
@@ -274,8 +276,6 @@ describe("sitemap", () => {
         "https://www.jita.space/faction/500001",
         "https://www.jita.space/race/1",
         "https://www.jita.space/bloodline/1",
-        "https://www.jita.space/dogma/attribute/9",
-        "https://www.jita.space/dogma/effect/11",
         "https://www.jita.space/lp-store/1000035",
       ]),
     );
@@ -315,8 +315,8 @@ describe("sitemap", () => {
   });
 
   it("normalizes trailing slashes on the configured origin", async () => {
-    // A run of slashes, not just one — the stripping is a linear scan and this
-    // is the input shape that made the previous regex backtrack.
+    // A run of slashes, not just one: stripping only the last would leave a
+    // doubled separator on every URL.
     mockEnv.NEXT_PUBLIC_SITE_URL = "https://www.jita.space///";
 
     const locs = await allLocs(load());
@@ -335,8 +335,8 @@ describe("sitemap", () => {
     expect(pages).toEqual([{ id: 0 }, { id: 1 }]);
 
     // 6 crawlable static routes (incl. the optional catch-all's parent)
-    // + 60,000 types + 12 single-row families.
-    const TOTAL = 6 + 60_000 + 12;
+    // + 60,000 types + 10 single-row families.
+    const TOTAL = 6 + 60_000 + 10;
     const first = await mod.default({ id: Promise.resolve("0") });
     const second = await mod.default({ id: Promise.resolve("1") });
 


### PR DESCRIPTION
## The bug

Every static route in the sitemap was written as a relative path. Live on production before this change:

```xml
<loc>/</loc>
<loc>/about</loc>
```

The sitemap protocol requires fully-qualified URLs, so crawlers discard these. Only the `/type/{id}` entries — which already prefixed `CONFIG.SITE_URL` — were ever valid. All 36 static routes were invisible to search.

## What changed

**Absolute URLs.** Every `<loc>` is now fully qualified, and a trailing slash on the configured origin is normalized away.

**11 entity families instead of 1.** Was types only. Now also categories, groups, regions, constellations, systems, stations, factions, races, bloodlines, and one page per NPC corporation that actually has loyalty-store offers.

Deliberately excluded, documented on `ENTITY_SOURCES`: player entities (characters, corporations, alliances, killmails, contracts, wars) as unbounded and churning; map minutiae (planets, moons, stars — ~90k rows) as too thin to rank; and dogma attributes/effects, see below.

**Dogma attributes and effects are excluded on purpose.** Each of those ~8k pages renders every type carrying the attribute. Measured against production: `/dogma/attribute/4` (mass) is 29.8 MB and took 70 s; `/dogma/attribute/9` is 18.2 MB in 39 s. The responses exceed the 2 MB `"use cache"` entry limit, so `cacheLife("days")` silently never stores and every hit is a full-table join; several also exceed Google's 15 MB fetch cap. Nothing links to them today, so the sitemap would have been the crawler's way in. Restore once those pages cap their type list.

**Soft-404 filtering.** `isDeleted: false` on every query, plus `typeId > 0` — the row exists, but `/type/0` renders the not-found UI while returning HTTP 200, because the page treats falsy `0` as missing and the `notFound()` throws inside a `<Suspense>` boundary. Production advertises it today.

**Sitemap and robots.txt can no longer contradict each other.** The sitemap was listing `/assets`, `/mail`, `/wallet` and friends while robots.txt blocked them — an error Search Console reports. The disallow list now lives in `apps/web/config/seo.ts`, is imported by both, and gates entity families as well as static routes.

**`/travel` and `/ship-scanner` are now indexable.** Both are anonymous, cacheable, server-rendered pages that robots.txt was blocking for no benefit. `/travel` needed more than unblocking: its page lives in `[[...waypoints]]`, and the route walk skipped every dynamic segment — an optional catch-all matches zero segments, so it serves its own parent. The walk now registers that; a required catch-all (`[...slug]`) still doesn't.

**Deterministic row order.** All 11 queries specify `orderBy`. `/sitemap/0.xml` and `/sitemap/1.xml` are separate requests, potentially answered by different instances from different cache snapshots — without a defined order the two pages would submit some URLs twice and drop others.

**Failure isolation.** A failed family query drops that family, not the sitemap, and the degraded list is deliberately not cached — the same trap `e60062ec` removed from the type and system pages. An unreadable `app/` directory is treated the same way.

**Fewer redundant queries.** The route is fully dynamic (`x-vercel-cache: MISS`, `max-age=0`), so before this change every robots.txt and sitemap request re-ran a 52k-row type scan. A one-hour module-level cache holds the assembled list.

## Deliberately left alone

The sitemap still lists all ~52k types including unpublished ones. Excluding them would sharpen crawl budget but deindexes currently-listed pages — a one-line `where` change whenever wanted.

## Verification

- Repo-wide `pnpm type-check`: green
- `apps/web` Jest: 137 suites, 1131 tests passing (15 new)
- ESLint clean on all changed files; SonarCloud 0 new issues
- Verified against the **real** `app/` tree, not just the mocked one: robots.txt drops to 11 `Disallow` rules and the sitemap emits 21 static URLs, all absolute, 0 relative `<loc>`, 0 disallowed leaks

The new tests are mutation-tested. Dropping an `orderBy`, dropping an `isDeleted` filter, hardcoding a divergent list back into `robots.ts`, and re-sorting the paginated slice each fail exactly one test.

## Follow-ups (not in this PR)

- A silently degraded family logs to `console.error` only — a `Sentry.captureException` would close the loop, plus a short negative TTL to bound retry load during an outage.
- `generateSitemaps()` fixes the servable id set at build time while `getSitemapUrls()` recomputes it per request, so a build-time query failure could leave robots.txt pointing at a sitemap page that 404s.
- All URLs share one `lastmod`; every model has `@updatedAt`, so per-URL values are one extra column away.
- `/lp-store/all` (8.3 MB) has the same over-fetch shape as the dogma pages.

## After merge

Submit `https://www.jita.space/sitemap/0.xml` in Google Search Console — the indexed-page count is where this shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
