### PR TITLE
fix(hooks): re-resolve ESI names when the language changes

### DIFF
--- a/.changeset/esi-name-language-cache.md
+++ b/.changeset/esi-name-language-cache.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": patch
+"@jitaspace/hooks": patch
+"@jitaspace/esi-client": patch
+---
+
+Fixed changing the ESI language leaving parts of the app in the previous language. Type, region, solar system and faction names kept rendering in the old language until a full page reload; they now switch over with everything else, and switching back is instant because both languages stay cached.

--- a/apps/web/lib/MyQueryClientProvider.tsx
+++ b/apps/web/lib/MyQueryClientProvider.tsx
@@ -8,7 +8,22 @@ import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experime
 
 import { setAcceptLanguage, setUserAgent } from "@jitaspace/esi-client";
 
-import { usePreferencesStore } from "~/lib/preferences";
+import {
+  DEFAULT_ESI_ACCEPT_LANGUAGE,
+  usePreferencesStore,
+} from "~/lib/preferences";
+
+// Seed the ESI language at module scope — before React renders anything, on the
+// server pass and in the browser alike.
+//
+// The effect below can only set it *after* the persisted preferences rehydrate,
+// which is after every descendant's effects have already run. Cached ESI names
+// are keyed by language (see useEsiAcceptLanguage), so leaving it unset until
+// then made the boot transition look like a language switch: every name on the
+// first paint resolved once under "no language" and again a microtask later.
+// Starting from the app default means that only a user who actually prefers a
+// different language pays for a second resolution, which is the whole point.
+setAcceptLanguage(DEFAULT_ESI_ACCEPT_LANGUAGE);
 
 type MyQueryClientProviderProps = PropsWithChildren<{
   esiUserAgent?: string;
@@ -25,6 +40,8 @@ export const MyQueryClientProvider = ({
     void (async () => {
       await usePreferencesStore.persist.rehydrate();
       setUserAgent(esiUserAgent);
+      // Fires a change only if the persisted preference differs from the
+      // default seeded above.
       setAcceptLanguage(usePreferencesStore.getState().esiAcceptLanguage);
     })();
   }, [esiUserAgent]);

--- a/packages/esi-client/src/client.accept-language.test.ts
+++ b/packages/esi-client/src/client.accept-language.test.ts
@@ -1,0 +1,161 @@
+import {
+  getAcceptLanguage,
+  setAcceptLanguage,
+  setConfig,
+  setUserAgent,
+  subscribeToAcceptLanguage,
+  updateConfig,
+} from "./client";
+
+// ESI localises the names it serves, so any cache keyed on an ESI answer has to
+// treat Accept-Language as part of its identity. Module-level caches in
+// @jitaspace/hooks cannot be reached from the app's provider tree, so they
+// subscribe to the client instead — which makes these two properties
+// load-bearing, and pins them here:
+//
+//  1. a language change MUST notify, or stale localised names survive it; and
+//  2. a config write that leaves the language alone MUST NOT notify, or every
+//     `setUserAgent`/`updateConfig` call (they happen on every auth-adjacent
+//     update) throws away caches that are still perfectly valid.
+//
+// The module keeps global state, so every test resets it via `setConfig({})`
+// and every subscription is torn down in afterEach — a listener leaking into
+// the next test would see that reset fire and corrupt its call counts.
+
+describe("client accept-language subscription", () => {
+  const unsubscribers: (() => void)[] = [];
+
+  /** Subscribe and register the teardown so nothing leaks between tests. */
+  const subscribe = (listener: () => void) => {
+    const unsubscribe = subscribeToAcceptLanguage(listener);
+    unsubscribers.push(unsubscribe);
+    return unsubscribe;
+  };
+
+  beforeEach(() => {
+    setConfig({});
+  });
+
+  afterEach(() => {
+    while (unsubscribers.length > 0) {
+      unsubscribers.pop()?.();
+    }
+    setConfig({});
+  });
+
+  it("reports the configured language, and undefined when unset or blank", () => {
+    expect(getAcceptLanguage()).toBeUndefined();
+
+    setAcceptLanguage("de");
+    expect(getAcceptLanguage()).toBe("de");
+
+    // A blank/whitespace-only value is not a language: it must read as unset,
+    // otherwise a cache would key entries under "   " and never match again.
+    setAcceptLanguage("   ");
+    expect(getAcceptLanguage()).toBeUndefined();
+
+    setAcceptLanguage("fr");
+    expect(getAcceptLanguage()).toBe("fr");
+
+    setAcceptLanguage(undefined);
+    expect(getAcceptLanguage()).toBeUndefined();
+
+    setConfig({ acceptLanguage: "" });
+    expect(getAcceptLanguage()).toBeUndefined();
+  });
+
+  it("notifies subscribers when setAcceptLanguage changes the language", () => {
+    const listener = jest.fn();
+    subscribe(listener);
+
+    setAcceptLanguage("de");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getAcceptLanguage()).toBe("de");
+  });
+
+  it("stops notifying once the returned unsubscribe is called", () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribe(listener);
+
+    setAcceptLanguage("de");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    expect(typeof unsubscribe).toBe("function");
+    unsubscribe();
+
+    setAcceptLanguage("fr");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies every subscriber, and only the ones still subscribed", () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const third = jest.fn();
+    subscribe(first);
+    subscribe(second);
+    const unsubscribeThird = subscribe(third);
+
+    setAcceptLanguage("de");
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(third).toHaveBeenCalledTimes(1);
+
+    unsubscribeThird();
+    setAcceptLanguage("fr");
+
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(third).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies on setConfig only when it moves the resolved language", () => {
+    const listener = jest.fn();
+    subscribe(listener);
+
+    setConfig({ acceptLanguage: "de" });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Same language, different config object: the resolved language has not
+    // moved, so nobody's cache is stale.
+    setConfig({ acceptLanguage: "de", userAgent: "agent/1.0" });
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Dropping the language entirely IS a move, back to unset.
+    setConfig({});
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(getAcceptLanguage()).toBeUndefined();
+
+    // ...and blank is indistinguishable from unset, so it must stay quiet.
+    setConfig({ acceptLanguage: "  " });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify when a config write leaves the language alone", () => {
+    setAcceptLanguage("de");
+
+    const listener = jest.fn();
+    subscribe(listener);
+
+    // This is the whole point of notifyIfAcceptLanguageChanged: unrelated
+    // config writes are frequent, and treating them as language changes would
+    // invalidate every localised cache in the app for nothing.
+    updateConfig({ userAgent: "x" });
+    expect(listener).not.toHaveBeenCalled();
+
+    setUserAgent("y");
+    updateConfig({ headers: { Authorization: "Bearer token" } });
+    updateConfig({ baseURL: "https://esi.evetech.net" });
+    expect(listener).not.toHaveBeenCalled();
+
+    // Re-setting the same language is also not a change.
+    setAcceptLanguage("de");
+    expect(listener).not.toHaveBeenCalled();
+
+    // Sanity check that this listener was wired up at all.
+    setAcceptLanguage("fr");
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getAcceptLanguage()).toBe("fr");
+  });
+});

--- a/packages/esi-client/src/client.ts
+++ b/packages/esi-client/src/client.ts
@@ -73,8 +73,52 @@ let _config: Partial<RequestConfig> = {
 
 export const getConfig = () => _config;
 
+/**
+ * Listeners notified when the globally configured Accept-Language changes.
+ *
+ * ESI localises the resources it serves — type, region, solar system and
+ * faction names all come back in the language this header asks for — so any
+ * cache holding those answers has to treat the language as part of the cache
+ * identity. Consumers backed by React Query can be invalidated by the app, but
+ * @jitaspace/hooks also keeps module-level caches that the app's provider tree
+ * cannot reach; those subscribe here instead.
+ */
+const acceptLanguageListeners = new Set<() => void>();
+
+const normalizeAcceptLanguage = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() !== "" ? value : undefined;
+
+/** The globally configured Accept-Language, or `undefined` when unset. */
+export const getAcceptLanguage = (): string | undefined =>
+  normalizeAcceptLanguage(_config.acceptLanguage);
+
+/**
+ * Subscribe to Accept-Language changes. Returns an unsubscribe function, so it
+ * plugs directly into `useSyncExternalStore`.
+ */
+export const subscribeToAcceptLanguage = (
+  listener: () => void,
+): (() => void) => {
+  acceptLanguageListeners.add(listener);
+  return () => {
+    acceptLanguageListeners.delete(listener);
+  };
+};
+
+/**
+ * Notify subscribers if — and only if — the resolved language actually moved.
+ * Config writes happen on every request-adjacent update, and a listener that
+ * fired on all of them would invalidate caches that are still valid.
+ */
+const notifyIfAcceptLanguageChanged = (previous: string | undefined) => {
+  if (getAcceptLanguage() === previous) return;
+  acceptLanguageListeners.forEach((listener) => listener());
+};
+
 export const setConfig = (config: RequestConfig) => {
+  const previousAcceptLanguage = getAcceptLanguage();
   _config = config;
+  notifyIfAcceptLanguageChanged(previousAcceptLanguage);
   return getConfig();
 };
 
@@ -97,11 +141,13 @@ const mergeHeaders = (
 };
 
 export const updateConfig = (config: Partial<RequestConfig>) => {
+  const previousAcceptLanguage = getAcceptLanguage();
   _config = {
     ..._config,
     ...config,
     headers: mergeHeaders(_config.headers, config.headers),
   };
+  notifyIfAcceptLanguageChanged(previousAcceptLanguage);
 
   return getConfig();
 };

--- a/packages/hooks/src/db/core.ts
+++ b/packages/hooks/src/db/core.ts
@@ -6,6 +6,7 @@ import { parseLoadSubsetOptions } from "@tanstack/query-db-collection";
 import { QueryClient } from "@tanstack/react-query";
 
 import type { GetCharactersCharacterIdSearchQueryParamsCategoriesEnum } from "@jitaspace/esi-client";
+import { subscribeToAcceptLanguage } from "@jitaspace/esi-client";
 
 export type ResolvableEntityCategory =
   | GetCharactersCharacterIdSearchQueryParamsCategoriesEnum
@@ -19,6 +20,15 @@ export const queryClient = new QueryClient({
       staleTime: 1000 * 60 * 60 * 24,
     },
   },
+});
+
+// This client is owned by the package rather than the app, so it sits outside
+// the provider tree the app invalidates on a language change — and with a
+// 24-hour staleTime, a switch would otherwise leave collections serving the
+// previous language's names for a full day. Subscribing to the ESI client's own
+// config keeps the invalidation with the cache that needs it.
+subscribeToAcceptLanguage(() => {
+  void queryClient.invalidateQueries();
 });
 
 export function createQueryCollection<

--- a/packages/hooks/src/hooks/index.ts
+++ b/packages/hooks/src/hooks/index.ts
@@ -24,6 +24,7 @@ export * from "./wallet";
 export * from "./wars";
 
 export * from "./useCorporation";
+export * from "./useEsiAcceptLanguage";
 export * from "./useEsiClientStatistics";
 export * from "./useEsiName";
 export * from "./useEsiSearch";

--- a/packages/hooks/src/hooks/useEsiAcceptLanguage.ts
+++ b/packages/hooks/src/hooks/useEsiAcceptLanguage.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import {
+  getAcceptLanguage,
+  subscribeToAcceptLanguage,
+} from "@jitaspace/esi-client";
+
+/**
+ * The server snapshot reads the same module-level config the client does.
+ *
+ * That is deliberate rather than lazy. `useSyncExternalStore` uses this value
+ * for the hydration render too, so returning a hardcoded `undefined` would make
+ * every name resolve once under "no language" and again the moment the real one
+ * landed — one wasted ESI request per entity on every cold load. Reading the
+ * config instead means an app that configures the language before its first
+ * render (apps/web seeds it at module scope in MyQueryClientProvider) agrees
+ * across the server render, the hydration render and every render after.
+ *
+ * `setAcceptLanguage` is only ever called from the browser, so on the server
+ * this is a request-independent constant and cannot leak between requests.
+ */
+const getServerSnapshot = (): string | undefined => getAcceptLanguage();
+
+/**
+ * The Accept-Language currently configured on the ESI client, re-rendering when
+ * it changes.
+ *
+ * ESI serves localised names for types, regions, solar systems and factions, so
+ * anything that caches a resolved name has to treat the language as part of the
+ * cache identity — otherwise a language switch leaves previously-resolved names
+ * rendered in the old language until a full page reload.
+ */
+export const useEsiAcceptLanguage = (): string | undefined =>
+  useSyncExternalStore(
+    subscribeToAcceptLanguage,
+    getAcceptLanguage,
+    getServerSnapshot,
+  );

--- a/packages/hooks/src/hooks/useEsiName.ts
+++ b/packages/hooks/src/hooks/useEsiName.ts
@@ -28,6 +28,8 @@ import {
   stationRanges,
 } from "@jitaspace/esi-metadata";
 
+import { useEsiAcceptLanguage } from "./useEsiAcceptLanguage";
+
 interface EsiNameCacheValue {
   name: string;
   category:
@@ -144,16 +146,43 @@ const resolveNameOfKnownCategory = async (
 //     category?: GetCharactersCharacterIdSearchCategoriesItem | undefined;
 // }]>
 
+interface EsiNameCacheArgs {
+  category?: ResolvableEntityCategory;
+  /**
+   * The entity id to resolve. Carried in the arguments rather than parsed back
+   * out of the cache key, because the key is language-scoped (see
+   * {@link esiNameCacheKey}) and the id is not the whole of it.
+   */
+  entityId: string;
+}
+
+/**
+ * Cache key for one entity's name in one language.
+ *
+ * ESI returns localised names for types, regions, solar systems and factions,
+ * so the same id resolves to different strings under different
+ * `Accept-Language` values. Scoping the key by language means a language switch
+ * resolves afresh instead of serving the previous language's string, and
+ * switching back reuses what was already fetched rather than refetching it.
+ *
+ * NUL separates the two halves so no language tag can collide with an id.
+ */
+const esiNameCacheKey = (entityId: string, language: string | undefined) =>
+  `${language ?? ""}\u0000${entityId}`;
+
 // Creates a fetch cache w/ a max of 10000 entries for JSON requests
 const fetchCache = createCache(
-  async (id, options: { category?: ResolvableEntityCategory }) => {
+  async (
+    _key,
+    { category: requestedCategory, entityId: id }: EsiNameCacheArgs,
+  ) => {
     if (id.length === 0) throw new Error("No ID provided");
     let name: string | undefined;
 
     // let's figure out the category first
     const category: ResolvableEntityCategory =
       // is the category provided?
-      options.category ??
+      requestedCategory ??
       // can we infer it from the id?
       inferCategoryFromId(typeof id === "string" ? Number(id) : id) ??
       // otherwise, we need to resolve it to get the name
@@ -181,22 +210,25 @@ export function useEsiName(
   loading: boolean;
   error?: string;
 } {
-  let idCacheKey: string;
+  let entityId: string;
   if (id === undefined) {
-    idCacheKey = "";
+    entityId = "";
   } else if (typeof id === "string") {
-    idCacheKey = id;
+    entityId = id;
   } else {
-    idCacheKey = id.toString();
+    entityId = id.toString();
   }
 
-  const [{ status, value, error }, fetchName] = useCache(
-    fetchCache,
-    idCacheKey,
-    {
-      category,
-    },
-  );
+  const language = useEsiAcceptLanguage();
+  // A language change moves this to a different cache entry, which `useCache`
+  // reports as `idle` — so the effect below resolves the name afresh instead of
+  // leaving the previous language's string on screen.
+  const cacheKey = esiNameCacheKey(entityId, language);
+
+  const [{ status, value, error }, fetchName] = useCache(fetchCache, cacheKey, {
+    category,
+    entityId,
+  });
 
   useEffect(() => {
     if (status === "idle") {
@@ -232,12 +264,18 @@ export function useEsiNamePrefetch(
     category?: ResolvableEntityCategory;
   }[],
 ) {
+  const language = useEsiAcceptLanguage();
+
   useEffect(() => {
     entries.forEach((entry) => {
-      if (entry.id)
-        void fetchCache.load(entry.id.toString(), { category: entry.category });
+      if (!entry.id) return;
+      const entityId = entry.id.toString();
+      void fetchCache.load(esiNameCacheKey(entityId, language), {
+        category: entry.category,
+        entityId,
+      });
     });
-  }, [entries]);
+  }, [entries, language]);
 }
 
 function makeCacheUpdater(
@@ -258,7 +296,20 @@ export function useEsiNames(
     category?: ResolvableEntityCategory;
   }[],
 ): Record<string, CacheState<EsiNameCacheValue, Error> | undefined> {
-  const keys = useMemo(() => names.map((name) => name.id.toString()), [names]);
+  const language = useEsiAcceptLanguage();
+  // Two identifiers per entry: the language-scoped `cacheKey` this hook reads
+  // and subscribes with, and the plain `entityId` the returned record is keyed
+  // by — callers index it as `names[id.toString()]`, so the language must not
+  // leak into the public shape.
+  const entries = useMemo(
+    () =>
+      names.map((name) => {
+        const entityId = name.id.toString();
+        return { entityId, cacheKey: esiNameCacheKey(entityId, language) };
+      }),
+    [names, language],
+  );
+
   const [current, setCurrent] = useState<
     Record<string, CacheState<EsiNameCacheValue, Error> | undefined>
   >(() => {
@@ -266,7 +317,9 @@ export function useEsiNames(
       string,
       CacheState<EsiNameCacheValue, Error> | undefined
     > = {};
-    keys.forEach((key) => (initial[key] = fetchCache.read(key)));
+    entries.forEach(({ entityId, cacheKey }) => {
+      initial[entityId] = fetchCache.read(cacheKey);
+    });
     return initial;
   });
 
@@ -277,26 +330,26 @@ export function useEsiNames(
       (v: CacheState<EsiNameCacheValue, Error> | undefined) => void
     >();
 
-    keys.forEach((key) => {
+    entries.forEach(({ entityId, cacheKey }) => {
       const callback = (
         value: CacheState<EsiNameCacheValue, Error> | undefined,
       ) => {
         if (didUnsubscribe) return;
         if (value === undefined) return;
-        setCurrent(makeCacheUpdater(key, value));
+        setCurrent(makeCacheUpdater(entityId, value));
       };
-      callbacks.set(key, callback);
-      fetchCache.subscribe(key, callback);
-      callback(fetchCache.read(key));
+      callbacks.set(cacheKey, callback);
+      fetchCache.subscribe(cacheKey, callback);
+      callback(fetchCache.read(cacheKey));
     });
 
     return () => {
       didUnsubscribe = true;
-      callbacks.forEach((callback, key) => {
-        fetchCache.unsubscribe(key, callback);
+      callbacks.forEach((callback, cacheKey) => {
+        fetchCache.unsubscribe(cacheKey, callback);
       });
     };
-  }, [keys]);
+  }, [entries]);
 
   return current;
 }

--- a/packages/hooks/tests/useEsiNameLanguage.test.tsx
+++ b/packages/hooks/tests/useEsiNameLanguage.test.tsx
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+
+// ESI serves localised names — type, region, solar system and faction names all
+// come back in whatever `Accept-Language` asked for — but the name cache in
+// useEsiName is a module-level LRU keyed by entity id alone. Switching language
+// therefore used to leave every already-resolved name rendered in the old
+// language for the rest of the session: the key never moved, the entry stayed
+// `success`, and no request was ever issued. These tests pin the fix: the cache
+// key is now scoped by language, so a switch resolves afresh and a switch back
+// reuses what was already fetched.
+//
+// Test isolation: the LRU lives at module scope and is shared by every test in
+// this file. Rather than jest.resetModules() + re-require (which would rebuild
+// the mocked-hook wiring on every test), each test uses its own entity id — the
+// cheaper lever, and the one that lets a test observe entries left behind by its
+// own earlier renders, which is exactly what "switching back reuses the cached
+// entry" needs to assert.
+//
+// @swc/jest does not hoist jest.mock above imports, so the client is mocked here
+// and the hooks under test are required lazily below.
+
+// The jsdom environment resolves @react-hook/cache through its "browser"
+// export condition, which is an untransformed ESM build. Redirect both it and
+// its own dependency to the package's CommonJS build so the REAL LRU cache runs
+// here — stubbing it out would erase the very behaviour under test.
+jest.mock("@react-hook/cache", () =>
+  require("@react-hook/cache/dist/main/index.js"),
+);
+jest.mock("@react-hook/latest", () =>
+  require("@react-hook/latest/dist/main/index.js"),
+);
+
+/** Drives both the mocked language hook and the language the fake ESI answers in. */
+let currentLanguage: string | undefined = "en";
+
+/** Listeners registered through the mocked `subscribeToAcceptLanguage`. */
+const acceptLanguageListeners = new Set<() => void>();
+
+const mockUseEsiAcceptLanguage = jest.fn();
+const mockGetUniverseTypesTypeId = jest.fn();
+
+jest.mock("@jitaspace/esi-client", () => ({
+  __esModule: true,
+  getUniverseTypesTypeId: (...args: unknown[]) =>
+    mockGetUniverseTypesTypeId(...args),
+  // Consumed by the real useEsiAcceptLanguage in the last describe block.
+  getAcceptLanguage: () => currentLanguage,
+  subscribeToAcceptLanguage: (listener: () => void) => {
+    acceptLanguageListeners.add(listener);
+    return () => acceptLanguageListeners.delete(listener);
+  },
+}));
+
+// Every id below is passed with an explicit category, so the id-range inference
+// never runs; the ranges are stubbed only so the import resolves.
+jest.mock("@jitaspace/esi-metadata", () => ({
+  __esModule: true,
+  isIdInRanges: () => false,
+  allianceIdRanges: [],
+  characterIdRanges: [],
+  corporationIdRanges: [],
+  stargateRanges: [],
+  stationRanges: [],
+}));
+
+jest.mock("../src/hooks/useEsiAcceptLanguage", () => ({
+  __esModule: true,
+  useEsiAcceptLanguage: () => mockUseEsiAcceptLanguage(),
+}));
+
+const {
+  useEsiName,
+  useEsiNameLookup,
+  useEsiNamePrefetch,
+  useEsiNames,
+  useEsiNamesCache,
+} =
+  require("../src/hooks/useEsiName") as typeof import("../src/hooks/useEsiName");
+
+/** The real hook, over the mocked esi-client store above. */
+const { useEsiAcceptLanguage } = jest.requireActual<
+  typeof import("../src/hooks/useEsiAcceptLanguage")
+>("../src/hooks/useEsiAcceptLanguage");
+
+/** What the fake ESI answers with, for whatever language is configured now. */
+const localisedName = () => `Rifter [${currentLanguage ?? "none"}]`;
+
+beforeEach(() => {
+  currentLanguage = "en";
+  acceptLanguageListeners.clear();
+
+  mockUseEsiAcceptLanguage.mockReset();
+  mockUseEsiAcceptLanguage.mockImplementation(() => currentLanguage);
+
+  mockGetUniverseTypesTypeId.mockReset();
+  mockGetUniverseTypesTypeId.mockImplementation(() =>
+    Promise.resolve({ data: { name: localisedName() } }),
+  );
+});
+
+/** Flip the configured language and re-render whatever `rerender` belongs to. */
+function switchLanguageTo(language: string, rerender: () => void) {
+  currentLanguage = language;
+  act(() => {
+    rerender();
+  });
+}
+
+describe("useEsiName under a language switch", () => {
+  it("re-resolves the name when the language changes instead of serving the previous language's string", async () => {
+    const { result, rerender } = renderHook(() =>
+      useEsiName(601, "inventory_type"),
+    );
+
+    await waitFor(() => expect(result.current.name).toBe("Rifter [en]"));
+    expect(mockGetUniverseTypesTypeId).toHaveBeenCalledTimes(1);
+
+    switchLanguageTo("de", rerender);
+
+    // Before the fix this stayed "Rifter [en]" forever and no second request
+    // was ever issued — the half-translated UI the fix is about.
+    await waitFor(() => expect(result.current.name).toBe("Rifter [de]"));
+    expect(mockGetUniverseTypesTypeId).toHaveBeenCalledTimes(2);
+    expect(mockGetUniverseTypesTypeId).toHaveBeenNthCalledWith(2, 601, {}, {});
+  });
+
+  it("reuses the already-cached entry when switching back to the first language", async () => {
+    const { result, rerender } = renderHook(() =>
+      useEsiName(602, "inventory_type"),
+    );
+
+    await waitFor(() => expect(result.current.name).toBe("Rifter [en]"));
+
+    switchLanguageTo("de", rerender);
+    await waitFor(() => expect(result.current.name).toBe("Rifter [de]"));
+    expect(mockGetUniverseTypesTypeId).toHaveBeenCalledTimes(2);
+
+    switchLanguageTo("en", rerender);
+
+    // The payoff of keying rather than clearing: the English entry is still
+    // there, so the name is available on the very next render with no loading
+    // flicker and no third request.
+    expect(result.current.name).toBe("Rifter [en]");
+    expect(result.current.loading).toBe(false);
+    expect(mockGetUniverseTypesTypeId).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds independent entries for the same id under two languages at once", async () => {
+    const english = renderHook(() => useEsiName(603, "inventory_type"));
+    await waitFor(() =>
+      expect(english.result.current.name).toBe("Rifter [en]"),
+    );
+
+    currentLanguage = "de";
+    const german = renderHook(() => useEsiName(603, "inventory_type"));
+    await waitFor(() => expect(german.result.current.name).toBe("Rifter [de]"));
+
+    // Both entries coexist in the LRU, keyed apart by language. Before the fix
+    // the German render read the English entry straight back out and returned
+    // "Rifter [en]", leaving exactly one entry for this id.
+    const { result: cache } = renderHook(() => useEsiNamesCache());
+    const namesForThisId = Object.entries(cache.current)
+      .filter(([key]) => key.includes("603"))
+      .map(([, entry]) => entry.value?.name);
+
+    expect(namesForThisId.sort()).toEqual(["Rifter [de]", "Rifter [en]"]);
+  });
+});
+
+describe("useEsiName id normalisation", () => {
+  it("accepts a string id and resolves it under the current language", async () => {
+    // Callers reach useEsiName through EveEntityAnchor/EveEntityAvatar, which
+    // hand it whatever the DOM gave them — often a string.
+    currentLanguage = "en";
+
+    const { result } = renderHook(() => useEsiName("607", "inventory_type"));
+
+    await waitFor(() => expect(result.current.name).toBe("Rifter [en]"));
+    // The resolver coerces to a number before it reaches ESI.
+    expect(mockGetUniverseTypesTypeId).toHaveBeenCalledWith(607, {}, {});
+  });
+
+  it("stays idle for an undefined id instead of resolving one", async () => {
+    // EveEntityName renders with `entityId ?? undefined`, so this is the
+    // ordinary "nothing selected yet" render, not an error path.
+    currentLanguage = "en";
+
+    const { result } = renderHook(() => useEsiName(undefined));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.name).toBeUndefined();
+    expect(mockGetUniverseTypesTypeId).not.toHaveBeenCalled();
+  });
+});
+
+describe("useEsiNames / useEsiNameLookup public key shape", () => {
+  // Stable reference: `useEsiNames` memoises on it, and a fresh array each
+  // render would re-run the subscription effect for reasons unrelated to
+  // language.
+  const LOOKUP_ENTRIES = [{ id: 604, category: "inventory_type" as const }];
+
+  it("keys its record by the plain entity id, and refreshes that entry when the language changes", async () => {
+    const { result, rerender } = renderHook(() =>
+      useEsiNameLookup(LOOKUP_ENTRIES),
+    );
+
+    // apps/web/app/assets/character/page.tsx and EveEntitySelect.tsx both index
+    // this record as `names[id.toString()]`. If the language-scoped cache key
+    // leaked into the public shape, those pages would render blank labels.
+    await waitFor(() =>
+      expect(result.current["604"]?.value?.name).toBe("Rifter [en]"),
+    );
+    expect(Object.keys(result.current)).toEqual(["604"]);
+
+    switchLanguageTo("de", rerender);
+
+    await waitFor(() =>
+      expect(result.current["604"]?.value?.name).toBe("Rifter [de]"),
+    );
+    expect(Object.keys(result.current)).toEqual(["604"]);
+  });
+
+  it("never exposes a language-scoped key, even before anything has resolved", () => {
+    const entries = [{ id: 605, category: "inventory_type" as const }];
+    currentLanguage = "fr";
+
+    const { result } = renderHook(() => useEsiNames(entries));
+
+    expect(Object.keys(result.current)).toEqual(["605"]);
+    Object.keys(result.current).forEach((key) => {
+      expect(key).not.toContain("\u0000");
+      expect(key).not.toContain("fr");
+    });
+  });
+});
+
+describe("useEsiNamePrefetch under a language switch", () => {
+  const PREFETCH_ENTRIES = [{ id: 606, category: "inventory_type" as const }];
+
+  it("loads under the current language and loads again when the language changes", async () => {
+    const { rerender } = renderHook(() => useEsiNamePrefetch(PREFETCH_ENTRIES));
+
+    await waitFor(() =>
+      expect(mockGetUniverseTypesTypeId).toHaveBeenCalledTimes(1),
+    );
+
+    // The entries array is referentially stable, so before the fix the effect's
+    // `[entries]` deps never changed and the prefetch simply never ran again.
+    switchLanguageTo("de", rerender);
+
+    await waitFor(() =>
+      expect(mockGetUniverseTypesTypeId).toHaveBeenCalledTimes(2),
+    );
+
+    const { result: cache } = renderHook(() => useEsiNamesCache());
+    const namesForThisId = Object.entries(cache.current)
+      .filter(([key]) => key.includes("606"))
+      .map(([, entry]) => entry.value?.name);
+
+    expect(namesForThisId.sort()).toEqual(["Rifter [de]", "Rifter [en]"]);
+  });
+});
+
+describe("useEsiAcceptLanguage", () => {
+  function LanguageProbe() {
+    return <span>{useEsiAcceptLanguage() ?? "(unset)"}</span>;
+  }
+
+  it("renders the configured language on the server, so the hydration render matches", () => {
+    // The server snapshot deliberately reads the same module-level config the
+    // browser does. apps/web seeds it at module scope (MyQueryClientProvider),
+    // so both passes agree and the cache key does not move at hydration.
+    // Returning a hardcoded "unset" here instead would make every name resolve
+    // once under no language and again the moment the real one landed — one
+    // wasted ESI request per entity on every cold load.
+    currentLanguage = "de";
+
+    expect(renderToString(<LanguageProbe />)).toContain("de");
+  });
+
+  it("renders as unset on the server when nothing has configured a language", () => {
+    // An app that never seeds still gets a server render matching its first
+    // client render; it just pays for the transition later.
+    currentLanguage = undefined;
+
+    expect(renderToString(<LanguageProbe />)).toContain("(unset)");
+  });
+
+  it("re-renders with the new value when subscribeToAcceptLanguage fires", () => {
+    currentLanguage = "en";
+
+    const { result } = renderHook(() => useEsiAcceptLanguage());
+    expect(result.current).toBe("en");
+
+    act(() => {
+      currentLanguage = "de";
+      acceptLanguageListeners.forEach((listener) => listener());
+    });
+
+    expect(result.current).toBe("de");
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() => useEsiAcceptLanguage());
+    expect(acceptLanguageListeners.size).toBe(1);
+
+    unmount();
+
+    expect(acceptLanguageListeners.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## The bug

`@jitaspace/hooks` ships **three** independent caches over the same ESI resources, and the app's language handler could only reach one of them:

| Cache | Reachable from `MyQueryClientProvider`? |
|---|---|
| React Query (the app's client) | yes — `client.invalidateQueries()` |
| `@react-hook/cache` LRU behind `useEsiName` | **no** — module-level, outside the provider tree |
| `QueryClient` in `db/core.ts` (24h `staleTime`) | **no** — owned by the package |

ESI serves localised names for types, regions, solar systems and factions. After switching language, everything rendered through `EveEntityName` / `TypeName` / `SolarSystemName` / `RegionName` — the most common way the app displays EVE data — kept serving the previous language's string for the rest of the session.

## The fix

Name cache entries are keyed by **language**, not by id alone. A switch therefore lands on a different entry and resolves afresh; switching back reuses what was already fetched rather than refetching it. That's why keying beats clearing.

The language reaches the hooks via two new esi-client exports — `getAcceptLanguage` and `subscribeToAcceptLanguage` — wrapped in `useEsiAcceptLanguage` over `useSyncExternalStore`. Subscribers fire **only when the resolved language actually moves**, so the config writes that happen on ordinary request paths don't invalidate caches that are still valid. `db/core.ts` subscribes directly, keeping the invalidation next to the cache that needs it.

**The public shape is unchanged.** `useEsiNames` / `useEsiNameLookup` still return a record keyed by the plain id string — every consumer indexes it as `names[id.toString()]` (`apps/web/app/assets/character/page.tsx`, `EveEntitySelect.tsx`, …), so the language must not leak into the public key. There's a test pinning exactly that.

## One regression this change introduced, and how it was caught

I ran an adversarial review over the finished diff. **Three independent reviewers converged on the same defect**, and the verification pass reproduced it empirically (2 ESI calls per name vs 1):

The ESI language was only configured from a post-rehydration effect in `MyQueryClientProvider`, which runs *after* every descendant's effects. With the cache key now language-dependent, the boot `undefined → "en"` transition counted as a language change — so **every name on the first paint resolved twice on every cold load**.

Fixed by seeding the language at module scope in `MyQueryClientProvider` (before React renders anything, on the server pass and in the browser alike) and having `getServerSnapshot` read the real config, so the server render, the hydration render and the steady state all agree. Only a user who actually prefers a non-default language now pays for a second resolution — which is the fix doing its job.

An intermediate version called `setAcceptLanguage` during render; that's an impure render side effect and the module-scope seed already runs strictly earlier, so it was dropped.

## Verification

Workspace-wide: type-check 38/38, tests 29/29 tasks (esi-client 37, hooks 199, web 1140).

New suites, both written to fail against the old code and checked against it:

- `packages/esi-client/src/client.accept-language.test.ts` — 6 tests. The load-bearing one is that a config write which leaves the language alone (`setUserAgent`, a headers write, re-setting the same language) must **not** notify. Mutation-verified: removing the change check fails 2 tests, removing blank-string normalisation fails 2, a no-op unsubscribe fails 2, the pre-fix module fails all 6.
- `packages/hooks/tests/useEsiNameLanguage.test.tsx` — 12 tests. Verified empirically against `git show HEAD:…/useEsiName.ts`: **5 failed, 4 passed** on the old code, and the 5 failures are exactly the 5 regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)