### PR TITLE
fix(web): stop the travel planner swapping the waypoint you picked

### DIFF
--- a/.changeset/travel-empty-waypoint-segment.md
+++ b/.changeset/travel-empty-waypoint-segment.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed the travel planner swapping your origin and destination if you filled in the second waypoint box before the first. The address bar now waits until both are set before updating, instead of writing an incomplete route that moved your choice to the other box.

--- a/apps/web/app/travel/[[...waypoints]]/page.client.tsx
+++ b/apps/web/app/travel/[[...waypoints]]/page.client.tsx
@@ -219,18 +219,33 @@ export default function TravelPage({
                   (_, i) => (i === index ? value : (waypoints[i] ?? "")),
                 );
                 waypointHandlers.setState(nextWaypoints);
+                // Only sync the URL once every slot resolves to a system.
+                // Filling the second select first leaves slot 0 empty, which
+                // used to serialize as an empty path segment ("/travel//Delta").
+                // Next 308-redirects that away and parseInitialWaypoints drops
+                // the blank, so the chosen system lands in slot 0 — silently
+                // becoming the other end of the route. No placeholder segment
+                // can hold the position either ("_" already decodes to a space
+                // in system names), and a route needs both ends before it means
+                // anything, so leave the URL alone until the pair is complete.
+                // The state update above still lands, so the form shows the
+                // selection immediately.
+                const names = nextWaypoints.map(
+                  (systemId) => solarSystems[systemId]?.name,
+                );
+                if (names.some((name) => name === undefined)) return;
                 // Carry the control params across the navigation (see
                 // serializeTravelUrl). Serialize the raw URL state, NOT the
                 // derived `penalties` — for a preset the penalties are implied,
                 // and emitting them here would put back the redundant params
                 // that PRESET_PENALTIES exists to keep out of the URL.
                 router.push(
-                  serializeTravelUrl(
-                    `/travel/${nextWaypoints
-                      .map((systemId) => solarSystems[systemId]?.name ?? "")
-                      .join("/")}`,
-                    { pref: routePreference, nullSec, lowSec, highSec },
-                  ),
+                  serializeTravelUrl(`/travel/${names.join("/")}`, {
+                    pref: routePreference,
+                    nullSec,
+                    lowSec,
+                    highSec,
+                  }),
                 );
               }}
               key={index}

--- a/apps/web/tests/travelPage.test.tsx
+++ b/apps/web/tests/travelPage.test.tsx
@@ -105,6 +105,35 @@ describe("Travel Page", () => {
     // stale waypoints array and dropped the change, lagging one interaction.
     expect(mockPush).toHaveBeenLastCalledWith("/travel/Delta/Alpha");
   });
+
+  it("does not push a URL while a waypoint slot is still empty", () => {
+    renderPage([]);
+
+    // Fill the SECOND select first, leaving slot 0 empty. Serializing that gap
+    // produced "/travel//Alpha": Next 308-redirects the empty segment away and
+    // parseInitialWaypoints drops it, so Alpha would come back in slot 0 —
+    // silently swapping which end of the route the user picked.
+    fireEvent.click(screen.getAllByText("Alpha")[1]!);
+    expect(mockPush).not.toHaveBeenCalled();
+
+    // The selection is still held in local state, so the form is correct...
+    expect(screen.getAllByRole("combobox")[1]).toHaveValue("Alpha");
+
+    // ...and the URL lands, in the right order, once the pair is complete.
+    fireEvent.click(screen.getAllByText("Delta")[0]!);
+    expect(mockPush).toHaveBeenLastCalledWith("/travel/Delta/Alpha");
+  });
+
+  it("never serializes an empty path segment", () => {
+    renderPage([]);
+    fireEvent.click(screen.getAllByText("Alpha")[1]!);
+    fireEvent.click(screen.getAllByText("Delta")[0]!);
+    fireEvent.click(screen.getAllByText("Beta")[1]!);
+
+    for (const call of mockPush.mock.calls) {
+      expect(call[0] as string).not.toMatch(/\/\//);
+    }
+  });
 });
 
 describe("Travel Page route preference URL sync", () => {


### PR DESCRIPTION
## The bug

Filling the **second** waypoint select before the first leaves slot 0 empty, and the URL was serialized with a per-slot `?? ""` fallback:

```tsx
`/travel/${nextWaypoints.map((id) => solarSystems[id]?.name ?? "").join("/")}`
```

An empty slot therefore produced an empty path segment — `/travel//Alpha`. Next 308-redirects that to `/travel/Alpha`, and `parseInitialWaypoints` ([data.ts:67-69](apps/web/app/travel/[[...waypoints]]/data.ts)) filters unresolvable segments, so the system comes back in **slot 0**.

That matters because [page.client.tsx:156-157](apps/web/app/travel/[[...waypoints]]/page.client.tsx) reads slot 0 as `end` and slot 1 as `start`:

```tsx
const start = waypoints[1];
const end = waypoints[0];
```

So the waypoint the user entered as one end of the route silently became the other — on top of a wasted redirect round-trip. Confirmed against production: `/travel//Jita` → 308 → `/travel/Jita`.

## The fix

Only sync the URL once every slot resolves to a system.

No placeholder segment could hold the empty position instead: `_` already decodes to a space in system names (`waypoint.replaceAll("_", " ")`, data.ts:68), so it cannot also mean "nothing here". And a route needs both ends before it means anything — `route` returns `[]` unless both are set — so there is nothing worth preserving in the URL until the pair is complete.

The list-state update still lands, so the form shows the selection immediately; only the address bar waits.

One honest limitation this leaves in place: filling slot 0 first *does* update the URL (`/travel/Delta`), because that is expressible. Filling slot 1 first cannot be, so it waits. Asymmetric, but correct in both directions — the previous behaviour was symmetric and wrong.

## Tests

Two added, both confirmed to fail with the guard removed:

- no push happens while a slot is empty, the selection is still visible in the form, and the completed pair serializes in the right order (`/travel/Delta/Alpha`)
- no pushed URL ever contains `//`

```
apps/web   1142 tests   pass
type-check    0 errors
lint          0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)