### PR TITLE
fix(web): stop shipping a broken og:image and a 404 search result

### DIFF
--- a/.changeset/og-image-and-search-route.md
+++ b/.changeset/og-image-and-search-route.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed item pages sharing a broken preview image on Discord, Twitter and other sites that unfurl links. Items with no artwork in EVE's image service were advertising an image address that does not exist; they now share no image instead, so the link falls back to the title and description.
+
+Fixed searching for a solar system and clicking the result leading to a "page not found" error.

--- a/apps/web/app/type/[typeId]/page.tsx
+++ b/apps/web/app/type/[typeId]/page.tsx
@@ -49,7 +49,14 @@ async function getTypeData(typeId: number): Promise<PageProps> {
 
   return {
     typeId,
-    ogImageUrl: `https://images.evetech.net/types/${typeId}/${variation}`,
+    // No variation means the image service has no image for this type at all —
+    // `/types/<id>` 404s, and so would any variation we guessed at. Leave the
+    // URL undefined so the `openGraph`/`twitter` blocks below drop the tag
+    // entirely; interpolating the missing variation shipped
+    // `.../types/2/undefined` as og:image on every such page.
+    ogImageUrl: variation
+      ? `https://images.evetech.net/types/${typeId}/${variation}`
+      : undefined,
     typeName: type.name,
     typeDescription: type.description,
   };

--- a/apps/web/components/Spotlight/useSearchActions.tsx
+++ b/apps/web/components/Spotlight/useSearchActions.tsx
@@ -13,17 +13,22 @@ import { jitaApps } from "~/config/apps";
 
 // Where each ESI search category resolves to. Kept as a lookup table so the
 // click handler stays a single push instead of a large switch.
-const CATEGORY_ROUTE_PREFIX: Partial<Record<EsiSearchCategory, string>> = {
-  alliance: "/alliance/",
-  agent: "/character/",
-  character: "/character/",
-  corporation: "/corporation/",
-  faction: "/faction/",
-  solar_system: "/solar_system/",
-  station: "/station/",
-  structure: "/structure/",
-  inventory_type: "/type/",
-};
+export const CATEGORY_ROUTE_PREFIX: Partial<Record<EsiSearchCategory, string>> =
+  {
+    alliance: "/alliance/",
+    agent: "/character/",
+    character: "/character/",
+    corporation: "/corporation/",
+    faction: "/faction/",
+    // NB: the route is /system/, not /solar_system/ — the ESI category name and
+    // the app's path differ. Keep this in step with the switch in
+    // packages/eve-components/Anchor/EveEntityAnchor.tsx, which owns the same
+    // category-to-path mapping for entity links.
+    solar_system: "/system/",
+    station: "/station/",
+    structure: "/structure/",
+    inventory_type: "/type/",
+  };
 
 export interface SearchActionGroups {
   /** Every action matching the query, flat. */

--- a/apps/web/tests/mainSpotlight.test.tsx
+++ b/apps/web/tests/mainSpotlight.test.tsx
@@ -1,13 +1,15 @@
 import "@testing-library/jest-dom/jest-globals";
 
-import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import type { ImgHTMLAttributes, ReactNode } from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { MantineProvider } from "@mantine/core";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockRouterPush = jest.fn<(url: string) => Promise<boolean>>();
 const mockUseEsiSearch =
-  jest.fn<(...args: unknown[]) => { data?: { data: Record<string, number[]> } }>();
+  jest.fn<
+    (...args: unknown[]) => { data?: { data: Record<string, number[]> } }
+  >();
 const mockUseEsiNameLookup = jest.fn<
   (...args: unknown[]) => Record<
     string,
@@ -191,7 +193,9 @@ describe("MainSpotlight", () => {
       fireEvent.change(screen.getByTestId("spotlight-search"), {
         target: { value: "mail" },
       });
-      expect(screen.getByTestId("action-app/Character/EveMail")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-app/Character/EveMail"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByTestId("action-app/Character/Skills"),
       ).not.toBeInTheDocument();
@@ -203,7 +207,9 @@ describe("MainSpotlight", () => {
       fireEvent.change(screen.getByTestId("spotlight-search"), {
         target: { value: "correspondence" },
       });
-      expect(screen.getByTestId("action-app/Character/EveMail")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-app/Character/EveMail"),
+      ).toBeInTheDocument();
       expect(
         screen.queryByTestId("action-app/Character/Skills"),
       ).not.toBeInTheDocument();
@@ -214,8 +220,12 @@ describe("MainSpotlight", () => {
       const input = screen.getByTestId("spotlight-search");
       fireEvent.change(input, { target: { value: "mail" } });
       fireEvent.change(input, { target: { value: "" } });
-      expect(screen.getByTestId("action-app/Character/EveMail")).toBeInTheDocument();
-      expect(screen.getByTestId("action-app/Character/Skills")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-app/Character/EveMail"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-app/Character/Skills"),
+      ).toBeInTheDocument();
     });
 
     it("shows the empty state when no apps or results match", () => {
@@ -351,7 +361,9 @@ describe("MainSpotlight", () => {
       });
       renderSpotlight();
       fireEvent.click(screen.getByTestId("action-entity/30000142"));
-      expect(mockRouterPush).toHaveBeenCalledWith("/solar_system/30000142");
+      // The route is /system/, not /solar_system/ — this assertion used to
+      // pin the ESI category name and so kept a 404 in place.
+      expect(mockRouterPush).toHaveBeenCalledWith("/system/30000142");
     });
 
     it("navigates to the station page when a station result is clicked", () => {
@@ -415,4 +427,3 @@ describe("MainSpotlight", () => {
     });
   });
 });
-

--- a/apps/web/tests/searchRoutePrefixes.test.ts
+++ b/apps/web/tests/searchRoutePrefixes.test.ts
@@ -1,0 +1,47 @@
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "@jest/globals";
+
+import { CATEGORY_ROUTE_PREFIX } from "~/components/Spotlight/useSearchActions";
+
+const APP_DIR = join(process.cwd(), "app");
+
+/**
+ * Every prefix in the table is followed by an entity id, so the destination is
+ * always `<prefix><id>` — which requires a dynamic route segment underneath it.
+ */
+function hasDynamicRoute(prefix: string): boolean {
+  const segment = prefix.replace(/^\/|\/$/g, "");
+  const dir = join(APP_DIR, segment);
+  if (!existsSync(dir)) return false;
+  return readdirSync(dir, { withFileTypes: true }).some(
+    (entry) => entry.isDirectory() && entry.name.startsWith("["),
+  );
+}
+
+describe("Spotlight CATEGORY_ROUTE_PREFIX", () => {
+  const entries = Object.entries(CATEGORY_ROUTE_PREFIX);
+
+  it("is not empty", () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  // The ESI category name and the app's path are not always the same word —
+  // `solar_system` lives at /system/. Nothing in the type system catches that,
+  // and the table shipped pointing at /solar_system/, so every solar-system
+  // search result navigated to a 404.
+  it.each(entries)(
+    "%s -> %s resolves to a real dynamic route",
+    (_category, prefix) => {
+      expect(hasDynamicRoute(prefix)).toBe(true);
+    },
+  );
+
+  it("uses a leading and trailing slash so `${prefix}${id}` is well formed", () => {
+    for (const [, prefix] of entries) {
+      expect(prefix.startsWith("/")).toBe(true);
+      expect(prefix.endsWith("/")).toBe(true);
+      expect(prefix).not.toContain("//");
+    }
+  });
+});

--- a/apps/web/tests/typeMetadataOgImage.test.ts
+++ b/apps/web/tests/typeMetadataOgImage.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+type Row = Record<string, unknown>;
+
+const typeFindUniqueOrThrow = jest.fn<(args?: unknown) => Promise<Row>>();
+
+jest.mock("~/lib/db", () => ({
+  prisma: {
+    type: { findUniqueOrThrow: (a?: unknown) => typeFindUniqueOrThrow(a) },
+    typeAttribute: { findMany: () => Promise.resolve([]) },
+  },
+}));
+
+// `getTypeData` is a "use cache" function; cacheLife is a no-op here.
+jest.mock("next/cache", () => ({
+  cacheLife: () => undefined,
+  unstable_cacheLife: () => undefined,
+}));
+
+jest.mock("~/app/type/[typeId]/page.client", () => ({ default: () => null }));
+jest.mock("~/components/PageSkeleton", () => ({ PageSkeleton: () => null }));
+
+/** Stand in for images.evetech.net/types/<id>, which lists an item's renders. */
+function mockImageService(variations: string[] | "not-found") {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      status: variations === "not-found" ? 404 : 200,
+      json: () => Promise.resolve(variations === "not-found" ? [] : variations),
+    }),
+  ) as unknown as typeof fetch;
+}
+
+async function metadataFor(typeId: number) {
+  const { generateMetadata } = require("~/app/type/[typeId]/page") as {
+    generateMetadata: (a: {
+      params: Promise<{ typeId: string }>;
+    }) => Promise<Record<string, never>>;
+  };
+  return (await generateMetadata({
+    params: Promise.resolve({ typeId: String(typeId) }),
+  })) as {
+    openGraph?: { images?: { url: string }[] };
+    twitter?: { images?: string[] };
+  };
+}
+
+describe("type/[typeId] generateMetadata og:image", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    typeFindUniqueOrThrow.mockReset();
+    typeFindUniqueOrThrow.mockResolvedValue({
+      typeId: 34,
+      name: "Tritanium",
+      description: "The most common ore type in the known world.",
+    });
+  });
+
+  it("prefers the icon variation when the image service offers one", async () => {
+    mockImageService(["icon", "bp"]);
+    const meta = await metadataFor(34);
+    expect(meta.openGraph?.images?.[0]?.url).toBe(
+      "https://images.evetech.net/types/34/icon",
+    );
+    expect(meta.twitter?.images?.[0]).toBe(
+      "https://images.evetech.net/types/34/icon",
+    );
+  });
+
+  it("falls back to the first variation when there is no icon", async () => {
+    mockImageService(["render"]);
+    const meta = await metadataFor(34);
+    expect(meta.openGraph?.images?.[0]?.url).toBe(
+      "https://images.evetech.net/types/34/render",
+    );
+  });
+
+  // The regression: /types/2 404s, so the variation list is empty and the
+  // variation is undefined. Interpolating it shipped
+  // `https://images.evetech.net/types/2/undefined` as og:image and
+  // twitter:image on every image-less type page — all of which are in the
+  // sitemap. Guessing a variation is no better: /types/2/icon 404s too.
+  it("emits no image at all when the image service has none", async () => {
+    mockImageService("not-found");
+    const meta = await metadataFor(2);
+    expect(meta.openGraph?.images).toEqual([]);
+    expect(meta.twitter?.images).toEqual([]);
+  });
+
+  it("never emits a URL containing 'undefined'", async () => {
+    for (const variations of [
+      "not-found" as const,
+      [] as string[],
+      ["icon"],
+      ["render"],
+    ]) {
+      mockImageService(variations);
+      const meta = await metadataFor(2);
+      const urls = [
+        ...(meta.openGraph?.images ?? []).map((i) => i.url),
+        ...(meta.twitter?.images ?? []),
+      ];
+      for (const url of urls) expect(url).not.toContain("undefined");
+    }
+  });
+});


### PR DESCRIPTION
Two dead links found by a repo-wide href sweep. Both verified against production before and after.

## 1. `og:image` pointed at a URL ending in `undefined`

`getTypeData` asks images.evetech.net which variations exist for a type. When the service 404s it correctly yields an empty list — and then interpolated `typeImageVariations[0]`, which is `undefined`, straight into the URL. Production, before:

```
/type/2   og:image = https://images.evetech.net/types/2/undefined
/type/3   og:image = https://images.evetech.net/types/3/undefined
/type/34  og:image = https://images.evetech.net/types/34/icon      ← correct
```

Type 2 is "Corporation" — a published, indexed page, not an edge case. Every type id is enumerated in the sitemap, so this shipped on every item with no artwork, on the site's main organic surface.

Guessing a variation would not help: `/types/2/icon` 404s too, because the service has no image for that type at all. So emit nothing.

The `openGraph` and `twitter` blocks already truthiness-check the value — which a non-empty string containing `"undefined"` quietly passed. Returning `undefined` makes those existing guards do their job and the tag is dropped. The client component at `page.client.tsx:309` already had this right (`variations[0] ?? "icon"`); only the server path was missing it.

## 2. Solar-system search results navigated to a route that does not exist

`CATEGORY_ROUTE_PREFIX` mapped the ESI category `solar_system` to `"/solar_system/"`. The app serves systems from `/system/`:

```
/solar_system/30000142 -> 404
/system/30000142       -> 200
```

The prefix is a hardcoded constant, so *every* solar-system result was dead — from both the Spotlight modal and the `/search` page. `EveEntityAnchor` already owns the correct category-to-path mapping; the two drifted.

## Tests

`searchRoutePrefixes.test.ts` asserts every entry in the table resolves to a real dynamic route directory — so this cannot drift again for **any** category, not just this one.

`typeMetadataOgImage.test.ts` covers the icon, fallback and no-image paths, plus a blanket "never emits a URL containing `undefined`".

Both were confirmed to fail when the respective bug is reintroduced, then pass again once reverted.

`mainSpotlight.test.tsx` was **asserting the bug** — `toHaveBeenCalledWith("/solar_system/30000142")` — which is how it survived. That is the third test in this codebase found pinning a broken href in place (after `racePage.test.tsx` asserting `/faction/undefined`, and the `__mocks__` anchor stubs rendering `<span>` so no href could ever be checked).

```
apps/web   1155 tests   pass
type-check    0 errors
lint          0 errors
```

## Not fixed here

The sweep also confirmed `/wallet/corporation` is in the global header nav and the `/wallet` hub but has no route (404). That needs a product call — build the page, or drop the entry — so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)