### PR TITLE
fix(db,background-jobs): widen military-campaign progress columns to BigInt

### DIFF
--- a/.changeset/military-campaign-progress-bigint.md
+++ b/.changeset/military-campaign-progress-bigint.md
@@ -1,0 +1,24 @@
+---
+"@jitaspace/db": minor
+"@jitaspace/background-jobs": patch
+---
+
+Fix `ingest-sde-military-campaign-objectives`, which was dying on every run with
+`Value out of range for the type: integer out of range for type int4`.
+
+A campaign objective's progress is counted in whatever unit its contribution
+method reports — missions completed for `CompleteAgentMission`, but raw ISK for
+the value-denominated ones — so the ISK objectives ship targets far past
+2^31-1 and could not be written to an `Int` column. The six progress-magnitude
+columns are now `BigInt`: `MilitaryCampaign.targetProgress` plus
+`MilitaryCampaignObjective.targetProgress`, `maxProgressPerParticipant`,
+`iskProgressInterval`, `lpProgressInterval` and `standingProgressInterval`. The
+id columns beside them (faction, corporation, character) stay `Int` — EVE's id
+ranges fit comfortably.
+
+Requires a schema push.
+
+The transform emits `bigint` rather than `number` for those columns, which
+matters beyond the column type: `recordsAreEqual` compares `typeof` before
+value, so a `number` diffed against the `bigint` Prisma reads back would have
+marked every objective modified on every run.

--- a/packages/background-jobs/helpers/sdeFields.ts
+++ b/packages/background-jobs/helpers/sdeFields.ts
@@ -32,6 +32,22 @@ export function requiredBigInt(value: unknown): bigint {
   return BigInt(Number.isFinite(n) ? Math.round(n) : 0);
 }
 
+/**
+ * An optional SDE field for a `BigInt` column — null when absent or non-finite.
+ *
+ * Reach for this over {@link optionalNumber} whenever a column counts a
+ * quantity rather than identifying a row: ids fit int4, but ISK-denominated
+ * figures (military-campaign progress, for one) run past it. Emitting `bigint`
+ * and not `number` is also what keeps the ingest diff honest — `recordsAreEqual`
+ * compares `typeof` before value, so a `number` held against the `bigint` Prisma
+ * reads back would mark every row modified on every run.
+ */
+export function optionalBigInt(value: unknown): bigint | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? BigInt(Math.round(n)) : null;
+}
+
 /** A required boolean SDE field. */
 export const requiredBoolean: (value: unknown) => boolean = Boolean;
 

--- a/packages/background-jobs/jobs/scrape/sde/militaryCampaignTransforms.ts
+++ b/packages/background-jobs/jobs/scrape/sde/militaryCampaignTransforms.ts
@@ -1,46 +1,22 @@
 import type { Prisma } from "../../../db";
+// Reached directly rather than through `../../../helpers`: the field coercions
+// live in a module of their own with no imports at all, while the barrel pulls
+// in p-limit and the zod-checked env, which Jest cannot load without mocks.
+import {
+  enString,
+  optionalBigInt,
+  optionalNumber,
+  plainString,
+} from "../../../helpers/sdeFields";
 
 /**
  * Pure transforms for militaryCampaigns.yaml and militaryCampaignObjectives.yaml.
  *
- * Kept in its own module with a type-only `Prisma` import so it pulls in no
- * runtime dependencies: the ingest job's own module reaches p-limit and the
- * zod-checked env through `../../../helpers`, which Jest cannot load without
- * mocks. Everything that inspects the SDE's shape lives here so it is directly
- * unit-testable — the field-level bugs this module now guards against were
- * invisible to a "rows created, second run equal" check.
+ * Kept in its own module so it stays free of runtime dependencies and is
+ * directly unit-testable: everything that inspects these two files' shape lives
+ * here, and the field-level bugs it now guards against were invisible to a
+ * "rows created, second run equal" check.
  */
-
-/** The English text of a localized SDE field, or null. */
-function enString(value: unknown): string | null {
-  if (typeof value === "object" && value !== null) {
-    const en = (value as { en?: unknown }).en;
-    if (typeof en === "string") return en;
-  }
-  return null;
-}
-
-const plainString = (value: unknown): string | null =>
-  typeof value === "string" ? value : null;
-
-const optionalNumber = (value: unknown): number | null =>
-  value == null ? null : Number(value);
-
-/**
- * An optional SDE integer destined for a `BigInt` column.
- *
- * Emitting a `bigint` rather than a `number` is load-bearing twice over: an
- * ISK-denominated progress figure overflows int4 (the ingest died on
- * `Value out of range for the type: integer out of range for type int4`), and
- * `recordsAreEqual` — which decides create/update/equal — compares `typeof`
- * first, so a `number` against the `bigint` Prisma reads back would mark every
- * row modified on every run.
- */
-const optionalBigInt = (value: unknown): bigint | null => {
-  if (value == null) return null;
-  const number = Number(value);
-  return Number.isFinite(number) ? BigInt(Math.round(number)) : null;
-};
 
 /**
  * Render one `annotations` entry as text.

--- a/packages/background-jobs/jobs/scrape/sde/militaryCampaignTransforms.ts
+++ b/packages/background-jobs/jobs/scrape/sde/militaryCampaignTransforms.ts
@@ -27,6 +27,22 @@ const optionalNumber = (value: unknown): number | null =>
   value == null ? null : Number(value);
 
 /**
+ * An optional SDE integer destined for a `BigInt` column.
+ *
+ * Emitting a `bigint` rather than a `number` is load-bearing twice over: an
+ * ISK-denominated progress figure overflows int4 (the ingest died on
+ * `Value out of range for the type: integer out of range for type int4`), and
+ * `recordsAreEqual` — which decides create/update/equal — compares `typeof`
+ * first, so a `number` against the `bigint` Prisma reads back would mark every
+ * row modified on every run.
+ */
+const optionalBigInt = (value: unknown): bigint | null => {
+  if (value == null) return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? BigInt(Math.round(number)) : null;
+};
+
+/**
  * Render one `annotations` entry as text.
  *
  * Annotation values are a plain string, a localized object, or — for
@@ -135,20 +151,20 @@ export function toObjectiveRow(
     subtitle: enString(record.subtitle),
     militaryCampaignId,
     careerPath: plainString(record.careerPath),
-    targetProgress: optionalNumber(record.targetProgress),
-    maxProgressPerParticipant: optionalNumber(record.maxProgressPerParticipant),
+    targetProgress: optionalBigInt(record.targetProgress),
+    maxProgressPerParticipant: optionalBigInt(record.maxProgressPerParticipant),
     presentingCharacterId: optionalNumber(record.presentingCharacterID),
     issuerCorporationId: optionalNumber(obj(record.issuer).corporationID),
     iskAmountPerInterval: optionalNumber(isk.amountPerInterval),
-    iskProgressInterval: optionalNumber(isk.progressInterval),
+    iskProgressInterval: optionalBigInt(isk.progressInterval),
     iskIssuerCorporationId: issuerCorporationOf(isk),
     lpAmountPerInterval: optionalNumber(lp.amountPerInterval),
-    lpProgressInterval: optionalNumber(lp.progressInterval),
+    lpProgressInterval: optionalBigInt(lp.progressInterval),
     lpIssuerCorporationId: issuerCorporationOf(lp),
     standingGainPercentPerInterval: optionalNumber(
       standing.gainPercentPerInterval,
     ),
-    standingProgressInterval: optionalNumber(standing.progressInterval),
+    standingProgressInterval: optionalBigInt(standing.progressInterval),
     standingIssuerFactionId: optionalNumber(obj(standing.issuer).factionID),
     requiredEnlistmentWithFactionId: optionalNumber(
       annotations.requiredEnlistmentWithFactionID,
@@ -170,7 +186,7 @@ export function toCampaignRow(
     militaryCampaignId,
     title: enString(record.title) ?? "",
     subtitle: enString(record.subtitle),
-    targetProgress: optionalNumber(record.targetProgress),
+    targetProgress: optionalBigInt(record.targetProgress),
     issuerFactionId: optionalNumber(obj(record.issuer).factionID),
     isDeleted: false,
   };

--- a/packages/background-jobs/tests/sdeRowTransforms.test.ts
+++ b/packages/background-jobs/tests/sdeRowTransforms.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 
-// All four modules are runtime-dependency-free (type-only Prisma imports), so
-// unlike the other job tests these need no p-limit / env mocks.
+// All four modules are runtime-dependency-free (type-only Prisma imports, plus
+// sdeFields, which imports nothing), so unlike the other job tests these need
+// no p-limit / env mocks.
 import {
   rgba,
   toGraphicMaterialSetRow,

--- a/packages/background-jobs/tests/sdeRowTransforms.test.ts
+++ b/packages/background-jobs/tests/sdeRowTransforms.test.ts
@@ -162,6 +162,44 @@ describe("toObjectiveRow", () => {
     });
   });
 
+  it("carries progress figures as BigInt, past the int4 ceiling", () => {
+    // Regression: progress is counted in the unit the contribution method
+    // reports, and the ISK-denominated objectives ship targets far beyond
+    // 2^31-1 — as `Int` columns those killed the ingest with "integer out of
+    // range for type int4". They must be `bigint` and not `number`, too:
+    // `recordsAreEqual` compares typeof before value, so a number diffed
+    // against the bigint Prisma reads back would re-update every row forever.
+    const row = toObjectiveRow("obj-5", "camp-1", {
+      title: en("Destroy enemy ships"),
+      targetProgress: 500_000_000_000,
+      maxProgressPerParticipant: 10_000_000_000,
+      rewards: {
+        isk: { progressInterval: 5_000_000_000 },
+        lp: { progressInterval: 2_500_000_000 },
+        standing: { progressInterval: 100_000_000_000 },
+      },
+    });
+    expect(row).toMatchObject({
+      targetProgress: 500_000_000_000n,
+      maxProgressPerParticipant: 10_000_000_000n,
+      iskProgressInterval: 5_000_000_000n,
+      lpProgressInterval: 2_500_000_000n,
+      standingProgressInterval: 100_000_000_000n,
+    });
+  });
+
+  it("leaves an absent progress figure null rather than 0n", () => {
+    // 0n and null mean different things — "no cap" is not "a cap of zero".
+    const row = toObjectiveRow("obj-6", "camp-1", { title: en("x") });
+    expect(row).toMatchObject({
+      targetProgress: null,
+      maxProgressPerParticipant: null,
+      iskProgressInterval: null,
+      lpProgressInterval: null,
+      standingProgressInterval: null,
+    });
+  });
+
   it("carries the contribution method name and the campaign link", () => {
     const row = toObjectiveRow("obj-4", "camp-9", {
       title: en("x"),
@@ -184,9 +222,23 @@ describe("toCampaignRow", () => {
       militaryCampaignId: "camp-1",
       title: "The Blessed Exchange",
       subtitle: "Bring honour",
-      targetProgress: 30,
+      targetProgress: 30n,
       issuerFactionId: 500003,
     });
+  });
+
+  it("carries a campaign target past the int4 ceiling", () => {
+    const row = toCampaignRow("camp-2", {
+      title: en("Break the Blockade"),
+      targetProgress: 4_000_000_000,
+    });
+    expect(row.targetProgress).toBe(4_000_000_000n);
+  });
+
+  it("leaves an absent campaign target null", () => {
+    expect(
+      toCampaignRow("camp-3", { title: en("x") }).targetProgress,
+    ).toBeNull();
   });
 });
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -2480,7 +2480,10 @@ model MilitaryCampaign {
   militaryCampaignId String                       @id
   title              String
   subtitle           String?
-  targetProgress     Int?
+  /// BigInt, not Int: progress is counted in whatever unit the objectives
+  /// contribute in, and the ISK-denominated ones run well past int4 (see
+  /// MilitaryCampaignObjective.targetProgress).
+  targetProgress     BigInt?
   /// factions.yaml id of the issuing faction (`issuer.factionID`).
   issuerFactionId    Int?
   annotations        MilitaryCampaignAnnotation[]
@@ -2518,21 +2521,29 @@ model MilitaryCampaignObjective {
   militaryCampaignId              String
   militaryCampaign                MilitaryCampaign                     @relation(fields: [militaryCampaignId], references: [militaryCampaignId])
   careerPath                      String?
-  targetProgress                  Int?
-  maxProgressPerParticipant       Int?
+  /// BigInt, not Int: an objective's progress is counted in the raw unit its
+  /// contribution method reports — number of missions for "CompleteAgentMission",
+  /// but ISK for the value-denominated ones — so the targets run past int4.
+  /// Ingesting them as `Int` failed the job with "integer out of range for
+  /// type int4".
+  targetProgress                  BigInt?
+  maxProgressPerParticipant       BigInt?
   /// npcCharacters.yaml id.
   presentingCharacterId           Int?
   /// npcCorporations.yaml id (`issuer.corporationID`).
   issuerCorporationId             Int?
-  // rewards.isk / rewards.lp / rewards.standing
+  // rewards.isk / rewards.lp / rewards.standing. The `*ProgressInterval`
+  // columns are measured in the same unit as `targetProgress` above ("pay
+  // `amountPerInterval` for every `progressInterval` of progress"), so they
+  // are BigInt for the same reason.
   iskAmountPerInterval            Float?
-  iskProgressInterval             Int?
+  iskProgressInterval             BigInt?
   iskIssuerCorporationId          Int?
   lpAmountPerInterval             Float?
-  lpProgressInterval              Int?
+  lpProgressInterval              BigInt?
   lpIssuerCorporationId           Int?
   standingGainPercentPerInterval  Float?
-  standingProgressInterval        Int?
+  standingProgressInterval        BigInt?
   /// The standing reward's issuer is a FACTION, not a corporation: CCP ships
   /// `rewards.standing.issuer.factionID` (isk/lp use `issuer.corporationID`).
   standingIssuerFactionId         Int?


### PR DESCRIPTION
## The failure

`ingest-sde-military-campaign-objectives` has been dying on every run:

```
PrismaClientKnownRequestError:
Invalid `prisma.militaryCampaignObjective.update()` invocation:
Value out of range for the type: integer out of range for type int4
```

An objective's progress is counted in whatever unit its contribution method reports — missions completed for `CompleteAgentMission`, but **raw ISK** for the value-denominated ones — so the ISK objectives ship targets far past 2^31-1 and simply cannot be stored in an `Int` (int4) column.

It surfaced on `update()` rather than `createMany()` because the rows already existed from an earlier SDE build; the oversized figure arrived with a later one, so the diff classified it as *modified* and the update was the statement that hit the ceiling.

## The change

Six progress-magnitude columns become `BigInt`:

| Model | Columns |
| --- | --- |
| `MilitaryCampaign` | `targetProgress` |
| `MilitaryCampaignObjective` | `targetProgress`, `maxProgressPerParticipant`, `iskProgressInterval`, `lpProgressInterval`, `standingProgressInterval` |

The three `*ProgressInterval` columns are quoted in the same unit as the target ("pay `amountPerInterval` for every `progressInterval` of progress"), so they carry the identical risk and are widened alongside it. The id columns sitting beside them (faction, corporation, character) stay `Int` — EVE's id ranges fit comfortably.

`toObjectiveRow` / `toCampaignRow` now emit `bigint` for those columns via a new `optionalBigInt`. That detail is load-bearing beyond the column type: `recordsAreEqual` compares `typeof` before value, so feeding a `number` into the diff against the `bigint` Prisma reads back would have marked every objective *modified* on every run — trading a crash for permanent no-op churn.

Adds regression tests (values past the int4 ceiling round-trip as `bigint`; absent figures stay `null`, not `0n`) and a changeset.

## ⚠️ Requires a manual schema push

Deploys run `db:generate` but never `db:push`, so **the job keeps failing until the schema is applied by hand**:

```bash
pnpm db:diff   # review — it points at production CockroachDB
pnpm db:push
```

Two things to watch on that push, neither rehearsable in CI:

- CockroachDB may reject an `INT4 → INT8` `ALTER COLUMN TYPE` unless `SET enable_experimental_alter_column_type_general = true` is set for the session. It is a widening conversion, so no data is at risk either way.
- The `schema_locked` caveat in `CLAUDE.md` applies — if the push errors on a locked table, follow the `DETAIL:` line's unlock / re-push / re-lock sequence.

## Verification

`pnpm db:generate` → `pnpm type-check` (38 tasks green) → `pnpm lint` (0 errors; only pre-existing warnings) → `pnpm --filter @jitaspace/background-jobs test` (19 suites / 136 tests). `prisma validate` passes.

## Assumption worth flagging

The SDE host is unreachable from this environment, so I could not confirm *which* of the six columns actually carries the oversized value. Rather than widen one and watch the failure move next week, I widened the whole progress family — they are all denominated in the same unbounded unit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VggHUccsxJNkZrLovVJ6MQ)_