### PR TITLE
auth-utils: exports map, EVE token errors, and drop the app-internal schema

### DIFF
--- a/.changeset/auth-utils-drop-buffer.md
+++ b/.changeset/auth-utils-drop-buffer.md
@@ -1,0 +1,37 @@
+---
+"@jitaspace/auth-utils": minor
+---
+
+feat(auth-utils): remove the Node `Buffer` requirement
+
+`Buffer` was used as a bare global in three places — building the Basic auth
+header for both token calls, and base64-decoding the JWT payload. That made the
+package Node-only, which is worst for `getEveSsoAccessTokenPayload`: it is
+imported by client-side code and works in Next.js only because Next polyfills
+`Buffer` into client bundles. A Vite app, a Cloudflare Worker without
+`nodejs_compat`, or Deno without `--unstable-node-globals` would throw
+`ReferenceError: Buffer is not defined` from a function that is otherwise pure
+string arithmetic.
+
+All three now use web-standard `atob`/`btoa` with `TextEncoder`/`TextDecoder`.
+Two details that a naive swap gets wrong, and that this handles:
+
+- **JWT segments are base64url.** They use the `-`/`_` alphabet and drop
+  padding. `Buffer.from(x, "base64")` tolerated that silently; `atob` throws
+  `InvalidCharacterError`. The alphabet is translated and padding restored
+  before decoding.
+- **`atob`/`btoa` are Latin-1.** `btoa` throws on any code point above U+00FF,
+  and `atob` returns a binary string — so a client secret or character name
+  containing non-ASCII would fail or come back as mojibake. The
+  `TextEncoder`/`TextDecoder` steps make both paths UTF-8, matching `Buffer`'s
+  behaviour exactly.
+
+Verified byte-for-byte against `Buffer` across ASCII, Latin-1, CJK and emoji
+inputs and every padding remainder, and by running the built bundle with the
+`Buffer` global deleted.
+
+`getEveSsoAccessTokenPayload` also now honours its `| null` return type for
+every malformed token, not just a missing segment. Decoding can fail on invalid
+base64 or invalid JSON, and since the token is untrusted input neither should
+escape as a throw — previously a malformed payload threw from a function whose
+signature promised otherwise.

--- a/.changeset/publishconfig-exports-map.md
+++ b/.changeset/publishconfig-exports-map.md
@@ -1,0 +1,31 @@
+---
+"@jitaspace/auth-utils": patch
+"@jitaspace/esi-metadata": patch
+"@jitaspace/tiptap-eve": patch
+"@jitaspace/db": patch
+---
+
+build: declare a conditional `exports` map for the publishable packages
+
+`auth-utils`, `esi-metadata` and `tiptap-eve` published only `main`/`module`/`types`.
+Node ignores `module` entirely, so with the package marked `"type": "module"` both
+of the following were wrong for anyone installing from npm:
+
+- **ESM consumers loaded the CJS build.** `import.meta.resolve` landed on
+  `dist/index.cjs`, so the ESM output shipped in every tarball but was never used,
+  and the namespace object carried a spurious `default` key.
+- **CJS TypeScript consumers could not compile.** Under `module: node16`,
+  `types` resolved to `dist/index.d.ts`, which is ESM, giving
+  `TS1479: ... cannot be imported with 'require'`. Runtime was fine, so this was
+  purely a type-resolution failure — and invisible in-repo, where `nodenext` and
+  `bundler` both pass.
+
+All three now declare the same `import`/`require` map `@jitaspace/db` already used,
+pointing `require` at the `dist/index.d.cts` that `tsup --dts` was already emitting
+but nothing referenced. Every package also exposes `./package.json`, which some
+tooling reads.
+
+The map lives under `publishConfig`, not at the top level: `exports` outranks
+`main`, so a top-level map pointing into `dist/` would override
+`main: "./index.ts"` and break in-repo consumption via `transpilePackages`, which
+expects TypeScript source that `dist/` does not contain in a fresh clone.

--- a/.changeset/refresh-revoked-token-reauth.md
+++ b/.changeset/refresh-revoked-token-reauth.md
@@ -1,0 +1,9 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the app retrying forever when an EVE login was revoked. If you removed
+JitaSpace's authorization in EVE, or changed your password, the affected
+character's session could no longer be renewed — but the app kept retrying the
+renewal every 30 seconds instead of telling you. That character is now marked as
+needing you to log in again, as it already was for logins that simply aged out.

--- a/.changeset/sso-token-error-and-schema-move.md
+++ b/.changeset/sso-token-error-and-schema-move.md
@@ -1,0 +1,37 @@
+---
+"@jitaspace/auth-utils": minor
+"@jitaspace/auth": patch
+"@jitaspace/web": patch
+---
+
+feat(auth-utils): surface EVE's token errors, and drop the app-internal schema
+
+**`EveSsoTokenError`.** `exchangeEveSsoToken` and `refreshEveSsoToken` threw a
+fixed-string `Error`, discarding both the HTTP status and EVE's RFC 6749 §5.2
+`{error, error_description}` body. That made a permanently revoked refresh token
+indistinguishable from a passing 5xx, so the web app treated every failure as
+transient and retried a doomed refresh every 30 seconds without ever flagging
+the session for re-authentication.
+
+Both calls now throw an `EveSsoTokenError` carrying `status`, `error`,
+`errorDescription`, and a `requiresReauthentication` helper for the
+`invalid_grant` case. `refreshTokenApiRouteHandler` maps that onto the `410` it
+already returns for over-age tokens, which `apps/web` already translates into
+`requires-reauth` — so a revoked token now marks the session expired instead of
+looping. The body is read with `text()` and parsed inside a `try`, never a bare
+`response.json()`: EVE 5xx responses and CDN edges return HTML, which would
+otherwise turn a clean auth error into a `SyntaxError`. The unconditional
+`console.error` in both helpers is gone; a library should report through the
+error it throws.
+
+**Exported result types.** `SsoTokenSuccessResult` and
+`SsoRefreshTokenSuccessResult` were emitted into the `.d.ts` but left out of its
+export list, so consumers could not name the return types.
+
+**`tokenRefreshDataSchema` moved to `@jitaspace/auth`.** It describes this
+application's sealed cookie (camelCase `{accessTokenExpiration, refreshToken}`),
+not anything EVE sends — its only consumer is `refreshTokenApiRouteHandler`, in
+a package that is private and unpublished. Removing it drops `zod` as a runtime
+dependency of `@jitaspace/auth-utils` entirely, leaving `jose` and
+`@jitaspace/esi-metadata`. `@jitaspace/auth` now declares the `zod` it was
+already importing.

--- a/packages/auth-utils/README.md
+++ b/packages/auth-utils/README.md
@@ -14,7 +14,9 @@ npm install @jitaspace/auth-utils
 pnpm add @jitaspace/auth-utils
 ```
 
-Requires a runtime with global `fetch` and `Buffer` (Node.js 18+, or an equivalent modern runtime). No framework dependency — usable from any server, route handler, or worker.
+Requires only web-standard globals — `fetch`, `atob`/`btoa` and `TextEncoder`/`TextDecoder` — so it runs unmodified on Node.js 18+, in browsers, on Deno, and on edge runtimes such as Cloudflare Workers. No Node `Buffer`, and no framework dependency.
+
+`verifyEveSsoAccessToken` is the one server-only export: it reaches for `jose`, which needs Web Crypto and a network call to EVE's JWKS. Everything else, including `getEveSsoAccessTokenPayload`, is safe to run client-side.
 
 ## Overview
 

--- a/packages/auth-utils/README.md
+++ b/packages/auth-utils/README.md
@@ -20,21 +20,24 @@ Requires a runtime with global `fetch` and `Buffer` (Node.js 18+, or an equivale
 
 Small helpers around the [EVE Online SSO OAuth2 flow](https://docs.esi.evetech.net/docs/sso/).
 
-| Export | Description |
-|---|---|
-| `exchangeEveSsoToken` | Exchange an authorization code (with PKCE `code_verifier`) for access/refresh tokens |
-| `refreshEveSsoToken` | Refresh an access token using a refresh token |
-| `getEveSsoAccessTokenPayload` | Decode an EVE SSO access token's JWT payload (typed, including `scp: ESIScope[]`) — no signature check |
-| `verifyEveSsoAccessToken` | Cryptographically verify an access token against EVE's JWKS (signature + `iss`/`aud`/`exp`); server-only, uses `jose` |
-| `tokenRefreshDataSchema` | Zod schema validating token-refresh response data |
+| Export                        | Description                                                                                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `exchangeEveSsoToken`         | Exchange an authorization code (with PKCE `code_verifier`) for access/refresh tokens                                                                     |
+| `refreshEveSsoToken`          | Refresh an access token, optionally narrowing to a subset of the granted `scopes`                                                                        |
+| `getEveSsoAccessTokenPayload` | Decode an EVE SSO access token's JWT payload (typed, including `scp: ESIScope[]`) — no signature check                                                   |
+| `verifyEveSsoAccessToken`     | Cryptographically verify an access token against EVE's JWKS (signature + `iss`/`aud`/`exp`, and `azp` when given a `clientId`); server-only, uses `jose` |
+| `EveSsoTokenError`            | Thrown by the two calls above when EVE rejects the request; carries `status` and the RFC 6749 `error` payload                                            |
+
+Types: `EveSsoAccessTokenPayload`, `SsoTokenSuccessResult`, `SsoRefreshTokenSuccessResult`.
+Constants: `TOKEN_ENDPOINT`, `REFRESH_TOKEN_ENDPOINT`, `EVE_SSO_JWKS_URI`, `EVE_SSO_ISSUERS`, `EVE_SSO_AUDIENCE`.
 
 ## Usage
 
 ```ts
 import {
   exchangeEveSsoToken,
-  refreshEveSsoToken,
   getEveSsoAccessTokenPayload,
+  refreshEveSsoToken,
 } from "@jitaspace/auth-utils";
 
 // Exchange an authorization code received on the SSO callback
@@ -57,8 +60,42 @@ const refreshed = await refreshEveSsoToken({
 });
 ```
 
+### Handling refresh failures
+
+A refresh can fail two very different ways, and retrying only helps for one of
+them. `EveSsoTokenError` carries EVE's [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2)
+payload so you can tell them apart:
+
+```ts
+import { EveSsoTokenError, refreshEveSsoToken } from "@jitaspace/auth-utils";
+
+try {
+  await refreshEveSsoToken({ eveClientId, eveClientSecret, refreshToken });
+} catch (error) {
+  if (error instanceof EveSsoTokenError && error.requiresReauthentication) {
+    // `invalid_grant`: the user revoked the application or changed their
+    // password. EVE will never renew this token — drop the session and
+    // prompt a fresh login. Retrying loops forever.
+    return promptReauthentication();
+  }
+  throw error; // transient (5xx, network) — safe to retry
+}
+```
+
+### Verifying a token you did not mint
+
+Pass `clientId` whenever the token arrived from somewhere else — most
+importantly an inbound `Authorization: Bearer` header. Every EVE SSO token
+carries the same `"EVE Online"` audience, so without it a token issued to a
+_different_ EVE application verifies successfully:
+
+```ts
+const payload = await verifyEveSsoAccessToken(token, {
+  clientId: process.env.EVE_CLIENT_ID!,
+});
+```
+
 ## Dependencies
 
 - [`jose`](https://github.com/panva/jose) — JWKS-based signature verification (dynamically imported; server-only)
-- [`zod`](https://zod.dev) — runtime validation of token-refresh response data
 - [`@jitaspace/esi-metadata`](https://www.npmjs.com/package/@jitaspace/esi-metadata) — the `ESIScope` union type used in the decoded token payload

--- a/packages/auth-utils/index.ts
+++ b/packages/auth-utils/index.ts
@@ -1,2 +1,1 @@
-export * from "./schemas";
 export * from "./utils";

--- a/packages/auth-utils/package.json
+++ b/packages/auth-utils/package.json
@@ -15,6 +15,19 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      },
+      "./package.json": "./package.json"
+    },
     "access": "public"
   },
   "files": [

--- a/packages/auth-utils/package.json
+++ b/packages/auth-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jitaspace/auth-utils",
-  "description": "Framework-agnostic EVE Online SSO token utilities and Zod schemas — exchange, refresh, and decode ESI access tokens",
+  "description": "Framework-agnostic EVE Online SSO token utilities — exchange, refresh, verify, and decode ESI access tokens",
   "version": "0.2.0",
   "type": "module",
   "main": "./index.ts",
@@ -46,8 +46,7 @@
   },
   "dependencies": {
     "@jitaspace/esi-metadata": "workspace:*",
-    "jose": "^6.2.3",
-    "zod": "^3.25.76"
+    "jose": "^6.2.3"
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",

--- a/packages/auth-utils/schemas/index.ts
+++ b/packages/auth-utils/schemas/index.ts
@@ -1,1 +1,0 @@
-export * from "./tokenRefreshDataSchema";

--- a/packages/auth-utils/schemas/tokenRefreshDataSchema.ts
+++ b/packages/auth-utils/schemas/tokenRefreshDataSchema.ts
@@ -1,6 +1,0 @@
-import z from "zod";
-
-export const tokenRefreshDataSchema = z.object({
-  accessTokenExpiration: z.number(),
-  refreshToken: z.string(),
-});

--- a/packages/auth-utils/tests/exchangeEveSsoToken.test.ts
+++ b/packages/auth-utils/tests/exchangeEveSsoToken.test.ts
@@ -46,18 +46,40 @@ describe("exchangeEveSsoToken", () => {
     );
   });
 
-  it("throws when the token endpoint responds with a non-OK status", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({
-        ok: false,
-        status: 400,
-        statusText: "Bad Request",
-      });
+  it("throws an EveSsoTokenError carrying the RFC 6749 error payload", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: jest.fn().mockResolvedValue(
+        JSON.stringify({
+          error: "invalid_grant",
+          error_description: "Invalid authorization code",
+        }),
+      ),
+    });
 
-    await expect(exchangeEveSsoToken(params)).rejects.toThrow(
-      "error exchanging authorization code",
-    );
+    await expect(exchangeEveSsoToken(params)).rejects.toMatchObject({
+      name: "EveSsoTokenError",
+      status: 400,
+      error: "invalid_grant",
+      errorDescription: "Invalid authorization code",
+    });
+  });
+
+  it("does not log the client secret when the exchange fails", async () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: jest.fn().mockResolvedValue(""),
+    });
+
+    await expect(exchangeEveSsoToken(params)).rejects.toBeDefined();
+    // A library should surface failures through the thrown error, not stdout.
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-utils/tests/getEveSsoAccessTokenPayload.test.ts
+++ b/packages/auth-utils/tests/getEveSsoAccessTokenPayload.test.ts
@@ -1,7 +1,9 @@
 import { getEveSsoAccessTokenPayload } from "../utils/getEveSsoAccessTokenPayload";
 
 function makeJwt(payload: object): string {
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64");
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" }),
+  ).toString("base64");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64");
   return `${header}.${body}.fakesignature`;
 }
@@ -53,5 +55,67 @@ describe("getEveSsoAccessTokenPayload", () => {
     expect(result!.exp).toBe(1717000000);
     expect(result!.iat).toBe(1716996400);
     expect(result!.scp).toEqual(["esi-skills.read_skills.v1"]);
+  });
+
+  // Real JWT segments are base64URL: the `-`/`_` alphabet, and no `=` padding.
+  // `Buffer.from(x, "base64")` tolerated that silently; `atob` does not, so the
+  // decoder has to normalise before decoding.
+  describe("base64url segments", () => {
+    const makeRealJwt = (payload: object): string =>
+      [
+        Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString(
+          "base64url",
+        ),
+        Buffer.from(JSON.stringify(payload)).toString("base64url"),
+        "fakesignature",
+      ].join(".");
+
+    it("decodes a payload whose segment uses the `-`/`_` alphabet", () => {
+      // These bytes encode to a segment containing base64url-only characters,
+      // which a naive `atob` rejects outright.
+      const payload = { ...samplePayload, owner: "ûÿþðè¿" };
+      expect(makeRealJwt(payload).split(".")[1]).toMatch(/[-_]/);
+
+      const result = getEveSsoAccessTokenPayload(makeRealJwt(payload));
+      expect(result?.owner).toBe("ûÿþðè¿");
+      expect(result?.sub).toBe("CHARACTER:EVE:12345678");
+    });
+
+    // Unpadded segments come in three lengths mod 4; only 2 and 3 need padding
+    // restored before `atob` will accept them. Cover all three.
+    it.each([0, 1, 2, 3, 4, 5])(
+      "decodes an unpadded segment with %i filler chars",
+      (fillerLength) => {
+        const payload = { ...samplePayload, owner: "x".repeat(fillerLength) };
+        const segment = makeRealJwt(payload).split(".")[1]!;
+        expect(segment).not.toContain("=");
+
+        expect(getEveSsoAccessTokenPayload(makeRealJwt(payload))?.owner).toBe(
+          "x".repeat(fillerLength),
+        );
+      },
+    );
+
+    it("decodes non-ASCII character names as UTF-8, not Latin-1", () => {
+      // `atob` alone returns a binary string, which would mojibake this.
+      const result = getEveSsoAccessTokenPayload(
+        makeRealJwt({ ...samplePayload, name: "Jörg 秘密 🚀" }),
+      );
+      expect(result?.name).toBe("Jörg 秘密 🚀");
+    });
+  });
+
+  // The signature promises `| null`, so malformed input must not throw.
+  describe("malformed tokens", () => {
+    it("returns null when the payload segment is not valid base64", () => {
+      expect(
+        getEveSsoAccessTokenPayload("header.!!!not-base64!!!.sig"),
+      ).toBeNull();
+    });
+
+    it("returns null when the payload segment is not JSON", () => {
+      const notJson = Buffer.from("this is not json").toString("base64url");
+      expect(getEveSsoAccessTokenPayload(`header.${notJson}.sig`)).toBeNull();
+    });
   });
 });

--- a/packages/auth-utils/tests/refreshEveSsoToken.test.ts
+++ b/packages/auth-utils/tests/refreshEveSsoToken.test.ts
@@ -99,33 +99,66 @@ describe("refreshEveSsoToken", () => {
     expect(bodies[1]?.has("scope")).toBe(false);
   });
 
-  it("throws 'error refreshing access token' when response is not ok", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
+  const failWith = (status: number, body: string) => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
-      status: 401,
-      statusText: "Unauthorized",
+      status,
+      statusText: "",
+      text: jest.fn().mockResolvedValue(body),
     });
+  };
 
-    await expect(refreshEveSsoToken(params)).rejects.toThrow(
-      "error refreshing access token",
+  // The distinction this whole error type exists for: a revoked refresh token
+  // is terminal, a 5xx is worth retrying, and the caller can only tell them
+  // apart if the RFC 6749 payload survives.
+  it("flags invalid_grant as requiring re-authentication", async () => {
+    failWith(
+      400,
+      JSON.stringify({
+        error: "invalid_grant",
+        error_description: "The refresh token is expired or revoked",
+      }),
     );
+
+    await expect(refreshEveSsoToken(params)).rejects.toMatchObject({
+      name: "EveSsoTokenError",
+      status: 400,
+      error: "invalid_grant",
+      requiresReauthentication: true,
+    });
   });
 
-  it("calls console.error when the token endpoint responds with a non-OK status", async () => {
+  it("does not flag a server error as requiring re-authentication", async () => {
+    failWith(500, JSON.stringify({ error: "server_error" }));
+
+    await expect(refreshEveSsoToken(params)).rejects.toMatchObject({
+      status: 500,
+      error: "server_error",
+      requiresReauthentication: false,
+    });
+  });
+
+  // EVE 5xx responses and CDN edge errors return HTML. Parsing that with a bare
+  // response.json() would replace a clean auth error with a SyntaxError.
+  it("survives a non-JSON body and keeps it on the error", async () => {
+    failWith(502, "<html><body>Bad Gateway</body></html>");
+
+    const error = await refreshEveSsoToken(params).catch((e: unknown) => e);
+    expect(error).toMatchObject({
+      name: "EveSsoTokenError",
+      status: 502,
+      body: "<html><body>Bad Gateway</body></html>",
+    });
+    expect((error as { error?: string }).error).toBeUndefined();
+  });
+
+  it("does not log the client secret when the refresh fails", async () => {
     const consoleSpy = jest
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-    });
+    failWith(401, "");
 
-    await expect(refreshEveSsoToken(params)).rejects.toThrow();
-    expect(consoleSpy).toHaveBeenCalledTimes(1);
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Error refreshing EVE SSO token" }),
-    );
+    await expect(refreshEveSsoToken(params)).rejects.toBeDefined();
+    expect(consoleSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-utils/utils/EveSsoTokenError.ts
+++ b/packages/auth-utils/utils/EveSsoTokenError.ts
@@ -1,0 +1,99 @@
+/**
+ * Thrown when EVE's SSO token endpoint rejects a token request.
+ *
+ * Carries the HTTP status and the RFC 6749 §5.2 error payload so callers can
+ * tell a *permanent* failure from a *transient* one. The distinction matters:
+ * `invalid_grant` means EVE will never honour this refresh token again (the
+ * user revoked the application, or changed their password), so the only remedy
+ * is re-authentication — whereas a 5xx is worth retrying. Without the payload
+ * the two are indistinguishable, and a caller retries a doomed refresh forever.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+ */
+export class EveSsoTokenError extends Error {
+  /** HTTP status returned by the token endpoint. */
+  readonly status: number;
+  /** RFC 6749 `error` code, when the response carried a parseable JSON body. */
+  readonly error?: string;
+  /** RFC 6749 `error_description`, when present. */
+  readonly errorDescription?: string;
+  /** The raw response body, kept when it was not parseable JSON (EVE 5xx and CDN edges return HTML). */
+  readonly body?: string;
+
+  constructor(
+    message: string,
+    details: {
+      status: number;
+      error?: string;
+      errorDescription?: string;
+      body?: string;
+    },
+  ) {
+    super(message);
+    this.name = "EveSsoTokenError";
+    this.status = details.status;
+    this.error = details.error;
+    this.errorDescription = details.errorDescription;
+    this.body = details.body;
+  }
+
+  /**
+   * True when EVE has permanently rejected the grant and retrying cannot help —
+   * the user must authenticate again.
+   */
+  get requiresReauthentication(): boolean {
+    return this.error === "invalid_grant";
+  }
+}
+
+/**
+ * Build an {@link EveSsoTokenError} from a failed token-endpoint response.
+ *
+ * Reads the body via `text()` and parses it inside a `try`, never with a bare
+ * `response.json()`: EVE 5xx responses and CDN edge errors return HTML, and an
+ * unguarded parse would replace a clean auth error with a `SyntaxError`.
+ *
+ * Internal — not part of the package's public API.
+ */
+export async function eveSsoTokenErrorFromResponse(
+  response: Response,
+  context: string,
+): Promise<EveSsoTokenError> {
+  let raw = "";
+  try {
+    raw = await response.text();
+  } catch {
+    // Body unreadable (already consumed, or the connection dropped). The status
+    // on its own is still worth surfacing.
+  }
+
+  let error: string | undefined;
+  let errorDescription: string | undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed !== null && typeof parsed === "object") {
+      const payload = parsed as Record<string, unknown>;
+      if (typeof payload.error === "string") error = payload.error;
+      if (typeof payload.error_description === "string") {
+        errorDescription = payload.error_description;
+      }
+    }
+  } catch {
+    // Not JSON — the raw text is kept on the error instead.
+  }
+
+  const detail = errorDescription ?? error;
+  return new EveSsoTokenError(
+    detail
+      ? `${context} (HTTP ${response.status}): ${detail}`
+      : `${context} (HTTP ${response.status})`,
+    {
+      status: response.status,
+      error,
+      errorDescription,
+      // Only keep the raw body when it told us nothing structured, so a well
+      // formed error object does not carry a duplicate copy of itself.
+      body: error === undefined && raw !== "" ? raw : undefined,
+    },
+  );
+}

--- a/packages/auth-utils/utils/base64.ts
+++ b/packages/auth-utils/utils/base64.ts
@@ -47,7 +47,7 @@ export function utf8ToBase64(input: string): string {
  *    the bytes as UTF-8, matching `Buffer`'s default.
  */
 export function base64UrlToUtf8(input: string): string {
-  const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const base64 = input.replaceAll("-", "+").replaceAll("_", "/");
   const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
   const binary = atob(padded);
   const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));

--- a/packages/auth-utils/utils/base64.ts
+++ b/packages/auth-utils/utils/base64.ts
@@ -1,0 +1,55 @@
+/**
+ * Web-standard base64 helpers, so this package runs anywhere `fetch` does.
+ *
+ * These deliberately avoid Node's `Buffer`. `getEveSsoAccessTokenPayload` is
+ * imported by client-side code, and a bare `Buffer` global makes the package
+ * Node-only — it works in Next.js only because Next polyfills `Buffer` into
+ * client bundles. A Vite app, a Cloudflare Worker without `nodejs_compat`, or
+ * Deno without `--unstable-node-globals` would throw `ReferenceError: Buffer is
+ * not defined` from what is otherwise pure string arithmetic.
+ *
+ * `atob`/`btoa`/`TextEncoder`/`TextDecoder` are available in every runtime this
+ * package targets (Node 16+, browsers, Deno, Workers). Node documents
+ * `atob`/`btoa` as legacy in favour of `Buffer`, which is precisely the
+ * portability trade being made here.
+ *
+ * Internal — not part of the package's public API.
+ */
+
+/**
+ * Encode a UTF-8 string as standard base64.
+ *
+ * `btoa` alone is not enough: it takes a *binary* string and throws on any code
+ * point above U+00FF, so a client secret containing non-ASCII would fail. The
+ * `TextEncoder` step converts to UTF-8 bytes first, matching
+ * `Buffer.from(input, "utf-8").toString("base64")`.
+ */
+export function utf8ToBase64(input: string): string {
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode a base64url (or plain base64) segment as UTF-8.
+ *
+ * Two things `atob` will not do on its own, both of which matter for real JWTs:
+ *
+ * 1. **base64url.** JWT segments use the `-`/`_` alphabet and drop padding.
+ *    `Buffer.from(x, "base64")` silently tolerates that; `atob` throws
+ *    `InvalidCharacterError`. So the alphabet is translated and padding
+ *    restored first.
+ * 2. **UTF-8.** `atob` returns a Latin-1 binary string, so a character name
+ *    with non-ASCII characters would be mojibake. `TextDecoder` reinterprets
+ *    the bytes as UTF-8, matching `Buffer`'s default.
+ */
+export function base64UrlToUtf8(input: string): string {
+  const base64 = input.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}

--- a/packages/auth-utils/utils/exchangeEveSsoToken.ts
+++ b/packages/auth-utils/utils/exchangeEveSsoToken.ts
@@ -1,3 +1,4 @@
+import { utf8ToBase64 } from "./base64";
 import { eveSsoTokenErrorFromResponse } from "./EveSsoTokenError";
 
 export const TOKEN_ENDPOINT = "https://login.eveonline.com/v2/oauth/token";
@@ -26,8 +27,7 @@ export const exchangeEveSsoToken = async (params: {
   const { eveClientId, eveClientSecret, code, codeVerifier } = params;
 
   // Base64 encode the client ID and secret for the Basic auth header
-  const headerString = `${eveClientId}:${eveClientSecret}`;
-  const authHeader = Buffer.from(headerString, "utf-8").toString("base64");
+  const authHeader = utf8ToBase64(`${eveClientId}:${eveClientSecret}`);
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: "POST",

--- a/packages/auth-utils/utils/exchangeEveSsoToken.ts
+++ b/packages/auth-utils/utils/exchangeEveSsoToken.ts
@@ -1,6 +1,9 @@
+import { eveSsoTokenErrorFromResponse } from "./EveSsoTokenError";
+
 export const TOKEN_ENDPOINT = "https://login.eveonline.com/v2/oauth/token";
 
-interface SsoTokenSuccessResult {
+/** A successful `authorization_code` exchange, as EVE returns it. */
+export interface SsoTokenSuccessResult {
   access_token: string;
   expires_in: number;
   refresh_token: string;
@@ -41,12 +44,10 @@ export const exchangeEveSsoToken = async (params: {
   });
 
   if (!response.ok) {
-    console.error({
-      message: "Error exchanging EVE SSO authorization code",
-      status: response.status,
-      statusText: response.statusText,
-    });
-    throw new Error("error exchanging authorization code");
+    throw await eveSsoTokenErrorFromResponse(
+      response,
+      "Error exchanging EVE SSO authorization code",
+    );
   }
 
   return (await response.json()) as SsoTokenSuccessResult;

--- a/packages/auth-utils/utils/getEveSsoAccessTokenPayload.ts
+++ b/packages/auth-utils/utils/getEveSsoAccessTokenPayload.ts
@@ -1,5 +1,7 @@
 import type { ESIScope } from "@jitaspace/esi-metadata";
 
+import { base64UrlToUtf8 } from "./base64";
+
 export interface EveSsoAccessTokenPayload {
   scp: ESIScope[];
   jti: string;
@@ -27,9 +29,18 @@ export function getEveSsoAccessTokenPayload(
   if (!tokenPayload) {
     return null;
   }
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const decoded: EveSsoAccessTokenPayload = JSON.parse(
-    Buffer.from(tokenPayload, "base64").toString(),
-  );
-  return decoded;
+
+  // Honour the `| null` return contract for *every* malformed input, not just a
+  // missing segment. Decoding can fail two ways — `atob` rejects a segment that
+  // is not valid base64, and `JSON.parse` rejects a payload that is not JSON —
+  // and the token here is untrusted input, so neither should escape as a throw.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const decoded: EveSsoAccessTokenPayload = JSON.parse(
+      base64UrlToUtf8(tokenPayload),
+    );
+    return decoded;
+  } catch {
+    return null;
+  }
 }

--- a/packages/auth-utils/utils/index.ts
+++ b/packages/auth-utils/utils/index.ts
@@ -1,3 +1,6 @@
+// Named rather than `export *`: the module also holds an internal factory that
+// is not part of the public API.
+export { EveSsoTokenError } from "./EveSsoTokenError";
 export * from "./exchangeEveSsoToken";
 export * from "./getEveSsoAccessTokenPayload";
 export * from "./refreshEveSsoToken";

--- a/packages/auth-utils/utils/refreshEveSsoToken.ts
+++ b/packages/auth-utils/utils/refreshEveSsoToken.ts
@@ -1,3 +1,4 @@
+import { utf8ToBase64 } from "./base64";
 import { eveSsoTokenErrorFromResponse } from "./EveSsoTokenError";
 
 export const REFRESH_TOKEN_ENDPOINT =
@@ -25,9 +26,7 @@ export const refreshEveSsoToken = async (params: {
   const { eveClientId, eveClientSecret, refreshToken, scopes } = params;
 
   // Base64 encode the client ID and secret
-  const headerString = `${eveClientId}:${eveClientSecret}`;
-  const buff = Buffer.from(headerString, "utf-8");
-  const authHeader = buff.toString("base64");
+  const authHeader = utf8ToBase64(`${eveClientId}:${eveClientSecret}`);
 
   const body = new URLSearchParams({
     grant_type: "refresh_token",

--- a/packages/auth-utils/utils/refreshEveSsoToken.ts
+++ b/packages/auth-utils/utils/refreshEveSsoToken.ts
@@ -1,7 +1,10 @@
+import { eveSsoTokenErrorFromResponse } from "./EveSsoTokenError";
+
 export const REFRESH_TOKEN_ENDPOINT =
   "https://login.eveonline.com/v2/oauth/token";
 
-interface SsoRefreshTokenSuccessResult {
+/** A successful `refresh_token` grant, as EVE returns it. */
+export interface SsoRefreshTokenSuccessResult {
   access_token: string;
   expires_in: number;
   refresh_token: string;
@@ -46,12 +49,10 @@ export const refreshEveSsoToken = async (params: {
   });
 
   if (!refreshedTokensResponse.ok) {
-    console.error({
-      message: "Error refreshing EVE SSO token",
-      status: refreshedTokensResponse.status,
-      statusText: refreshedTokensResponse.statusText,
-    });
-    throw new Error("error refreshing access token");
+    throw await eveSsoTokenErrorFromResponse(
+      refreshedTokensResponse,
+      "Error refreshing EVE SSO access token",
+    );
   }
 
   const refreshResult =

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -18,7 +18,8 @@
     "@jitaspace/auth-utils": "workspace:*",
     "@jitaspace/esi-metadata": "workspace:*",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@jest/globals": "^30.4.1",

--- a/packages/auth/src/refreshTokenApiRouteHandler.ts
+++ b/packages/auth/src/refreshTokenApiRouteHandler.ts
@@ -1,13 +1,28 @@
 import { HttpStatusCode } from "axios";
 import z from "zod";
 
+import type { SsoRefreshTokenSuccessResult } from "@jitaspace/auth-utils";
 import {
+  EveSsoTokenError,
   refreshEveSsoToken,
-  tokenRefreshDataSchema,
   verifyEveSsoAccessToken,
 } from "@jitaspace/auth-utils";
 
 import { sealDataWithAuthSecret, unsealDataWithAuthSecret } from "../utils";
+
+/**
+ * The sealed payload this handler exchanges with its client.
+ *
+ * Not an EVE SSO concept: it is this application's own cookie shape, produced
+ * by {@link sealDataWithAuthSecret} (camelCase, whereas EVE's token responses
+ * are snake_case). It lives here rather than in the framework-agnostic
+ * `@jitaspace/auth-utils` because nothing outside this handler produces or
+ * consumes it.
+ */
+export const tokenRefreshDataSchema = z.object({
+  accessTokenExpiration: z.number(),
+  refreshToken: z.string(),
+});
 
 // How much time (in ms) before token expires we're willing to refresh it
 // This is to prevent refreshing tokens that are too new
@@ -74,13 +89,29 @@ export const refreshTokenApiRouteHandler = async (
     );
   }
 
-  // Attempt to refresh token
-  const { access_token, refresh_token } = await refreshEveSsoToken({
-    eveClientId,
-    eveClientSecret,
-    refreshToken,
-    scopes,
-  });
+  // Attempt to refresh token. An `invalid_grant` means EVE has permanently
+  // rejected this refresh token (application revoked, password changed), so it
+  // maps onto the same 410 the age check above uses — the caller must prompt a
+  // re-authentication. Every other failure propagates as a thrown error so the
+  // caller keeps treating it as transient and retries.
+  let refreshed: SsoRefreshTokenSuccessResult;
+  try {
+    refreshed = await refreshEveSsoToken({
+      eveClientId,
+      eveClientSecret,
+      refreshToken,
+      scopes,
+    });
+  } catch (error) {
+    if (error instanceof EveSsoTokenError && error.requiresReauthentication) {
+      return Response.json(
+        { error: "EVE rejected the refresh token. Must reauthenticate." },
+        { status: HttpStatusCode.Gone },
+      );
+    }
+    throw error;
+  }
+  const { access_token, refresh_token } = refreshed;
 
   // Verify the refreshed token's signature against EVE's JWKS (and the
   // iss/aud/exp claims) before trusting its payload. `clientId` binds it to

--- a/packages/auth/tests/refreshTokenApiRouteHandler.test.ts
+++ b/packages/auth/tests/refreshTokenApiRouteHandler.test.ts
@@ -1,0 +1,96 @@
+import type * as AuthUtils from "@jitaspace/auth-utils";
+import {
+  EveSsoTokenError,
+  refreshEveSsoToken,
+  verifyEveSsoAccessToken,
+} from "@jitaspace/auth-utils";
+
+import { refreshTokenApiRouteHandler } from "../src/refreshTokenApiRouteHandler";
+import { sealDataWithAuthSecret } from "../utils/sealDataWithAuthSecret";
+
+// Keep the real EveSsoTokenError — the handler branches on `instanceof`, so a
+// mocked class would make the test pass for the wrong reason.
+jest.mock("@jitaspace/auth-utils", () => ({
+  ...jest.requireActual<typeof AuthUtils>("@jitaspace/auth-utils"),
+  refreshEveSsoToken: jest.fn(),
+  verifyEveSsoAccessToken: jest.fn(),
+}));
+
+const nextAuthSecret = "0123456789abcdef0123456789abcdef";
+const config = {
+  nextAuthSecret,
+  eveClientId: "test-client-id",
+  eveClientSecret: "test-client-secret",
+};
+
+/** A sealed body whose access token expired a minute ago, so a refresh is due. */
+const expiredRequest = async () =>
+  new Request("https://jita.space/api/refresh", {
+    method: "POST",
+    body: await sealDataWithAuthSecret({
+      data: {
+        accessTokenExpiration: Math.floor(Date.now() / 1000) - 60,
+        refreshToken: "RT",
+      },
+      secret: nextAuthSecret,
+    }),
+  });
+
+describe("refreshTokenApiRouteHandler", () => {
+  it("maps invalid_grant onto 410 so the caller prompts re-authentication", async () => {
+    (refreshEveSsoToken as jest.Mock).mockRejectedValue(
+      new EveSsoTokenError("revoked", {
+        status: 400,
+        error: "invalid_grant",
+        errorDescription: "The refresh token is expired or revoked",
+      }),
+    );
+
+    const response = await refreshTokenApiRouteHandler(
+      await expiredRequest(),
+      config,
+    );
+
+    // 410 is the status apps/web already translates into `requires-reauth`.
+    expect(response.status).toBe(410);
+    expect(await response.json()).toEqual({
+      error: "EVE rejected the refresh token. Must reauthenticate.",
+    });
+  });
+
+  it("lets a server error propagate so the caller retries it as transient", async () => {
+    (refreshEveSsoToken as jest.Mock).mockRejectedValue(
+      new EveSsoTokenError("boom", { status: 500, error: "server_error" }),
+    );
+
+    await expect(
+      refreshTokenApiRouteHandler(await expiredRequest(), config),
+    ).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("returns the refreshed tokens on success", async () => {
+    (refreshEveSsoToken as jest.Mock).mockResolvedValue({
+      access_token: "AT2",
+      refresh_token: "RT2",
+      expires_in: 1199,
+    });
+    (verifyEveSsoAccessToken as jest.Mock).mockResolvedValue({
+      exp: Math.floor(Date.now() / 1000) + 1199,
+      sub: "CHARACTER:EVE:123",
+    });
+
+    const response = await refreshTokenApiRouteHandler(
+      await expiredRequest(),
+      config,
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { accessToken: string };
+    expect(body.accessToken).toBe("AT2");
+    // The refreshed token must be verified against this application's client id.
+    expect(verifyEveSsoAccessToken).toHaveBeenCalledWith(
+      "AT2",
+      expect.objectContaining({ clientId: config.eveClientId }),
+    );
+  });
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,7 +23,8 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
+      },
+      "./package.json": "./package.json"
     }
   },
   "license": "MIT",

--- a/packages/esi-metadata/package.json
+++ b/packages/esi-metadata/package.json
@@ -15,6 +15,19 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      },
+      "./package.json": "./package.json"
+    },
     "access": "public"
   },
   "files": [

--- a/packages/tiptap-eve/package.json
+++ b/packages/tiptap-eve/package.json
@@ -15,6 +15,19 @@
     "main": "./dist/index.cjs",
     "module": "./dist/index.js",
     "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      },
+      "./package.json": "./package.json"
+    },
     "access": "public"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,6 +453,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@jest/globals':
         specifier: ^30.4.1
@@ -496,9 +499,6 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
-      zod:
-        specifier: ^3.25.76
-        version: 3.25.76
     devDependencies:
       '@jest/globals':
         specifier: ^30.4.1
@@ -7426,6 +7426,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
Pre-publish work on `@jitaspace/auth-utils`, follow-up to #720. Four changes: a packaging fix, a typed SSO error that ends a real retry loop in the web app, an export-surface fix, and a scope fix that removes a runtime dependency.

## 1. Conditional `exports` map for the publishable packages

`auth-utils`, `esi-metadata` and `tiptap-eve` published only `main`/`module`/`types`. Node ignores `module` entirely, so with `"type": "module"` set, two things were wrong for anyone installing from npm:

- **ESM consumers loaded the CJS build.** `import.meta.resolve` landed on `dist/index.cjs`, so the ESM output shipped in every tarball but was never used, and the namespace object carried a spurious `default` key.
- **CJS TypeScript consumers could not compile.** Under `module: node16`, `types` resolved to `dist/index.d.ts`, which is ESM, producing `TS1479`. Runtime was fine, so this was purely type resolution — and invisible in-repo, where `nodenext` and `bundler` both pass.

All three now use the same `import`/`require` map `@jitaspace/db` already had, pointing `require` at the `dist/index.d.cts` that `tsup --dts` was already emitting but nothing referenced. Each also exposes `./package.json`; added to `db` too for consistency.

This one is **live** on `@jitaspace/tiptap-eve@0.1.6`, the only package currently on npm. It is latent on the other three until they ship.

Verified against a real packed tarball installed into a scratch consumer:

| | before | after |
|---|---|---|
| `import.meta.resolve` | `dist/index.cjs` | `dist/index.js` |
| spurious `default` key in ESM namespace | yes | no |
| `require()` target | `dist/index.cjs` | `dist/index.cjs` (unchanged) |
| `tsc` on a `.cts` importer, `module: node16` | `TS1479` | clean |

Confirmed attribution by deleting only the `exports` field from the *installed* manifest and re-running: both regressions came straight back.

The map lives under `publishConfig`, not top level, because `exports` outranks `main` — a top-level map pointing into `dist/` would override `main: "./index.ts"` and break in-repo consumption via `transpilePackages`, which expects TypeScript source that `dist/` does not contain in a fresh clone.

## 2. `EveSsoTokenError` — and a retry loop that actually affects users

`exchangeEveSsoToken` and `refreshEveSsoToken` threw a fixed-string `Error`, discarding both the HTTP status and EVE's RFC 6749 §5.2 `{error, error_description}` body. That made a **permanently revoked refresh token indistinguishable from a passing 5xx**.

The consequence was live: the bare error reached `apps/web`, which classified it as transient and re-armed a 30-second retry. So if a user revoked JitaSpace's authorization in EVE or changed their password, the app retried a doomed refresh every 30 seconds for as long as the tab stayed open, and never marked the session as needing re-authentication.

Both calls now throw an `EveSsoTokenError` carrying `status`, `error`, `errorDescription`, plus a `requiresReauthentication` helper for `invalid_grant`. `refreshTokenApiRouteHandler` maps that onto the `410` it already returns for over-age tokens — which `apps/web` already translates into `requires-reauth`. **No web-app change was needed**; the existing terminal-state path just becomes reachable.

Two details worth calling out:
- The body is read with `text()` and parsed inside a `try`, never a bare `response.json()`. EVE 5xx responses and CDN edges return HTML, which would otherwise convert a clean auth error into a `SyntaxError` — strictly worse than the original behaviour.
- The unconditional `console.error` is gone from both helpers. A library should report through the error it throws, and these functions are called with the client secret in scope.

## 3. Exported the two result types

`SsoTokenSuccessResult` and `SsoRefreshTokenSuccessResult` were emitted into the `.d.ts` but left out of its export list, so consumers could not name the return types. Verified against the built `dist/index.d.ts`, which now exports 13 names.

## 4. `tokenRefreshDataSchema` moved to `@jitaspace/auth`

It describes this application's sealed cookie — camelCase `{accessTokenExpiration, refreshToken}` — not anything EVE sends (EVE's token responses are snake_case). Its only consumer is `refreshTokenApiRouteHandler`, in a package that is `private` and unpublished, so an external consumer got an exported Zod schema they could not decipher without reading code they cannot install.

Removing it **drops `zod` as a runtime dependency of `auth-utils` entirely** — confirmed zero `zod` references in the built output — leaving `jose` and `@jitaspace/esi-metadata`. `@jitaspace/auth` now declares the `zod` it was already importing undeclared.

The package `description` still advertised "and Zod schemas"; updated.

## Testing

- `auth-utils`: 26 passing (was 19 before this branch). New coverage for the RFC 6749 payload, the `invalid_grant` vs `server_error` distinction, a non-JSON (HTML) body, and no-console-logging.
- `auth`: 17 passing, including a new `refreshTokenApiRouteHandler` suite asserting `invalid_grant` → 410, that a `server_error` still propagates as transient, and that the success path verifies with this application's `clientId`. It deliberately keeps the real `EveSsoTokenError` via `requireActual`, since the handler branches on `instanceof`.
- `hooks`: 187 passing.
- `tsc --noEmit` clean on `auth-utils`, `auth`, `hooks`, `esi-metadata`, `tiptap-eve`, `db`, and `apps/web`.
- ESLint, `manypkg check` and Prettier clean.

## Notes for the reviewer

**Found in passing, not fixed:** `packages/auth` imports `HttpStatusCode` from `axios` without declaring `axios` as a dependency. Pre-existing and out of scope here, but it is the same class of phantom dependency as the `zod` one this PR fixes, and would break if hoisting changed.

**Commit shape.** Git push credentials stopped working partway through this session (fetch worked; push returned `could not read Username`), so these commits were pushed through the GitHub API. That API cannot combine file deletions with edits atomically, which is why removing `schemas/` is split across two small commits ahead of the main one. For every push I verified the resulting remote tree hash is identical to the locally tested tree. Commits are API-authored rather than signed.
