### PR TITLE
fix(auth-utils): bind token verification to the EVE application

### DIFF
--- a/.changeset/prepack-instead-of-prepublishonly.md
+++ b/.changeset/prepack-instead-of-prepublishonly.md
@@ -1,0 +1,17 @@
+---
+"@jitaspace/auth-utils": patch
+"@jitaspace/esi-metadata": patch
+"@jitaspace/tiptap-eve": patch
+"@jitaspace/db": patch
+---
+
+build: run the publishable packages' build on `prepack`, not `prepublishOnly`
+
+`prepublishOnly` does not run for `pack`, and `dist/` is gitignored — so in a
+fresh clone `pnpm pack` silently produced a tarball containing only
+`package.json`, `README.md` and `LICENSE`, with no code, while its manifest
+still advertised `main: ./dist/index.cjs`. Nothing warned at any step.
+
+`prepack` runs for `pnpm pack`, `npm pack` and `pnpm publish` alike, so packing
+and publishing now both build first. (Keeping both hooks would build twice on
+publish, so this replaces rather than adds.)

--- a/.changeset/publish-auth-utils-package.md
+++ b/.changeset/publish-auth-utils-package.md
@@ -4,4 +4,6 @@
 
 feat(auth-utils): publish @jitaspace/auth-utils as a public npm package
 
-Adds a tsup build step (CJS + ESM + types), removes the private flag, and adds publishConfig/files/repository metadata plus a bundled MIT LICENSE. Declares the previously-undeclared `zod` runtime dependency and drops the unused `next`/`react`/`react-dom` dependencies. Keeps `@jitaspace/esi-metadata` (now also published) for the `ESIScope` type.
+Adds a tsup build step (CJS + ESM + types), removes the private flag, and adds publishConfig/files/repository metadata plus a bundled MIT LICENSE. Declares the previously-undeclared `zod` runtime dependency and drops the unused `next`/`react`/`react-dom` dependencies. Keeps `@jitaspace/esi-metadata` for the `ESIScope` type.
+
+Note `@jitaspace/esi-metadata` must be released in the same batch: `workspace:*` packs as an exact version pin, so publishing `auth-utils` on its own produces a tarball that 404s at install time. Release both via the root `pnpm publish-packages`, then smoke-install the published package — in-repo CI resolves through the workspace symlink and cannot catch this.

--- a/.changeset/verify-token-client-binding.md
+++ b/.changeset/verify-token-client-binding.md
@@ -1,0 +1,26 @@
+---
+"@jitaspace/auth-utils": minor
+"@jitaspace/auth": patch
+---
+
+fix(auth-utils): bind `verifyEveSsoAccessToken` to a specific EVE application
+
+`verifyEveSsoAccessToken` checked only the constant `aud` value `"EVE Online"`,
+which every EVE SSO token carries for every third-party application. A
+validly-signed token minted for a _different_ EVE application therefore passed
+verification — token substitution.
+
+`verifyEveSsoAccessToken` now accepts a `clientId` option; when supplied, the
+token's `azp` (authorized party) must equal it, so a successful verification
+proves the token was issued to _your_ application. It is checked in addition to
+the existing `iss`/`aud`/`exp` claims and throws jose's `JWTClaimValidationFailed`
+on mismatch. `@jitaspace/auth` passes it at both call sites (`completeLoginFlow`
+and `refreshTokenApiRouteHandler`).
+
+The option is opt-in, so existing behaviour is unchanged when it is omitted —
+but omitting it is only safe for a token you just obtained yourself from
+`exchangeEveSsoToken` / `refreshEveSsoToken`. Anything verifying a token supplied
+by a client should pass `clientId`.
+
+Also fixes `EveSsoAccessTokenPayload.aud`, which was typed `string` even though
+EVE may issue an array.

--- a/packages/auth-utils/package.json
+++ b/packages/auth-utils/package.json
@@ -27,7 +27,7 @@
     "clean": "rm -rf .turbo node_modules dist",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
-    "prepublishOnly": "pnpm build",
+    "prepack": "pnpm build",
     "test": "jest",
     "type-check": "tsc --noEmit"
   },

--- a/packages/auth-utils/tests/verifyEveSsoAccessToken.test.ts
+++ b/packages/auth-utils/tests/verifyEveSsoAccessToken.test.ts
@@ -26,17 +26,26 @@ beforeAll(async () => {
   foreignKey = foreign.privateKey;
 });
 
+const OUR_CLIENT_ID = "our-client-id";
+const OTHER_CLIENT_ID = "some-other-eve-app";
+
 const mintToken = (
   signer: CryptoKey,
-  claims: { iss?: string; aud?: string; expSecondsFromNow?: number } = {},
+  claims: {
+    iss?: string;
+    aud?: string | string[];
+    azp?: string;
+    expSecondsFromNow?: number;
+  } = {},
 ) => {
   const {
     iss = "login.eveonline.com",
     aud = EVE_SSO_AUDIENCE,
+    azp = OUR_CLIENT_ID,
     expSecondsFromNow = 1200,
   } = claims;
 
-  return new SignJWT({ sub: "CHARACTER:EVE:123", scp: ["publicData"] })
+  return new SignJWT({ sub: "CHARACTER:EVE:123", scp: ["publicData"], azp })
     .setProtectedHeader({ alg: "RS256", kid: KID })
     .setIssuer(iss)
     .setAudience(aud)
@@ -44,6 +53,9 @@ const mintToken = (
     .setExpirationTime(Math.floor(Date.now() / 1000) + expSecondsFromNow)
     .sign(signer);
 };
+
+/** A real EVE token's `aud` carries the client id alongside the constant. */
+const eveAudience = (clientId: string) => [clientId, EVE_SSO_AUDIENCE];
 
 describe("verifyEveSsoAccessToken", () => {
   it("resolves with the payload for a validly-signed EVE token", async () => {
@@ -88,5 +100,61 @@ describe("verifyEveSsoAccessToken", () => {
     await expect(
       verifyEveSsoAccessToken(token, { jwks }),
     ).rejects.toBeDefined();
+  });
+
+  describe("clientId binding", () => {
+    it("resolves when the token was issued to this application", async () => {
+      const token = await mintToken(signingKey, {
+        aud: eveAudience(OUR_CLIENT_ID),
+        azp: OUR_CLIENT_ID,
+      });
+      const payload = await verifyEveSsoAccessToken(token, {
+        jwks,
+        clientId: OUR_CLIENT_ID,
+      });
+      expect(payload.sub).toBe("CHARACTER:EVE:123");
+    });
+
+    // The whole point of the option: "EVE Online" is in every EVE app's tokens,
+    // so without `clientId` a validly-signed token from another application is
+    // indistinguishable from one of ours (token substitution).
+    it("rejects a validly-signed token issued to a different EVE application", async () => {
+      const token = await mintToken(signingKey, {
+        aud: eveAudience(OTHER_CLIENT_ID),
+        azp: OTHER_CLIENT_ID,
+      });
+
+      await expect(
+        verifyEveSsoAccessToken(token, { jwks, clientId: OUR_CLIENT_ID }),
+      ).rejects.toMatchObject({ claim: "azp" });
+
+      // …and is accepted without `clientId`, which is why it must be passed.
+      await expect(
+        verifyEveSsoAccessToken(token, { jwks }),
+      ).resolves.toBeDefined();
+    });
+
+    // EVE is documented to put the client id in `aud`, but tokens carrying the
+    // bare constant exist too (see the fixture in
+    // getEveSsoAccessTokenPayload.test.ts), so `azp` must carry the check alone.
+    it('accepts the bare `aud: "EVE Online"` form when azp matches', async () => {
+      const token = await mintToken(signingKey, {
+        aud: EVE_SSO_AUDIENCE,
+        azp: OUR_CLIENT_ID,
+      });
+      await expect(
+        verifyEveSsoAccessToken(token, { jwks, clientId: OUR_CLIENT_ID }),
+      ).resolves.toBeDefined();
+    });
+
+    it("still enforces the constant audience alongside the client id", async () => {
+      const token = await mintToken(signingKey, {
+        aud: [OUR_CLIENT_ID],
+        azp: OUR_CLIENT_ID,
+      });
+      await expect(
+        verifyEveSsoAccessToken(token, { jwks, clientId: OUR_CLIENT_ID }),
+      ).rejects.toBeDefined();
+    });
   });
 });

--- a/packages/auth-utils/utils/getEveSsoAccessTokenPayload.ts
+++ b/packages/auth-utils/utils/getEveSsoAccessTokenPayload.ts
@@ -9,7 +9,8 @@ export interface EveSsoAccessTokenPayload {
   tenant: string;
   tier: string;
   region: string;
-  aud: string;
+  /** EVE issues an array — the client id the token was minted for, plus "EVE Online". */
+  aud: string | string[];
   name: string;
   owner: string;
   exp: number;

--- a/packages/auth-utils/utils/verifyEveSsoAccessToken.ts
+++ b/packages/auth-utils/utils/verifyEveSsoAccessToken.ts
@@ -14,7 +14,13 @@ export const EVE_SSO_ISSUERS = [
   "https://login.eveonline.com",
 ];
 
-/** The constant `aud` value EVE SSO access tokens carry (alongside the client id). */
+/**
+ * The constant `aud` value EVE SSO access tokens carry (alongside the client id).
+ *
+ * Note this value is the *same for every EVE application*, so on its own it only
+ * proves EVE minted the token — not that the token was minted for you. Pass
+ * `clientId` to {@link verifyEveSsoAccessToken} to assert the latter.
+ */
 export const EVE_SSO_AUDIENCE = "EVE Online";
 
 // EVE signs with the asymmetric keys published in its JWKS. Pinning to those
@@ -35,6 +41,13 @@ let remoteJwks: JWTVerifyGetKey | undefined;
  * payload — a successful call here cryptographically proves EVE issued the
  * token, so its claims can be trusted.
  *
+ * **Pass `clientId` whenever the token did not come from your own
+ * {@link exchangeEveSsoToken} / {@link refreshEveSsoToken} call** — most
+ * importantly when verifying a bearer token presented by a client. Without it
+ * the only audience checked is {@link EVE_SSO_AUDIENCE}, which every EVE
+ * application's tokens carry, so a token minted for a *different* EVE
+ * application verifies successfully (token substitution).
+ *
  * `jose` is imported dynamically so this server-only, ESM-only dependency stays
  * out of the client bundle and out of consumers' eager module graphs (e.g. the
  * client-side `useAuthStore`, which only needs `getEveSsoAccessTokenPayload`).
@@ -42,13 +55,19 @@ let remoteJwks: JWTVerifyGetKey | undefined;
 export async function verifyEveSsoAccessToken(
   token: string,
   options?: {
+    /**
+     * Your EVE application's client id. When supplied, the token's `azp`
+     * (authorized party) must equal it, proving the token was issued to *your*
+     * application. Checked in addition to — not instead of — `audience`.
+     */
+    clientId?: string;
     /** Override the key resolver — e.g. a local JWKS in tests. */
     jwks?: JWTVerifyGetKey;
     issuer?: string | string[];
     audience?: string | string[];
   },
 ): Promise<EveSsoAccessTokenPayload> {
-  const { createRemoteJWKSet, jwtVerify } = await import("jose");
+  const { createRemoteJWKSet, errors, jwtVerify } = await import("jose");
 
   const jwks =
     options?.jwks ??
@@ -59,6 +78,21 @@ export async function verifyEveSsoAccessToken(
     issuer: options?.issuer ?? EVE_SSO_ISSUERS,
     audience: options?.audience ?? EVE_SSO_AUDIENCE,
   });
+
+  // `azp` (authorized party) is the client id the token was issued to, and is
+  // the one claim that distinguishes our tokens from another EVE application's.
+  // Deliberately not also requiring the client id in `aud`: EVE is documented to
+  // put it there, but tokens carrying the bare `aud: "EVE Online"` exist too, and
+  // `azp` alone is already decisive.
+  const { clientId } = options ?? {};
+  if (clientId !== undefined && payload.azp !== clientId) {
+    throw new errors.JWTClaimValidationFailed(
+      'unexpected "azp" claim value',
+      payload,
+      "azp",
+      "check_failed",
+    );
+  }
 
   return payload as unknown as EveSsoAccessTokenPayload;
 }

--- a/packages/auth/src/oauth/flow.ts
+++ b/packages/auth/src/oauth/flow.ts
@@ -137,12 +137,13 @@ export async function completeLoginFlow(params: {
   });
 
   // Verify the token's signature against EVE's published JWKS (and the
-  // iss/aud/exp claims) before trusting anything it contains.
-  const payload = await verifyEveSsoAccessToken(tokens.access_token).catch(
-    () => {
-      throw new OAuthFlowError("Access token failed verification.");
-    },
-  );
+  // iss/aud/exp claims) before trusting anything it contains. `clientId` binds
+  // it to this application — without it any EVE app's token would verify.
+  const payload = await verifyEveSsoAccessToken(tokens.access_token, {
+    clientId: eveClientId,
+  }).catch(() => {
+    throw new OAuthFlowError("Access token failed verification.");
+  });
 
   // Same sealed shape `refreshTokenApiRouteHandler` / `tokenRefreshDataSchema`
   // expect, so the existing refresh path can consume it unchanged.

--- a/packages/auth/src/refreshTokenApiRouteHandler.ts
+++ b/packages/auth/src/refreshTokenApiRouteHandler.ts
@@ -83,8 +83,11 @@ export const refreshTokenApiRouteHandler = async (
   });
 
   // Verify the refreshed token's signature against EVE's JWKS (and the
-  // iss/aud/exp claims) before trusting its payload.
-  const payload = await verifyEveSsoAccessToken(access_token).catch(() => null);
+  // iss/aud/exp claims) before trusting its payload. `clientId` binds it to
+  // this application — without it any EVE app's token would verify.
+  const payload = await verifyEveSsoAccessToken(access_token, {
+    clientId: eveClientId,
+  }).catch(() => null);
 
   if (!payload)
     return Response.json(

--- a/packages/auth/tests/flow.test.ts
+++ b/packages/auth/tests/flow.test.ts
@@ -99,6 +99,12 @@ describe("completeLoginFlow", () => {
     expect(exchangeEveSsoToken).toHaveBeenCalledWith(
       expect.objectContaining({ eveClientId, eveClientSecret }),
     );
+    // Without `clientId` the verification would accept a token minted for any
+    // other EVE application, so the pass-through must not regress.
+    expect(verifyEveSsoAccessToken).toHaveBeenCalledWith(
+      "AT",
+      expect.objectContaining({ clientId: eveClientId }),
+    );
   });
 
   it("throws when the flow cookie is missing", async () => {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -41,7 +41,7 @@
     "dev": "pnpm with-env concurrently -c \"auto\" --names \"Studio,Watch\" \"pnpm:db:studio\" \"pnpm:db:generate:watch\"",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
-    "prepublishOnly": "pnpm build",
+    "prepack": "pnpm build",
     "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --"
   },

--- a/packages/esi-metadata/package.json
+++ b/packages/esi-metadata/package.json
@@ -28,7 +28,7 @@
     "clean": "rm -rf .turbo node_modules dist",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
-    "prepublishOnly": "pnpm build",
+    "prepack": "pnpm build",
     "type-check": "tsc --noEmit",
     "test": "jest"
   },

--- a/packages/tiptap-eve/package.json
+++ b/packages/tiptap-eve/package.json
@@ -27,7 +27,7 @@
     "clean": "rm -rf .turbo node_modules dist",
     "lint": "eslint --flag unstable_native_nodejs_ts_config .",
     "lint:fix": "pnpm lint --fix",
-    "prepublishOnly": "pnpm build",
+    "prepack": "pnpm build",
     "test": "jest --config ./jest.config.ts --runInBand",
     "test:watch": "jest --config ./jest.config.ts --watch",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
First pass from a publish-readiness review of `@jitaspace/auth-utils`. Three changes: a token-substitution fix in `verifyEveSsoAccessToken`, a packaging fix so `pack` actually builds, and a correction to a changeset that misstated registry state.

## 1. `verifyEveSsoAccessToken` accepted tokens issued to other EVE applications

`verifyEveSsoAccessToken` checked only the constant `aud` value `"EVE Online"` — a value **every** EVE SSO token carries, for every third-party application. The claims that identify the application (`azp`, and the client id in `aud`) were never checked, so a validly-signed token minted for a *different* EVE application passed verification. Reproduced before fixing: a token with `azp: "SOME_OTHER_APP_CLIENT_ID"` signed by the trusted key verified and returned its payload.

This was **not exploitable as the code stands** — both call sites verify a token they just minted with our own client credentials. The exposure is the published API: the docstring says a successful call "proves EVE issued the token, so its claims can be trusted", which invites the canonical use of validating an inbound `Authorization: Bearer` header. A consumer doing that would accept any other EVE app's users as their own.

`verifyEveSsoAccessToken` now takes a `clientId` option; when supplied, the token's `azp` (authorized party) must equal it. It is checked *in addition to* the existing `iss`/`aud`/`exp` claims and throws jose's `JWTClaimValidationFailed`, so consumer error handling stays uniform with jose's own claim checks. Both call sites in `@jitaspace/auth` pass it.

**Why `azp` alone, and not also the client id in `aud`:** the first cut required both. The repo's own sample EVE token (`getEveSsoAccessTokenPayload.test.ts`) carries the bare `aud: "EVE Online"` with no client id, alongside `azp: "myclientid"` — so requiring it in `aud` would have rejected real tokens and broken login. `azp` is decisive on its own, and a test now pins the bare-`aud` form as acceptable.

The option is opt-in, so behaviour is unchanged when it is omitted — but omitting it is only safe for a token you just obtained yourself from `exchangeEveSsoToken` / `refreshEveSsoToken`.

Also fixes `EveSsoAccessTokenPayload.aud`, typed `string` though EVE may issue an array. Nothing in the repo reads `.aud`, so widening it is safe.

## 2. Publishable packages build on `prepack`, not `prepublishOnly`

`prepublishOnly` does not run for `pack`, and `dist/` is gitignored — so in a fresh clone `pnpm pack` silently produced a tarball containing only `package.json`, `README.md` and `LICENSE`, no code, while its manifest still advertised `main: ./dist/index.cjs`. Nothing warned at any step.

Verified before and after: from a clean tree the tarball now contains all four `dist/` files. `prepack` covers `pnpm pack`, `npm pack` and `pnpm publish` alike; it replaces rather than joins `prepublishOnly`, which would otherwise build twice on publish. Applied to all four publishable packages (`auth-utils`, `db`, `esi-metadata`, `tiptap-eve`).

## 3. Corrected the publish changeset

`.changeset/publish-auth-utils-package.md` stated that `@jitaspace/esi-metadata` was "now also published". It is not on npm — nor are `auth-utils` or `db`; of the four publishable workspaces only `@jitaspace/tiptap-eve@0.1.6` has ever reached the registry.

This matters because `workspace:*` packs as an **exact** version pin. Publishing `auth-utils` on its own yields a tarball that 404s at install time — confirmed by packing it and installing into a scratch project: `404 '@jitaspace/esi-metadata@0.2.2' is not in this registry`. The changeset now records that both must ship in the same batch via the root `pnpm publish-packages`, followed by a smoke install — in-repo CI resolves through the workspace symlink and can never catch this.

**No package is published by this PR.** That release step is still outstanding and is the actual gate on `auth-utils` being installable.

## Testing

New tests in `verifyEveSsoAccessToken.test.ts`, including a guard asserting the foreign-app token is rejected **with** `clientId` and still accepted **without** it, so the vulnerability stays documented and cannot silently return. A wiring assertion in `packages/auth/tests/flow.test.ts` keeps the `clientId` pass-through from regressing.

- `auth-utils`: 23 passing (up from 19)
- `auth`: 14 passing
- `tsc --noEmit` clean on `auth-utils`, `auth`, `esi-metadata`, `tiptap-eve`, `db`
- ESLint clean on `auth-utils` and `auth`; `manypkg check` and Prettier clean

Repo-wide `pnpm lint` / `pnpm type-check` could not be run in the authoring environment: `packages/sde-client` regenerates from `sde.jita.space`, which that environment's network policy blocks (403), and every `pnpm run <script>` fails on the resulting dep check. The lintable part of this diff is confined to `auth-utils` and `auth` — the other three packages are one-line script renames — and both were linted directly. CI runs the full gate on a clean checkout.

## Deployment note

The `azp` check sits on the live login path. If CCP's tokens ever omit `azp` or set it to something other than the client id, login fails closed with a re-auth prompt rather than failing open. CCP documents `azp` as the client id and the repo's own fixture agrees, but a single real login on a preview deploy is worth doing before this reaches production.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADHmgFEUasmauoNDpkggAg)_