### PR TITLE
refactor(web): drop the sitemap page-0 insurance from robots.txt

### DIFF
--- a/.changeset/drop-sitemap-insurance.md
+++ b/.changeset/drop-sitemap-insurance.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Internal: robots.txt now lists only the sitemap index, after confirming in production that the index resolves correctly. No change to which pages search engines can find.

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 import { CRAWLER_DISALLOWED_PATHS } from "~/config/seo.ts";
-import { FIRST_SITEMAP_PAGE_URL, SITEMAP_INDEX_URL } from "./sitemap";
+import { SITEMAP_INDEX_URL } from "./sitemap";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -10,22 +10,8 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: [...CRAWLER_DISALLOWED_PATHS],
     },
-    // The index expands to every /sitemap/{n}.xml, so adding a page needs no
-    // change here. Page 0 is listed beside it deliberately, as insurance.
-    //
-    // The index only answers at /sitemap.xml through a `beforeFiles` rewrite in
-    // next.config.mjs, and nothing verifies that end to end: Cypress boots the
-    // server but never requests it, the jest tests call the route handler
-    // directly, and Vercel resolves `beforeFiles` in its own routing layer
-    // rather than Next's. If that rewrite ever fails to survive the Build
-    // Output API, the index 404s — and without this second entry, nothing would
-    // point a crawler at the sitemap at all, which is worse than the broken
-    // state this replaced. Page 0 always serves, so it degrades instead.
-    //
-    // REMOVE THIS ENTRY once https://www.jita.space/sitemap.xml is confirmed
-    // serving <sitemapindex> in production, together with the ordering
-    // assertion in tests/sitemap.test.ts. Until then it is load-bearing; after
-    // that it is only a puzzle.
-    sitemap: [SITEMAP_INDEX_URL, FIRST_SITEMAP_PAGE_URL],
+    // One entry, not the enumerated pages: the index at /sitemap.xml expands to
+    // every /sitemap/{n}.xml, so a new page needs no change here.
+    sitemap: SITEMAP_INDEX_URL,
   };
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -375,15 +375,6 @@ async function getSitemapCount(): Promise<number> {
  */
 export const SITEMAP_INDEX_URL = `${SITE_URL}/sitemap.xml`;
 
-/**
- * Page 0, which exists unconditionally: `getSitemapCount()` floors at 1, and
- * `sitemap()` returns `[]` past the end of the list rather than throwing. So
- * this URL serves valid XML whatever the database is doing, and — unlike the
- * rest of the pages — it is a constant, so robots.txt can name it without a
- * query. See the note in ./robots.ts for why it is named there at all.
- */
-export const FIRST_SITEMAP_PAGE_URL = `${SITE_URL}/sitemap/0.xml`;
-
 /** Every `/sitemap/{n}.xml` page, i.e. the contents of the index. */
 export async function getSitemapUrls(): Promise<string[]> {
   const count = await getSitemapCount();

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -248,20 +248,14 @@ describe("sitemap", () => {
   });
 
   it("advertises the index in robots.txt, and the index lists every page", async () => {
-    // robots.txt names the index plus page 0 (see the note in app/robots.ts);
-    // the index expands to the numbered pages. Both derive from ./sitemap.ts,
-    // so this pins the chain end to end. Order matters: the index must come
-    // first, and page 0 is pinned rather than incidental so that removing it
-    // later is a deliberate edit here, not a silent drift.
+    // robots.txt names only the index; the index expands to the numbered pages.
+    // Both derive from ./sitemap.ts, so this pins the chain end to end.
     const xml = await (await loadSitemapIndex().GET()).text();
     const indexed = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
     const { sitemap: advertised } = loadRobots().default();
     const pages = await load().generateSitemaps();
 
-    expect(advertised).toEqual([
-      "https://www.jita.space/sitemap.xml",
-      "https://www.jita.space/sitemap/0.xml",
-    ]);
+    expect(advertised).toBe("https://www.jita.space/sitemap.xml");
     expect(indexed).toEqual(await load().getSitemapUrls());
     expect(indexed).toHaveLength(pages.length);
     expect(xml).toContain("<sitemapindex");


### PR DESCRIPTION
Follow-up to #719, doing exactly what that PR's own comment instructed once production confirmed the rewrite.

## Why the entry existed

`ef573de3` added a second `Sitemap:` directive for `/sitemap/0.xml`. The index only answers at `/sitemap.xml` through a `beforeFiles` rewrite, and nothing in CI could prove that survives Vercel's Build Output API — Cypress boots the server but never requests it, the jest tests call the route handler directly, and Vercel resolves `beforeFiles` in its own routing layer rather than Next's. Had it not landed, robots.txt would have named only a 404 and left the site with no crawler discovery at all — worse than the broken sitemap #719 set out to fix.

## Why it can go

Verified against the production deploy of #719 (merge `2fded395`):

```
/sitemap.xml    <sitemapindex> listing /sitemap/0.xml and /sitemap/1.xml
                lastmod 2026-08-21T19:46:58Z — the merge commit's own timestamp,
                so this is the new build, not a cached response
/sitemap/1.xml  19,788 URLs, zero relative <loc>
                /type/94134 … /lp-store/1000437
robots.txt      both Sitemap directives, 11 Disallow rules
```

Page 1 ending on `/lp-store/` confirms the entity families landed in `ENTITY_SOURCES` order. Page 0 being full puts the live total near 69,800 URLs.

The rewrite works, so the entry stopped being insurance and would only be a puzzle for the next reader.

## What changed

- `robots.ts` — back to a single `SITEMAP_INDEX_URL` entry
- `sitemap.ts` — `FIRST_SITEMAP_PAGE_URL` export removed
- `tests/sitemap.test.ts` — ordering assertion back to the single-URL form

robots.txt is otherwise untouched and remains a static function with no database access.

Verification: type-check clean, 0 ESLint errors, 137 suites / 1134 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
