### PR TITLE
fix(hooks): page the calendar forward instead of backwards

### DIFF
--- a/.changeset/calendar-forward-paging.md
+++ b/.changeset/calendar-forward-paging.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/web": patch
+"@jitaspace/hooks": patch
+---
+
+Fixed the calendar's "Load more events" button re-listing events it had already shown. Paging walked the calendar backwards by a single event per request, so each new page repeated 49 of the 50 events above it and reaching the end of a busy calendar took roughly 150 clicks instead of four.

--- a/packages/hooks/src/hooks/calendar/useCharacterCalendar.ts
+++ b/packages/hooks/src/hooks/calendar/useCharacterCalendar.ts
@@ -8,6 +8,12 @@ import {
 import { useAccessToken } from "../auth";
 import { esiInfiniteQueryKey } from "../utils/esiQueryKeys";
 
+/**
+ * How many event summaries ESI answers `/characters/{id}/calendar` with. A page
+ * that comes back shorter than this is the last one.
+ */
+const ESI_CALENDAR_PAGE_SIZE = 50;
+
 export const useCharacterCalendar = (characterId?: number) => {
   const { accessToken, authHeaders } = useAccessToken({
     characterId,
@@ -27,12 +33,26 @@ export const useCharacterCalendar = (characterId?: number) => {
             getCharactersCharacterIdCalendarInfiniteQueryKey(characterId ?? 0),
           ),
           enabled: characterId !== undefined && accessToken !== null,
+          // The generated default is `0`, which esi-client's own kubb.config.ts
+          // flags as invalid — `from_event` is an event id, not an offset, and
+          // there is no event 0. Omitting it entirely is what asks for "the
+          // next 50 chronological event summaries from now", which is the first
+          // page. Same override useCharacterMails applies to `last_mail_id`.
+          initialPageParam: undefined as number | undefined,
           getNextPageParam: (lastPage) => {
-            if (lastPage.data.length != 50) return undefined;
-            return lastPage.data.reduce(
-              (acc, msg) => Math.min(acc, msg.event_id ?? acc),
-              Infinity,
-            );
+            if (lastPage.data.length < ESI_CALENDAR_PAGE_SIZE) return undefined;
+            // `from_event` pages FORWARD — ESI returns "the next 50
+            // chronological event summaries from after that event" — so the
+            // cursor is the page's LAST entry, the one furthest along the
+            // window we just read. Taking the lowest id (the rule the mail
+            // cursor follows, where `last_mail_id` means "older than") walked
+            // the window backwards by a single event per request, so each page
+            // repeated 49 of the 50 events before it.
+            //
+            // Position, not `Math.max`: event ids are assigned when an event is
+            // created, so a recently-created event with an early date carries a
+            // high id. Only the array order is chronological.
+            return lastPage.data.at(-1)?.event_id;
           },
         },
       },

--- a/packages/hooks/tests/characterInfiniteHooks.test.tsx
+++ b/packages/hooks/tests/characterInfiniteHooks.test.tsx
@@ -130,9 +130,17 @@ const page = (data: unknown[], xPages?: string): Page => ({
   headers: xPages == undefined ? {} : { "x-pages": xPages },
 });
 const fiftyMails = Array.from({ length: 50 }, (_, i) => ({ mail_id: 500 - i }));
-const fiftyEvents = Array.from({ length: 50 }, (_, i) => ({
-  event_id: 900 - i,
-}));
+// A full calendar page, in the chronological order ESI returns it. The ids are
+// deliberately neither ascending nor descending: they are assigned when an
+// event is created, so the chronologically-last event need not hold the highest
+// (or the lowest) id. The last entry is 925, the lowest is 900 and the highest
+// is 948, so a cursor taken by position is distinguishable from one taken by
+// Math.min (the mail rule) or Math.max.
+const fiftyEvents = [
+  ...Array.from({ length: 48 }, (_, i) => ({ event_id: 901 + i })),
+  { event_id: 900 },
+  { event_id: 925 },
+];
 
 beforeEach(() => {
   // clearMocks clears calls but not implementations, so reset every mock here
@@ -365,7 +373,7 @@ describe("useCharacterContacts", () => {
 });
 
 describe("useCharacterCalendar", () => {
-  it("flattens events and pages backwards from the oldest event id", () => {
+  it("flattens events and pages forward from the last event on the page", () => {
     const { result: query, nextPageParam } = driveInfinite(
       mockCalendarInfinite,
       infiniteResult([page([{ event_id: 900 }, { event_id: 901 }])], true),
@@ -380,13 +388,59 @@ describe("useCharacterCalendar", () => {
     expect(result.current.hasMoreEvents).toBe(true);
     expect(result.current.loadMoreEvents).toBe(query.fetchNextPage);
 
-    // A full page of 50 means there may be more, and the cursor is the oldest
-    // event id on it. Anything short of 50 is the last page.
-    expect(nextPageParam(page(fiftyEvents), [])).toBe(851);
+    // `from_event` pages FORWARD — ESI answers with "the next 50 chronological
+    // event summaries from after that event" — so a full page's cursor is its
+    // LAST entry. Taking the lowest id instead (the rule `last_mail_id`
+    // follows, where the cursor means "older than") advanced the window by a
+    // single event per request, so each page repeated 49 of the 50 before it.
+    expect(nextPageParam(page(fiftyEvents), [])).toBe(925);
+    // Not the lowest id on the page (the old, backwards cursor)...
+    expect(nextPageParam(page(fiftyEvents), [])).not.toBe(900);
+    // ...and not the highest either: only the array order is chronological.
+    expect(nextPageParam(page(fiftyEvents), [])).not.toBe(948);
+  });
+
+  it("stops paging on a short page", () => {
+    const { nextPageParam } = driveInfinite(
+      mockCalendarInfinite,
+      infiniteResult([page([{ event_id: 900 }])], false),
+    );
+    renderHook(() => useCharacterCalendar(CHARACTER_ID));
+
+    // Fewer than 50 summaries means ESI had nothing more to give.
     expect(nextPageParam(page([{ event_id: 900 }]), [])).toBeUndefined();
-    // A row without an id is skipped rather than poisoning the cursor with
-    // NaN: the oldest id still present wins.
-    expect(nextPageParam(page([{}, ...fiftyEvents.slice(1)]), [])).toBe(851);
+    expect(nextPageParam(page(fiftyEvents.slice(1)), [])).toBeUndefined();
+  });
+
+  it("stops paging when the last event on a full page carries no id", () => {
+    const { nextPageParam } = driveInfinite(
+      mockCalendarInfinite,
+      infiniteResult([page(fiftyEvents)], true),
+    );
+    renderHook(() => useCharacterCalendar(CHARACTER_ID));
+
+    // There is no cursor to continue from, and guessing one from an earlier row
+    // would re-read a window we have already seen.
+    expect(
+      nextPageParam(page([...fiftyEvents.slice(0, 49), {}]), []),
+    ).toBeUndefined();
+  });
+
+  it("omits from_event on the first request", () => {
+    driveInfinite(
+      mockCalendarInfinite,
+      infiniteResult([page([{ event_id: 900 }])], false),
+    );
+    renderHook(() => useCharacterCalendar(CHARACTER_ID));
+
+    // The generated default is 0, which esi-client's own kubb.config.ts flags
+    // as invalid: `from_event` is an event id and there is no event 0. Omitting
+    // it is what asks ESI for the first page.
+    const options = mockCalendarInfinite.mock.calls.at(-1)?.at(-1) as
+      | InfiniteOptions
+      | undefined;
+    expect(options?.query).toHaveProperty("initialPageParam");
+    expect(options?.query?.initialPageParam).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## The bug

`useCharacterCalendar`'s `getNextPageParam` returned `Math.min(...event_id)` — the rule `last_mail_id` follows, where the cursor means *older than*. But ESI's `from_event` pages **forward**:

> Get 50 event summaries from the calendar. […] If a `from_event` ID is specified, it will return the next 50 chronological event summaries **from after that event**

Taking the lowest id advanced the window by exactly one event per request. For a character with 200 future events, the first "Load more events" click returned events 2–51 instead of 51–100; the 49 duplicates were appended by the `flatMap` in the hook and rendered as visibly repeated entries. Reaching the end took ~150 requests instead of 4, every one of them a redundant hit on the `char-calendar` rate-limit bucket.

## The fix

The cursor is now the page's **last** entry — by position, not `Math.max`. Event ids are assigned when an event is *created*, so a recently-created event with an early date carries a high id; only the array order is chronological.

Also overrides `initialPageParam`, which esi-client's own `kubb.config.ts` already flags for this route:

```ts
// FIXME: This is not valid! Needs to be overriden when using the generated code!
initialPageParam: 0,
```

`from_event` is an event id and there is no event 0. Verified against axios that `0` was being serialized onto the wire as `?from_event=0` while `undefined` is dropped — which is what asks ESI for the first page. `useCharacterMails` already applies the same override to `last_mail_id`.

## On the existing test

`characterInfiniteHooks.test.tsx` asserted the old behaviour as though it were intended ("pages backwards from the oldest event id"). Its fixture happened to be in descending id order, so `Math.min` and "last element" returned the same number — the test passed against both the bug and the fix.

The new fixture is in chronological order with ids whose min (900), max (948) and last (925) are three different values, so it now distinguishes all three cursor rules. Added coverage for the short-page stop, a full page whose last row carries no id, and the `initialPageParam` override.

## Verification

`packages/hooks`: type-check clean, 190 tests pass, `useCharacterCalendar.ts` at 100% statement/branch/function coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)