### PR TITLE
fix(web): stop entity links pointing at undefined ids

### DIFF
--- a/.changeset/entity-links-no-undefined-ids.md
+++ b/.changeset/entity-links-no-undefined-ids.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed race, bloodline, corporation, character, faction, type and solar-system links on entity pages briefly pointing at a broken address while the page was still loading. Opening a character, station, structure, planet, bloodline, alliance or race page during that moment could produce a link to a page that does not exist. Those rows now show the name unlinked until the destination is known, and become links once the data arrives.
+
+Also stopped the site footer from pre-loading the About, Support and Status pages on every page view. They are now fetched when you actually click them.

--- a/.changeset/race-bloodline-anchors.md
+++ b/.changeset/race-bloodline-anchors.md
@@ -5,6 +5,6 @@
 
 Added `RaceAnchor` and `BloodlineAnchor`. Races and bloodlines are SDE reference data rather than ESI-resolvable entities, so they cannot route through `EveEntityAnchor`; both build the href from the id directly, with no name lookup.
 
-`CorporationAnchor` now accepts an optional `corporationId`, matching `TypeAnchor`, `CharacterAnchor` and `FactionAnchor`. All three new/changed components render their children unlinked while the id is nullish, so a call site can no longer emit `/corporation/undefined` for `next/link` to prefetch. `CorporationAnchor` also drops the trailing slash from its href, so it stops splitting the CDN cache between `/corporation/123` and `/corporation/123/`.
+`CorporationAnchor` now accepts an optional `corporationId`, matching `TypeAnchor`, `CharacterAnchor` and `FactionAnchor`. All three new/changed components render their children unlinked while the id is nullish, so a call site can no longer emit `/corporation/undefined` for `next/link` to prefetch. `CorporationAnchor` also drops the trailing slash from its href so it reads like every sibling anchor; that part is cosmetic, since `next/link` already normalised the slash away before the request was made.
 
 `EveEntityAnchor` now prefers the `category` prop over the category reported by `useEsiName`. That value is read off the resolved cache entry, so it stayed undefined until the name lookup landed and every typed anchor rendered `href="#"` in the meantime — even though the destination follows from the id alone.

--- a/.changeset/race-bloodline-anchors.md
+++ b/.changeset/race-bloodline-anchors.md
@@ -1,0 +1,10 @@
+---
+"@jitaspace/ui": minor
+"@jitaspace/eve-components": patch
+---
+
+Added `RaceAnchor` and `BloodlineAnchor`. Races and bloodlines are SDE reference data rather than ESI-resolvable entities, so they cannot route through `EveEntityAnchor`; both build the href from the id directly, with no name lookup.
+
+`CorporationAnchor` now accepts an optional `corporationId`, matching `TypeAnchor`, `CharacterAnchor` and `FactionAnchor`. All three new/changed components render their children unlinked while the id is nullish, so a call site can no longer emit `/corporation/undefined` for `next/link` to prefetch. `CorporationAnchor` also drops the trailing slash from its href, so it stops splitting the CDN cache between `/corporation/123` and `/corporation/123/`.
+
+`EveEntityAnchor` now prefers the `category` prop over the category reported by `useEsiName`. That value is read off the resolved cache entry, so it stayed undefined until the name lookup landed and every typed anchor rendered `href="#"` in the meantime — even though the destination follows from the id alone.

--- a/apps/web/__mocks__/@jitaspace/eve-components.tsx
+++ b/apps/web/__mocks__/@jitaspace/eve-components.tsx
@@ -27,18 +27,35 @@ const childrenStub =
       children,
     );
 
+// Entity anchors render a real <a> so tests can assert the destination. The
+// href is omitted while the id is nullish, mirroring the real components —
+// emitting `/type/undefined` is precisely the bug these stubs must not hide.
+const anchorStub =
+  (path: string, idProp: string, testid?: string) =>
+  ({ children, ...props }: AnyProps) => {
+    const id = props[idProp] as string | number | null | undefined;
+    return React.createElement(
+      "a",
+      {
+        ...(testid ? { "data-testid": testid } : null),
+        ...(id === null || id === undefined ? null : { href: `${path}/${id}` }),
+      },
+      children,
+    );
+  };
+
 // --- Anchors (render children) ---
-export const CharacterAnchor = childrenStub();
+export const CharacterAnchor = anchorStub("/character", "characterId");
 export const ConstellationAnchor = childrenStub();
 export const EveEntityAnchor = childrenStub();
 export const EveEntityNameAnchor = childrenStub();
 export const EveMailSenderAnchor = childrenStub();
-export const FactionAnchor = childrenStub();
+export const FactionAnchor = anchorStub("/faction", "factionId");
 export const RegionAnchor = childrenStub();
-export const SolarSystemAnchor = childrenStub();
+export const SolarSystemAnchor = anchorStub("/system", "solarSystemId");
 export const StargateDestinationAnchor = childrenStub();
 export const StationAnchor = childrenStub();
-export const TypeAnchor = childrenStub("type-anchor");
+export const TypeAnchor = anchorStub("/type", "typeId", "type-anchor");
 export const WarAggressorAnchor = childrenStub();
 export const WarDefenderAnchor = childrenStub();
 

--- a/apps/web/__mocks__/@jitaspace/ui.tsx
+++ b/apps/web/__mocks__/@jitaspace/ui.tsx
@@ -12,12 +12,36 @@
  */
 import React from "react";
 
+// Entity anchors render a real <a> so tests can assert the destination. The
+// href is omitted while the id is nullish, mirroring the real components —
+// emitting `/race/undefined` is precisely the bug these stubs must not hide.
+const anchorStub =
+  (path: string, idProp: string, testid?: string) =>
+  ({
+    children,
+    ...props
+  }: Record<string, unknown> & { children?: React.ReactNode }) => {
+    const id = props[idProp] as string | number | null | undefined;
+    return React.createElement(
+      "a",
+      {
+        ...(testid ? { "data-testid": testid } : null),
+        ...(id === null || id === undefined ? null : { href: `${path}/${id}` }),
+      },
+      children,
+    );
+  };
+
 // --- Corporation ---
-export const CorporationAnchor = ({
-  children,
-}: {
-  children?: React.ReactNode;
-}) => React.createElement("span", { "data-testid": "corp-anchor" }, children);
+export const CorporationAnchor = anchorStub(
+  "/corporation",
+  "corporationId",
+  "corp-anchor",
+);
+
+// --- Race / Bloodline (SDE reference data, not ESI-resolvable entities) ---
+export const RaceAnchor = anchorStub("/race", "raceId");
+export const BloodlineAnchor = anchorStub("/bloodline", "bloodlineId");
 
 export const CorporationAvatar = () =>
   React.createElement("span", { "data-testid": "corp-avatar" });
@@ -105,3 +129,13 @@ export const CharacterAvatar = () => null;
 export const CharacterName = ({ characterId }: { characterId?: number }) =>
   React.createElement("span", null, `char-${characterId}`);
 export const TimeAgoText = () => null;
+
+// --- Alliance / Faction avatars ---
+export const AllianceAvatar = () => null;
+export const FactionAvatar = () => null;
+
+// --- Dates ---
+// The hover card renders its children so the wrapped date still reaches the DOM.
+export const DateHoverCard = ({ children }: { children?: React.ReactNode }) =>
+  React.createElement("span", { "data-testid": "date-hover-card" }, children);
+export const FormattedDateText = () => null;

--- a/apps/web/app/alliance/[allianceId]/page.client.tsx
+++ b/apps/web/app/alliance/[allianceId]/page.client.tsx
@@ -17,6 +17,7 @@ import { format } from "date-fns";
 
 import {
   AllianceName,
+  CharacterAnchor,
   CharacterName,
   CorporationName,
   FactionName,
@@ -29,6 +30,7 @@ import {
 import {
   AllianceAvatar,
   CharacterAvatar,
+  CorporationAnchor,
   CorporationAvatar,
   FactionAvatar,
 } from "@jitaspace/ui";
@@ -109,12 +111,9 @@ export default function Page() {
                 characterId={alliance?.data.creator_id}
                 size="sm"
               />
-              <Anchor
-                component={Link}
-                href={`/character/${alliance?.data.creator_id}`}
-              >
+              <CharacterAnchor characterId={alliance?.data.creator_id}>
                 <CharacterName span characterId={alliance?.data.creator_id} />
-              </Anchor>
+              </CharacterAnchor>
             </Group>
           </Group>
           <Group justify="space-between">
@@ -124,15 +123,14 @@ export default function Page() {
                 corporationId={alliance?.data.creator_corporation_id}
                 size="sm"
               />
-              <Anchor
-                component={Link}
-                href={`/corporation/${alliance?.data.creator_corporation_id}`}
+              <CorporationAnchor
+                corporationId={alliance?.data.creator_corporation_id}
               >
                 <CorporationName
                   span
                   corporationId={alliance?.data.creator_corporation_id}
                 />
-              </Anchor>
+              </CorporationAnchor>
             </Group>
           </Group>
           {alliance?.data.executor_corporation_id && (
@@ -186,9 +184,11 @@ export default function Page() {
           {allianceCorporations?.data.map((corporationId) => (
             <Group wrap="nowrap" key={corporationId}>
               <CorporationAvatar corporationId={corporationId} size="sm" />
-              <Anchor component={Link} href={`/corporation/${corporationId}`}>
+              {/* One link per member corporation, unpaginated — the largest
+                  prefetch fan-out on the site. */}
+              <CorporationAnchor corporationId={corporationId} prefetch={false}>
                 <CorporationName span corporationId={corporationId} />
-              </Anchor>
+              </CorporationAnchor>
               <Group gap="xs">
                 {alliance?.data.creator_corporation_id === corporationId && (
                   <Badge size="xs">Creator</Badge>

--- a/apps/web/app/bloodline/[bloodlineId]/page.client.tsx
+++ b/apps/web/app/bloodline/[bloodlineId]/page.client.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import Link from "next/link";
 import { useParams } from "next/navigation";
-import { Anchor, Container, Group, Stack, Text, Title } from "@mantine/core";
+import { Container, Group, Stack, Text, Title } from "@mantine/core";
 
-import { CorporationName, TypeName } from "@jitaspace/eve-components";
+import {
+  CorporationName,
+  TypeAnchor,
+  TypeName,
+} from "@jitaspace/eve-components";
 import { useBloodline } from "@jitaspace/hooks";
 import { sanitizeFormattedEveString } from "@jitaspace/tiptap-eve";
-import { CorporationAvatar, TypeAvatar } from "@jitaspace/ui";
+import {
+  CorporationAnchor,
+  CorporationAvatar,
+  RaceAnchor,
+  TypeAvatar,
+} from "@jitaspace/ui";
 
 import { RaceAvatar } from "~/components/Avatar";
 import { MailMessageViewer } from "~/components/EveMail";
@@ -47,21 +55,18 @@ export default function Page() {
           <Text>Corporation</Text>
           <Group wrap="nowrap">
             <CorporationAvatar corporationId={bloodline?.corporation_id} />
-            <Anchor
-              component={Link}
-              href={`/corporation/${bloodline?.corporation_id}`}
-            >
+            <CorporationAnchor corporationId={bloodline?.corporation_id}>
               <CorporationName corporationId={bloodline?.corporation_id} />
-            </Anchor>
+            </CorporationAnchor>
           </Group>
         </Group>
         <Group justify="space-between">
           <Text>Race</Text>
           <Group wrap="nowrap">
             <RaceAvatar raceId={bloodline?.race_id} />
-            <Anchor component={Link} href={`/race/${bloodline?.race_id}`}>
+            <RaceAnchor raceId={bloodline?.race_id}>
               <RaceName raceId={bloodline?.race_id} />
-            </Anchor>
+            </RaceAnchor>
           </Group>
         </Group>
         <Group justify="space-between">
@@ -71,9 +76,9 @@ export default function Page() {
               typeId={bloodline?.ship_type_id ?? undefined}
               radius="xl"
             />
-            <Anchor component={Link} href={`/type/${bloodline?.ship_type_id}`}>
+            <TypeAnchor typeId={bloodline?.ship_type_id ?? undefined}>
               <TypeName typeId={bloodline?.ship_type_id ?? undefined} />
-            </Anchor>
+            </TypeAnchor>
           </Group>
         </Group>
         {bloodline &&

--- a/apps/web/app/character/[characterId]/page.client.tsx
+++ b/apps/web/app/character/[characterId]/page.client.tsx
@@ -53,12 +53,15 @@ import { useCharacterWalletBalance } from "@jitaspace/hooks/src/hooks/character/
 import { sanitizeFormattedEveString } from "@jitaspace/tiptap-eve";
 import {
   AllianceAvatar,
+  BloodlineAnchor,
   CharacterAvatar,
+  CorporationAnchor,
   CorporationAvatar,
   DateHoverCard,
   FactionAvatar,
   FormattedDateText,
   ISKAmount,
+  RaceAnchor,
   TypeAvatar,
 } from "@jitaspace/ui";
 
@@ -175,16 +178,17 @@ function CharacterEmploymentHistory({
           }
           title={
             <Group gap="xs">
-              <Anchor
-                component={Link}
-                href={`/corporation/${entry.corporation_id}`}
+              {/* A historical timeline is not a navigation surface. */}
+              <CorporationAnchor
+                corporationId={entry.corporation_id}
+                prefetch={false}
               >
                 <CorporationName
                   span
                   corporationId={entry.corporation_id}
                   fw={500}
                 />
-              </Anchor>
+              </CorporationAnchor>
               {entry.isCurrent && (
                 <Badge size="xs" color="teal" variant="light">
                   Current
@@ -470,20 +474,14 @@ export default function Page({
                     </InfoRow>
                   )}
                   <InfoRow label="Race">
-                    <Anchor
-                      component={Link}
-                      href={`/race/${character?.raceId}`}
-                    >
+                    <RaceAnchor raceId={character?.raceId}>
                       <RaceName span raceId={character?.raceId} />
-                    </Anchor>
+                    </RaceAnchor>
                   </InfoRow>
                   <InfoRow label="Bloodline">
-                    <Anchor
-                      component={Link}
-                      href={`/bloodline/${character?.bloodlineId}`}
-                    >
+                    <BloodlineAnchor bloodlineId={character?.bloodlineId}>
                       <BloodlineName bloodlineId={character?.bloodlineId} />
-                    </Anchor>
+                    </BloodlineAnchor>
                   </InfoRow>
                   {character?.factionId && (
                     <InfoRow label="Faction">

--- a/apps/web/app/planet/[planetId]/page.client.tsx
+++ b/apps/web/app/planet/[planetId]/page.client.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import Link from "next/link";
 import { useParams } from "next/navigation";
-import { Anchor, Container, Group, Stack, Text, Title } from "@mantine/core";
+import { Container, Group, Stack, Text, Title } from "@mantine/core";
 
-import { SolarSystemName, TypeName } from "@jitaspace/eve-components";
+import {
+  SolarSystemAnchor,
+  SolarSystemName,
+  TypeAnchor,
+  TypeName,
+} from "@jitaspace/eve-components";
 import { usePlanet } from "@jitaspace/hooks";
 import { Position3DText, TypeAvatar } from "@jitaspace/ui";
 
@@ -38,16 +42,16 @@ export default function Page() {
               solarSystemId={planet?.data.system_id}
               size="sm"
             />
-            <Anchor component={Link} href={`/system/${planet?.data.system_id}`}>
+            <SolarSystemAnchor solarSystemId={planet?.data.system_id}>
               <SolarSystemName span solarSystemId={planet?.data.system_id} />
-            </Anchor>
+            </SolarSystemAnchor>
           </Group>
         </Group>
         <Group justify="space-between">
           <Text>Planet Type</Text>
-          <Anchor component={Link} href={`/type/${planet?.data.type_id}`}>
+          <TypeAnchor typeId={planet?.data.type_id}>
             <TypeName span typeId={planet?.data.type_id} />
-          </Anchor>
+          </TypeAnchor>
         </Group>
         <Group justify="space-between">
           <Text>Position</Text>

--- a/apps/web/app/race/[raceId]/page.client.tsx
+++ b/apps/web/app/race/[raceId]/page.client.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import Link from "next/link";
 import { useParams } from "next/navigation";
-import { Anchor, Container, Group, Stack, Text, Title } from "@mantine/core";
+import { Container, Group, Stack, Text, Title } from "@mantine/core";
 
-import { FactionName } from "@jitaspace/eve-components";
+import { FactionAnchor, FactionName } from "@jitaspace/eve-components";
 import { useRace } from "@jitaspace/hooks";
 import { FactionAvatar } from "@jitaspace/ui";
 
@@ -36,9 +35,9 @@ export default function Page() {
           <Text>Faction</Text>
           <Group>
             <FactionAvatar factionId={race?.alliance_id} radius={16} />
-            <Anchor component={Link} href={`/faction/${race?.alliance_id}`}>
+            <FactionAnchor factionId={race?.alliance_id}>
               <FactionName span factionId={race?.alliance_id} />
-            </Anchor>
+            </FactionAnchor>
           </Group>
         </Group>
       </Stack>

--- a/apps/web/app/station/[stationId]/page.client.tsx
+++ b/apps/web/app/station/[stationId]/page.client.tsx
@@ -2,25 +2,20 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import {
-  Anchor,
-  Button,
-  Container,
-  Group,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
+import { Button, Container, Group, Stack, Text, Title } from "@mantine/core";
 import { IconExternalLink } from "@tabler/icons-react";
 
 import {
   EveEntityAnchor,
   EveEntityName,
+  SolarSystemAnchor,
   SolarSystemName,
   StationName,
+  TypeAnchor,
   TypeName,
 } from "@jitaspace/eve-components";
 import { useSelectedCharacter, useStation } from "@jitaspace/hooks";
+import { RaceAnchor } from "@jitaspace/ui";
 
 import { SetAutopilotDestinationActionIcon } from "~/components/ActionIcon";
 import { StationAvatar } from "~/components/Avatar";
@@ -75,25 +70,22 @@ export default function Page() {
               solarSystemId={station?.data.system_id}
               size="sm"
             />
-            <Anchor
-              component={Link}
-              href={`/system/${station?.data.system_id}`}
-            >
+            <SolarSystemAnchor solarSystemId={station?.data.system_id}>
               <SolarSystemName span solarSystemId={station?.data.system_id} />
-            </Anchor>
+            </SolarSystemAnchor>
           </Group>
         </Group>
         <Group justify="space-between">
           <Text>Station Type</Text>
-          <Anchor component={Link} href={`/type/${station?.data.type_id}`}>
+          <TypeAnchor typeId={station?.data.type_id}>
             <TypeName span typeId={station?.data.type_id} />
-          </Anchor>
+          </TypeAnchor>
         </Group>
         <Group justify="space-between">
           <Text>Race</Text>
-          <Anchor component={Link} href={`/race/${station?.data.race_id}`}>
+          <RaceAnchor raceId={station?.data.race_id}>
             <RaceName span raceId={station?.data.race_id} />
-          </Anchor>
+          </RaceAnchor>
         </Group>
         <Group justify="space-between">
           <Text>Owner</Text>

--- a/apps/web/app/structure/[structureId]/page.client.tsx
+++ b/apps/web/app/structure/[structureId]/page.client.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import Link from "next/link";
 import { useParams } from "next/navigation";
-import { Anchor, Container, Group, Stack, Text, Title } from "@mantine/core";
+import { Container, Group, Stack, Text, Title } from "@mantine/core";
 
 import {
   EveEntityName,
+  SolarSystemAnchor,
   SolarSystemName,
   StructureName,
+  TypeAnchor,
   TypeName,
 } from "@jitaspace/eve-components";
 import { useSelectedCharacter, useStructure } from "@jitaspace/hooks";
@@ -53,22 +54,21 @@ export default function Page() {
                 solarSystemId={structure?.data.solar_system_id}
                 size="sm"
               />
-              <Anchor
-                component={Link}
-                href={`/system/${structure?.data.solar_system_id}`}
+              <SolarSystemAnchor
+                solarSystemId={structure?.data.solar_system_id}
               >
                 <SolarSystemName
                   span
                   solarSystemId={structure?.data.solar_system_id}
                 />
-              </Anchor>
+              </SolarSystemAnchor>
             </Group>
           </Group>
           <Group justify="space-between">
             <Text>Structure Type</Text>
-            <Anchor component={Link} href={`/type/${structure?.data.type_id}`}>
+            <TypeAnchor typeId={structure?.data.type_id}>
               <TypeName span typeId={structure?.data.type_id} />
-            </Anchor>
+            </TypeAnchor>
           </Group>
           <Group justify="space-between">
             <Text>Owner</Text>

--- a/apps/web/layouts/MainLayout/FooterWithLinks.tsx
+++ b/apps/web/layouts/MainLayout/FooterWithLinks.tsx
@@ -37,6 +37,11 @@ export function FooterWithLinks() {
       key={link.label}
       component={Link}
       href={link.link}
+      // The footer renders on every page, so prefetching these would fetch
+      // /about, /support and /status on every single page view — four PPR
+      // segment requests each. Almost nobody navigates here, so the prefetch
+      // was pure waste (~400k requests/day in production).
+      prefetch={false}
       size="xs"
       c="dimmed"
     >

--- a/apps/web/tests/bloodlinePage.test.tsx
+++ b/apps/web/tests/bloodlinePage.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/jest-globals";
 
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { MantineProvider } from "@mantine/core";
 import { render, screen } from "@testing-library/react";
 
@@ -21,8 +21,6 @@ jest.mock("@jitaspace/tiptap-eve", () => ({
   sanitizeFormattedEveString: (s: string) => `sanitized:${s}`,
 }));
 
-jest.mock("@jitaspace/ui", () => new Proxy({}, { get: () => () => null }));
-
 jest.mock("~/components/Avatar", () => ({
   RaceAvatar: () => null,
 }));
@@ -31,7 +29,9 @@ jest.mock("~/components/Text", () => ({
   BloodlineName: ({ bloodlineId }: { bloodlineId: number }) => (
     <span>{`Bloodline ${bloodlineId}`}</span>
   ),
-  RaceName: ({ raceId }: { raceId?: number }) => <span>{`Race ${raceId}`}</span>,
+  RaceName: ({ raceId }: { raceId?: number }) => (
+    <span>{`Race ${raceId}`}</span>
+  ),
 }));
 
 jest.mock("~/components/EveMail", () => ({

--- a/apps/web/tests/characterPage.test.tsx
+++ b/apps/web/tests/characterPage.test.tsx
@@ -70,8 +70,6 @@ jest.mock("@jitaspace/tiptap-eve", () => ({
   sanitizeFormattedEveString: (s: string) => `sanitized:${s}`,
 }));
 
-jest.mock("@jitaspace/ui", () => new Proxy({}, { get: () => () => null }));
-
 jest.mock("~/components/ActionIcon", () => ({
   OpenInformationWindowActionIcon: () => <div data-testid="info-window" />,
 }));

--- a/apps/web/tests/footerWithLinks.test.tsx
+++ b/apps/web/tests/footerWithLinks.test.tsx
@@ -1,0 +1,60 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import type { ReactNode } from "react";
+import { describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    prefetch,
+    children,
+  }: {
+    href?: string | object;
+    prefetch?: boolean;
+    children?: ReactNode;
+  }) => (
+    <a
+      href={typeof href === "string" ? href : ""}
+      data-prefetch={String(prefetch)}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("~/env", () => ({
+  env: { NEXT_PUBLIC_DISCORD_INVITE_LINK: "https://discord.gg/jitaspace" },
+}));
+
+jest.mock("~/components/Badge", () => ({
+  PartnerBadge: () => null,
+}));
+
+describe("FooterWithLinks", () => {
+  it("renders the footer links with prefetching disabled", () => {
+    const { FooterWithLinks } = require("~/layouts/MainLayout/FooterWithLinks");
+
+    render(
+      <MantineProvider>
+        <FooterWithLinks />
+      </MantineProvider>,
+    );
+
+    // The footer is on every page, so prefetching these would fetch /about,
+    // /support and /status on every single page view — four PPR segment
+    // requests each, ~400k requests/day in production. Almost nobody
+    // navigates here, so the prefetch must stay off.
+    for (const [label, href] of [
+      ["About", "/about"],
+      ["Support", "/support"],
+      ["Status", "/status"],
+    ]) {
+      const link = screen.getByRole("link", { name: label });
+      expect(link).toHaveAttribute("href", href);
+      expect(link).toHaveAttribute("data-prefetch", "false");
+    }
+  });
+});

--- a/apps/web/tests/racePage.test.tsx
+++ b/apps/web/tests/racePage.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/jest-globals";
 
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { MantineProvider } from "@mantine/core";
 import { render, screen } from "@testing-library/react";
 
@@ -71,7 +71,7 @@ describe("race page", () => {
     expect(hrefs).toContain("/faction/500001");
   });
 
-  it("renders static label and faction link when race data is undefined", () => {
+  it("renders the faction row unlinked when race data is undefined", () => {
     mockUseRace.mockReturnValue({ data: undefined });
 
     const Page = require("~/app/race/[raceId]/page.client").default;
@@ -81,13 +81,21 @@ describe("race page", () => {
       </MantineProvider>,
     );
 
+    // The row itself must survive, so the layout does not shift once the
+    // faction id arrives.
     expect(screen.getByText("Race 1")).toBeInTheDocument();
     expect(screen.getByText("Faction")).toBeInTheDocument();
-    // faction link still rendered, pointing at undefined id
-    const hrefs = screen
-      .getAllByRole("link")
-      .map((a) => a.getAttribute("href"));
-    expect(hrefs).toContain("/faction/undefined");
+
+    // ...but no link may be emitted while the id is unknown. Interpolating
+    // `undefined` into the href produced /faction/undefined, which next/link
+    // then eagerly prefetched — ~100k requests/day in production across
+    // /race, /bloodline, /type and /system.
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    const hrefs = Array.from(document.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs.some((href) => href?.includes("undefined"))).toBe(false);
+
     expect(
       screen.queryByText("Founded by exiles of the Amarr Empire."),
     ).not.toBeInTheDocument();

--- a/packages/eve-components/Anchor/EveEntityAnchor.tsx
+++ b/packages/eve-components/Anchor/EveEntityAnchor.tsx
@@ -22,7 +22,17 @@ export const EveEntityAnchor = memo(
     children,
     ...props
   }: EveEntityAnchorProps) => {
-    const { category } = useEsiName(entityId ?? undefined, categoryHint);
+    const { category: resolvedCategory } = useEsiName(
+      entityId ?? undefined,
+      categoryHint,
+    );
+
+    // `useEsiName` reports the category off the *resolved* cache entry, so it
+    // stays undefined until the name lookup lands. Callers like `TypeAnchor`
+    // and `CharacterAnchor` already know the category statically, and the
+    // destination follows from the id alone — so prefer the hint and emit a
+    // real href on first render instead of parking the link on "#".
+    const category = categoryHint ?? resolvedCategory;
 
     const url = useMemo(() => {
       if (!entityId || !category) return "#";

--- a/packages/eve-components/tests/Anchor/Anchor.test.tsx
+++ b/packages/eve-components/tests/Anchor/Anchor.test.tsx
@@ -65,8 +65,6 @@ describe("Anchor components", () => {
       "CorporationAnchor",
       <CorporationAnchor corporationId={98}>Corp</CorporationAnchor>,
       "Corp",
-      // The source builds "/corporation/98/" but next/link normalizes away the
-      // trailing slash; assert the actually-rendered href.
       "/corporation/98",
     ],
     [

--- a/packages/ui/Anchor/BloodlineAnchor.tsx
+++ b/packages/ui/Anchor/BloodlineAnchor.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { AnchorProps } from "@mantine/core";
+import type { LinkProps } from "next/link";
+import { memo } from "react";
+import Link from "next/link";
+import { Anchor } from "@mantine/core";
+
+export type BloodlineAnchorProps = AnchorProps &
+  Omit<LinkProps, "href"> &
+  Omit<React.HTMLProps<HTMLAnchorElement>, "ref" | "size" | "style"> & {
+    bloodlineId?: string | number | null;
+  };
+
+/**
+ * Links to a bloodline page.
+ *
+ * Bloodlines are SDE reference data rather than ESI-resolvable entities, so
+ * this cannot route through `EveEntityAnchor` — and does not need to, since
+ * the destination follows from the id alone with no name lookup.
+ *
+ * `bloodlineId` is optional because callers read it off a query result that has
+ * not resolved on first render. While it is nullish the children render
+ * unlinked: interpolating `undefined` into the href produced
+ * `/bloodline/undefined`, which `next/link` then prefetched ~46k times a day in
+ * production — the single largest wasted route on the site.
+ */
+export const BloodlineAnchor = memo(
+  ({
+    bloodlineId,
+    children,
+    prefetch,
+    ...otherProps
+  }: BloodlineAnchorProps) => {
+    // An <a> without href is the HTML placeholder for "a link might go here",
+    // so the row keeps its styling and layout while the id loads.
+    if (bloodlineId === null || bloodlineId === undefined) {
+      return <Anchor {...otherProps}>{children}</Anchor>;
+    }
+
+    return (
+      <Anchor
+        component={Link}
+        href={`/bloodline/${bloodlineId}`}
+        prefetch={prefetch}
+        {...otherProps}
+      >
+        {children}
+      </Anchor>
+    );
+  },
+);
+BloodlineAnchor.displayName = "BloodlineAnchor";

--- a/packages/ui/Anchor/CorporationAnchor.tsx
+++ b/packages/ui/Anchor/CorporationAnchor.tsx
@@ -9,15 +9,34 @@ import { Anchor } from "@mantine/core";
 export type CorporationNameAnchorProps = AnchorProps &
   Omit<LinkProps, "href"> &
   Omit<React.HTMLProps<HTMLAnchorElement>, "ref" | "size" | "style"> & {
-    corporationId: string | number;
+    corporationId?: string | number | null;
   };
 
+/**
+ * Links to a corporation page.
+ *
+ * `corporationId` is optional because callers read it off a query result that
+ * has not resolved on first render. While it is nullish the children render
+ * unlinked, rather than emitting `/corporation/undefined` for `next/link` to
+ * prefetch. This matches `TypeAnchor`, `CharacterAnchor` and `FactionAnchor`,
+ * which already accept an optional id.
+ */
 export const CorporationAnchor = memo(
-  ({ corporationId, children, ...otherProps }: CorporationNameAnchorProps) => {
+  ({
+    corporationId,
+    children,
+    prefetch,
+    ...otherProps
+  }: CorporationNameAnchorProps) => {
+    if (corporationId === null || corporationId === undefined) {
+      return <Anchor {...otherProps}>{children}</Anchor>;
+    }
+
     return (
       <Anchor
         component={Link}
-        href={`/corporation/${corporationId}/`}
+        href={`/corporation/${corporationId}`}
+        prefetch={prefetch}
         {...otherProps}
       >
         {children}

--- a/packages/ui/Anchor/RaceAnchor.tsx
+++ b/packages/ui/Anchor/RaceAnchor.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { AnchorProps } from "@mantine/core";
+import type { LinkProps } from "next/link";
+import { memo } from "react";
+import Link from "next/link";
+import { Anchor } from "@mantine/core";
+
+export type RaceAnchorProps = AnchorProps &
+  Omit<LinkProps, "href"> &
+  Omit<React.HTMLProps<HTMLAnchorElement>, "ref" | "size" | "style"> & {
+    raceId?: string | number | null;
+  };
+
+/**
+ * Links to a race page.
+ *
+ * Races are SDE reference data rather than ESI-resolvable entities, so this
+ * cannot route through `EveEntityAnchor` — and does not need to, since the
+ * destination follows from the id alone with no name lookup.
+ *
+ * `raceId` is optional because callers read it off a query result that has not
+ * resolved on first render. While it is nullish the children render unlinked:
+ * interpolating `undefined` into the href produced `/race/undefined`, which
+ * `next/link` then prefetched ~37k times a day in production.
+ */
+export const RaceAnchor = memo(
+  ({ raceId, children, prefetch, ...otherProps }: RaceAnchorProps) => {
+    // An <a> without href is the HTML placeholder for "a link might go here",
+    // so the row keeps its styling and layout while the id loads.
+    if (raceId === null || raceId === undefined) {
+      return <Anchor {...otherProps}>{children}</Anchor>;
+    }
+
+    return (
+      <Anchor
+        component={Link}
+        href={`/race/${raceId}`}
+        prefetch={prefetch}
+        {...otherProps}
+      >
+        {children}
+      </Anchor>
+    );
+  },
+);
+RaceAnchor.displayName = "RaceAnchor";

--- a/packages/ui/Anchor/index.ts
+++ b/packages/ui/Anchor/index.ts
@@ -1,4 +1,5 @@
 export * from "./AllianceAnchor";
+export * from "./BloodlineAnchor";
 export * from "./CategoryAnchor";
 export * from "./CorporationAnchor";
 export * from "./DogmaAttributeAnchor";
@@ -7,5 +8,6 @@ export * from "./EveEntityAnchorDisplay";
 export * from "./GroupAnchor";
 export * from "./MarketGroupAnchor";
 export * from "./OpenInformationWindowAnchor";
+export * from "./RaceAnchor";
 export * from "./StarAnchor";
 export * from "./WarAnchor";

--- a/packages/ui/tests/Anchor/EntityIdAnchors.test.tsx
+++ b/packages/ui/tests/Anchor/EntityIdAnchors.test.tsx
@@ -1,0 +1,119 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import type { ComponentType, ReactElement } from "react";
+import { createElement } from "react";
+import { describe, expect, it } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+import { BloodlineAnchor } from "../../Anchor/BloodlineAnchor";
+import { CorporationAnchor } from "../../Anchor/CorporationAnchor";
+import { RaceAnchor } from "../../Anchor/RaceAnchor";
+
+const renderWithMantine = (ui: ReactElement) =>
+  render(<MantineProvider>{ui}</MantineProvider>);
+
+/**
+ * These anchors take an entity id that callers read off a query result which
+ * has not resolved on first render. Interpolating that straight into an href
+ * produced paths like `/race/undefined`, which `next/link` then eagerly
+ * prefetched — ~99k requests/day in production. Each must therefore render its
+ * children unlinked until the id actually exists.
+ */
+const anchors = [
+  {
+    name: "RaceAnchor",
+    path: "/race",
+    Component: RaceAnchor,
+    idProp: "raceId",
+  },
+  {
+    name: "BloodlineAnchor",
+    path: "/bloodline",
+    Component: BloodlineAnchor,
+    idProp: "bloodlineId",
+  },
+  {
+    name: "CorporationAnchor",
+    path: "/corporation",
+    Component: CorporationAnchor,
+    idProp: "corporationId",
+  },
+] as const;
+
+describe.each(anchors)("$name", ({ path, Component, idProp }) => {
+  const renderAnchor = (
+    id: string | number | null | undefined,
+    extra: Record<string, unknown> = {},
+  ) =>
+    renderWithMantine(
+      createElement(
+        Component as ComponentType<Record<string, unknown>>,
+        { [idProp]: id, ...extra },
+        "Label",
+      ),
+    );
+
+  const anchorEl = () => screen.getByText("Label").closest("a");
+
+  it("links to the entity page once the id is known", () => {
+    renderAnchor(42);
+    expect(anchorEl()).toHaveAttribute("href", `${path}/42`);
+  });
+
+  it("accepts a string id", () => {
+    renderAnchor("42");
+    expect(anchorEl()).toHaveAttribute("href", `${path}/42`);
+  });
+
+  it("renders no trailing slash", () => {
+    // Two spellings of the same page would be two CDN cache entries.
+    renderAnchor(42);
+    expect(anchorEl()?.getAttribute("href")).not.toMatch(/\/$/);
+  });
+
+  it("still links when the id is 0", () => {
+    // Guarding with `id && …` would silently drop this link. Only a nullish id
+    // means "not loaded yet".
+    renderAnchor(0);
+    expect(anchorEl()).toHaveAttribute("href", `${path}/0`);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+  ])("renders its children unlinked while the id is %s", (_label, id) => {
+    renderAnchor(id);
+
+    // The label survives, so a row keeps its layout and does not shift once
+    // the id arrives...
+    expect(screen.getByText("Label")).toBeInTheDocument();
+    // ...but it must carry no destination at all.
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+    expect(anchorEl()).not.toHaveAttribute("href");
+  });
+
+  it("never emits an href containing 'undefined'", () => {
+    renderAnchor(undefined);
+    const hrefs = Array.from(document.querySelectorAll("a")).map((a) =>
+      a.getAttribute("href"),
+    );
+    expect(hrefs.some((href) => href?.includes("undefined"))).toBe(false);
+  });
+
+  it("keeps the next/link prefetch prop out of the DOM when unlinked", () => {
+    // `prefetch` is destructured off before the unlinked branch spreads the
+    // rest onto a plain Mantine Anchor, so it can never reach the element.
+    renderAnchor(undefined, { prefetch: true });
+    expect(anchorEl()).not.toHaveAttribute("prefetch");
+  });
+
+  it("forwards Mantine anchor props in both states", () => {
+    const { unmount } = renderAnchor(42, { c: "dimmed", underline: "never" });
+    expect(anchorEl()).toHaveAttribute("data-underline", "never");
+    unmount();
+
+    renderAnchor(undefined, { c: "dimmed", underline: "never" });
+    expect(anchorEl()).toHaveAttribute("data-underline", "never");
+  });
+});


### PR DESCRIPTION
## What

Fifteen call sites across seven entity pages interpolated an optional-chained value straight into an `href`, so before React Query resolved they emitted paths containing the literal string `undefined` — which `next/link` then eagerly prefetched.

Measured in production over 24h:

| path | requests/day |
| --- | --- |
| `/bloodline/undefined` | 45,943 |
| `/race/undefined` | 36,713 |
| `/type/undefined` | 9,486 |
| `/system/undefined` | 7,686 |
| `/corporation/undefined` | 2,222 |
| `/character/undefined` | 1,759 |

The character page already had the correct idiom eight lines below the two worst offenders, where the faction link is guarded — it just was never applied to race and bloodline.

## How

Rather than guard each call site, the links now route through the shared entity anchors, so the bug cannot be reconstructed at a call site.

That needed two new components — **`RaceAnchor`** and **`BloodlineAnchor`**. Races and bloodlines are SDE reference data rather than ESI-resolvable entities, so they cannot go through `EveEntityAnchor`, which is why no anchor existed for them. Both build the href from the id directly, with no name lookup.

Two supporting changes:

- **`CorporationAnchor` takes an optional id**, matching `TypeAnchor` / `CharacterAnchor` / `FactionAnchor`, which already do. Widening is safe for all 22 existing callers. It also drops the trailing slash from its href so it reads like every sibling anchor. ~~This was splitting the CDN cache.~~ **Correction:** it was not — `next/link` normalises the slash away before the request is made, which `Anchor.test.tsx` already asserted against a real unmocked `next/link`. This part is cosmetic.
- **`EveEntityAnchor` now prefers its `category` prop** over the category `useEsiName` reports. That value is read off the *resolved* cache entry, so it stayed `undefined` until the name lookup landed and every typed anchor rendered `href="#"` until then. Without this, moving `/type/` links onto `TypeAnchor` would have been an SEO regression on the site's main organic surface.

All of them render their children unlinked while the id is nullish, so the row keeps its layout (no CLS) but emits no href.

## Prefetch

Separately, the footer renders on every page and prefetched `/about`, `/support` and `/status` on every page view — four PPR segment requests each, **~321,000 requests/day** for three links almost nobody clicks:

```
/status   109,174/day
/support  107,854/day
/about    104,101/day
```

`prefetch={false}` is now set there, plus two other unbounded lists: the alliance member-corporation roster and the character employment-history timeline. It is deliberately **not** a default on the shared anchors — everywhere else keeps prefetching.

## Tests

`racePage.test.tsx` was asserting the bug, which is how it survived:

```js
// faction link still rendered, pointing at undefined id
expect(hrefs).toContain("/faction/undefined");
```

It now asserts the row renders unlinked. The shared `__mocks__` anchor stubs rendered `<span>`, so no test could ever have caught a bad href — they now render a real `<a>` with the href omitted when the id is nullish, which also filled four exports the stubs were missing (`AllianceAvatar`, `FactionAvatar`, `DateHoverCard`, `FormattedDateText`).

```
apps/web                 137 suites, 1117 tests   pass
packages/ui               11 suites,  120 tests   pass
packages/eve-components   13 suites,  279 tests   pass
pnpm type-check           0 errors
pnpm lint                 0 errors (30 pre-existing warnings)
```

## Notes

- Found while investigating a traffic spike that pushed the site to ~1.38M requests/day. Worth stressing that only ~1,414/day were real function invocations — the cost was edge requests and bandwidth, not compute, and roughly 420k/day of it was self-inflicted rather than caused by the crawler.
- `CategoryAnchor`, `GroupAnchor` and `MarketGroupAnchor` have the same latent defect (optional id, interpolated blindly). They do not appear in the logs, so they are not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
