### PR TITLE
fix(hooks): report loading state for the current ship fitting

### DIFF
--- a/.changeset/current-fit-loading-state.md
+++ b/.changeset/current-fit-loading-state.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/web": patch
+"@jitaspace/hooks": patch
+---
+
+Fixed the current-ship fitting card showing an empty module list while it was still loading — it now shows placeholder rows until the fitting is complete. The collapsed cards on the home and fittings pages no longer download the character's entire asset list to build modules they never display.

--- a/apps/web/components/Fitting/ShipFittingCard/EsiCurrentShipFittingCard.tsx
+++ b/apps/web/components/Fitting/ShipFittingCard/EsiCurrentShipFittingCard.tsx
@@ -20,9 +20,17 @@ export const EsiCurrentShipFittingCard = memo(
     characterId,
     fallback,
     hideFallback = false,
+    hideModules = false,
     ...otherProps
   }: EsiCurrentShipFittingCardProps) => {
-    const { hasToken, ...fit } = useCharacterCurrentFit(characterId);
+    // A card that hides the modules never renders them, so there is no reason
+    // to walk the character's whole asset collection to find them.
+    const { hasToken, isLoading, ...fit } = useCharacterCurrentFit(
+      characterId,
+      {
+        includeModules: !hideModules,
+      },
+    );
 
     if (!hasToken) {
       return hideFallback
@@ -39,6 +47,8 @@ export const EsiCurrentShipFittingCard = memo(
         name={fit.name}
         description="Current Ship"
         shipTypeId={fit.shipTypeId}
+        hideModules={hideModules}
+        isLoading={isLoading}
         items={(fit.items ?? []).map((item) => ({
           typeId: item.type_id,
           flag: item.location_flag,

--- a/apps/web/components/Fitting/ShipFittingCard/ShipFittingCard.tsx
+++ b/apps/web/components/Fitting/ShipFittingCard/ShipFittingCard.tsx
@@ -1,6 +1,6 @@
 import type { CardProps } from "@mantine/core";
 import { memo, useMemo } from "react";
-import { Card } from "@mantine/core";
+import { Card, Skeleton, Stack } from "@mantine/core";
 
 import type { FittingItemFlag } from "@jitaspace/hooks";
 
@@ -22,6 +22,12 @@ export type ShipFittingCardProps = Omit<CardProps, "children"> & {
 
   hideHeader?: boolean;
   hideModules?: boolean;
+  /**
+   * Render placeholder rows in place of the module sections. Without it an
+   * empty `items` reads as "this ship has no modules" while they are still
+   * being fetched.
+   */
+  isLoading?: boolean;
 };
 
 export const ShipFittingCard = memo(
@@ -34,6 +40,7 @@ export const ShipFittingCard = memo(
     shipTypeId,
     hideHeader = false,
     hideModules = false,
+    isLoading = false,
     ...otherProps
   }: ShipFittingCardProps) => {
     const highSlotModules = useMemo(
@@ -124,15 +131,31 @@ export const ShipFittingCard = memo(
           />
         )}
         {!hideModules &&
-          moduleSections
-            .filter((section) => section.items.length > 0)
-            .map((section) => (
-              <ShipFittingCardModulesSection
-                key={section.name}
-                header={section.name}
-                items={section.items}
-              />
-            ))}
+          (isLoading ? (
+            <Card.Section
+              m={0}
+              p="xs"
+              className={classes.modulesSection}
+              data-testid="fitting-modules-skeleton"
+            >
+              <Stack gap={6}>
+                <Skeleton height={10} width="35%" radius="sm" />
+                <Skeleton height={16} radius="sm" />
+                <Skeleton height={16} radius="sm" />
+                <Skeleton height={16} width="70%" radius="sm" />
+              </Stack>
+            </Card.Section>
+          ) : (
+            moduleSections
+              .filter((section) => section.items.length > 0)
+              .map((section) => (
+                <ShipFittingCardModulesSection
+                  key={section.name}
+                  header={section.name}
+                  items={section.items}
+                />
+              ))
+          ))}
       </Card>
     );
   },

--- a/apps/web/components/Modals/CurrentShipFittingModal.tsx
+++ b/apps/web/components/Modals/CurrentShipFittingModal.tsx
@@ -15,6 +15,7 @@ export function CurrentShipFittingModal({
       name={fit.name}
       shipTypeId={fit.shipTypeId}
       description="Current Ship"
+      isLoading={fit.isLoading}
       items={(fit.items ?? []).map((item) => ({
         typeId: item.type_id,
         flag: item.location_flag,

--- a/apps/web/tests/EsiCurrentShipFittingCard.test.tsx
+++ b/apps/web/tests/EsiCurrentShipFittingCard.test.tsx
@@ -1,0 +1,213 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import type React from "react";
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// EsiCurrentShipFittingCard is the adapter between useCharacterCurrentFit and
+// the presentational <ShipFittingCard>. Three things are worth pinning here:
+//  * it tells the hook whether the modules are actually going to be rendered
+//    (`includeModules`), because resolving them costs a full walk of the
+//    character's assets — a cost a `hideModules` card would just discard;
+//  * `hideModules` is now destructured out of the props, so it has to be
+//    forwarded explicitly — dropping it would make the collapsed landing-page
+//    cards start rendering module sections;
+//  * the hook's `isLoading` has to reach the card, or an empty fit reads as
+//    "this ship has no modules" while the asset pages are still streaming in.
+// We stub the hook and swap ShipFittingCard for a tiny inspector that echoes
+// the props it received.
+// ---------------------------------------------------------------------------
+
+interface CurrentFit {
+  hasToken: boolean;
+  isLoading: boolean;
+  error?: unknown;
+  name?: string;
+  shipTypeId?: number;
+  items?: {
+    type_id: number;
+    location_flag: string;
+    quantity?: number;
+  }[];
+}
+
+const mockUseCharacterCurrentFit =
+  jest.fn<
+    (characterId: number, options?: { includeModules?: boolean }) => CurrentFit
+  >();
+
+jest.mock("@jitaspace/hooks", () => ({
+  useCharacterCurrentFit: (
+    characterId: number,
+    options?: { includeModules?: boolean },
+  ) => mockUseCharacterCurrentFit(characterId, options),
+}));
+
+jest.mock("~/components/Fitting/ShipFittingCard/ShipFittingCard", () => {
+  const React = require("react");
+  return {
+    ShipFittingCard: ({
+      name,
+      description,
+      shipTypeId,
+      hideModules,
+      isLoading,
+      items,
+    }: {
+      name?: string;
+      description?: string;
+      shipTypeId?: number;
+      hideModules?: boolean;
+      isLoading?: boolean;
+      items: { typeId: number; flag: string; quantity?: number }[];
+    }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "ship-fitting-card" },
+        React.createElement(
+          "span",
+          { "data-testid": "card-summary" },
+          `name-${name ?? "none"}|desc-${description ?? "none"}|ship-${shipTypeId ?? "none"}`,
+        ),
+        React.createElement(
+          "span",
+          { "data-testid": "card-flags" },
+          `hideModules-${String(hideModules)}|isLoading-${String(isLoading)}`,
+        ),
+        items.map((item, index) =>
+          React.createElement(
+            "span",
+            { "data-testid": "card-item", key: index },
+            `${item.flag}|${item.typeId}|x${item.quantity ?? "none"}`,
+          ),
+        ),
+      ),
+  };
+});
+
+const LOADED_FIT: CurrentFit = {
+  hasToken: true,
+  isLoading: false,
+  name: "Rusty Rifter",
+  shipTypeId: 587,
+  items: [
+    { type_id: 100, location_flag: "HiSlot0", quantity: 1 },
+    { type_id: 200, location_flag: "Cargo", quantity: 7 },
+  ],
+};
+
+function renderCard(
+  fit: CurrentFit,
+  props: {
+    characterId?: number;
+    hideModules?: boolean;
+    hideFallback?: boolean;
+    fallback?: React.ReactNode;
+  } = {},
+) {
+  mockUseCharacterCurrentFit.mockReturnValue(fit);
+  const {
+    EsiCurrentShipFittingCard,
+  } = require("~/components/Fitting/ShipFittingCard/EsiCurrentShipFittingCard");
+  const { characterId = 1234, ...cardProps } = props;
+  return render(
+    <MantineProvider>
+      <EsiCurrentShipFittingCard characterId={characterId} {...cardProps} />
+    </MantineProvider>,
+  );
+}
+
+describe("EsiCurrentShipFittingCard", () => {
+  beforeEach(() => {
+    mockUseCharacterCurrentFit.mockReset();
+  });
+
+  it("asks the hook to resolve the modules when they are going to be rendered", () => {
+    renderCard(LOADED_FIT);
+    expect(mockUseCharacterCurrentFit).toHaveBeenCalledWith(1234, {
+      includeModules: true,
+    });
+  });
+
+  it("asks the hook to skip the asset walk when hideModules is set", () => {
+    renderCard(LOADED_FIT, { hideModules: true });
+    expect(mockUseCharacterCurrentFit).toHaveBeenCalledWith(1234, {
+      includeModules: false,
+    });
+  });
+
+  it("still forwards hideModules to ShipFittingCard after destructuring it out", () => {
+    renderCard(LOADED_FIT, { hideModules: true });
+    // Consumed for `includeModules` AND handed on: the card is what actually
+    // suppresses the module sections.
+    expect(screen.getByTestId("card-flags")).toHaveTextContent(
+      "hideModules-true",
+    );
+  });
+
+  it("leaves hideModules false on the card when the caller did not set it", () => {
+    renderCard(LOADED_FIT);
+    expect(screen.getByTestId("card-flags")).toHaveTextContent(
+      "hideModules-false",
+    );
+  });
+
+  it("forwards the hook's isLoading to ShipFittingCard", () => {
+    renderCard({ ...LOADED_FIT, isLoading: true, items: undefined });
+    expect(screen.getByTestId("card-flags")).toHaveTextContent(
+      "isLoading-true",
+    );
+    // No items yet — the card needs the flag to tell "empty" from "pending".
+    expect(screen.queryByTestId("card-item")).not.toBeInTheDocument();
+  });
+
+  it("forwards isLoading false once the fit has resolved", () => {
+    renderCard(LOADED_FIT);
+    expect(screen.getByTestId("card-flags")).toHaveTextContent(
+      "isLoading-false",
+    );
+  });
+
+  it("maps the ESI item shape onto the card's item shape", () => {
+    renderCard(LOADED_FIT);
+    expect(screen.getByTestId("card-summary")).toHaveTextContent(
+      "name-Rusty Rifter|desc-Current Ship|ship-587",
+    );
+    const items = screen
+      .getAllByTestId("card-item")
+      .map((node) => node.textContent);
+    expect(items).toEqual(["HiSlot0|100|x1", "Cargo|200|x7"]);
+  });
+
+  it("renders the default fallback text and no card when the character has no token", () => {
+    renderCard({ hasToken: false, isLoading: false });
+    expect(screen.queryByTestId("ship-fitting-card")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Active Ship Fitting not available"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the caller's fallback instead of the card when there is no token", () => {
+    renderCard(
+      { hasToken: false, isLoading: true },
+      { fallback: <span data-testid="custom-fallback">nope</span> },
+    );
+    expect(screen.queryByTestId("ship-fitting-card")).not.toBeInTheDocument();
+    expect(screen.getByTestId("custom-fallback")).toBeInTheDocument();
+  });
+
+  it("renders nothing at all when there is no token and hideFallback is set", () => {
+    const { container } = renderCard(
+      { hasToken: false, isLoading: false },
+      { hideFallback: true },
+    );
+    expect(screen.queryByTestId("ship-fitting-card")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Active Ship Fitting not available"),
+    ).not.toBeInTheDocument();
+    // Nothing but the <style> tags MantineProvider injects of its own accord.
+    expect(container.querySelectorAll("*:not(style)")).toHaveLength(0);
+  });
+});

--- a/apps/web/tests/ShipFittingCard.test.tsx
+++ b/apps/web/tests/ShipFittingCard.test.tsx
@@ -16,26 +16,23 @@ import type { ShipFittingCardProps } from "~/components/Fitting/ShipFittingCard/
 // in @jitaspace/ui clipboard/avatar internals.
 // ---------------------------------------------------------------------------
 
-jest.mock(
-  "~/components/Fitting/ShipFittingCard/ShipFittingCardHeader",
-  () => {
-    const React = require("react");
-    return {
-      ShipFittingCardHeader: ({
-        shipName,
-        shipTypeId,
-      }: {
-        shipName?: string;
-        shipTypeId?: number;
-      }) =>
-        React.createElement(
-          "div",
-          { "data-testid": "fitting-header" },
-          `header:${shipName ?? "none"}:${shipTypeId ?? "none"}`,
-        ),
-    };
-  },
-);
+jest.mock("~/components/Fitting/ShipFittingCard/ShipFittingCardHeader", () => {
+  const React = require("react");
+  return {
+    ShipFittingCardHeader: ({
+      shipName,
+      shipTypeId,
+    }: {
+      shipName?: string;
+      shipTypeId?: number;
+    }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "fitting-header" },
+        `header:${shipName ?? "none"}:${shipTypeId ?? "none"}`,
+      ),
+  };
+});
 
 jest.mock(
   "~/components/Fitting/ShipFittingCard/ShipFittingCardModulesSection",
@@ -58,7 +55,11 @@ jest.mock(
   },
 );
 
-function renderCard(props: Partial<ShipFittingCardProps> & { items: ShipFittingCardProps["items"] }) {
+function renderCard(
+  props: Partial<ShipFittingCardProps> & {
+    items: ShipFittingCardProps["items"];
+  },
+) {
   const {
     ShipFittingCard,
   } = require("~/components/Fitting/ShipFittingCard/ShipFittingCard");
@@ -136,7 +137,9 @@ describe("ShipFittingCard", () => {
       name: "Hidden",
       shipTypeId: 587,
       hideHeader: true,
-      items: [{ flag: "HiSlot0", typeId: 100, quantity: 1 }] as ShipFittingCardProps["items"],
+      items: [
+        { flag: "HiSlot0", typeId: 100, quantity: 1 },
+      ] as ShipFittingCardProps["items"],
     });
     expect(screen.queryByTestId("fitting-header")).not.toBeInTheDocument();
     // modules still render
@@ -152,5 +155,75 @@ describe("ShipFittingCard", () => {
     });
     expect(screen.getByTestId("fitting-header")).toBeInTheDocument();
     expect(screen.queryByTestId("modules-section")).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // isLoading: the module list arrives after the header does, so an `items`
+  // that is still empty used to render nothing at all — indistinguishable from
+  // a ship that genuinely carries no modules. The skeleton stands in for the
+  // sections until the fit resolves; it lives *inside* the hideModules gate,
+  // so a card that hides modules stays silent while loading.
+  // -------------------------------------------------------------------------
+
+  it("renders the modules skeleton instead of the sections while isLoading", () => {
+    renderCard({
+      name: "Loading",
+      shipTypeId: 587,
+      isLoading: true,
+      // Non-empty on purpose: loading wins over whatever items are already in.
+      items: FULL_ITEMS,
+    });
+    expect(screen.getByTestId("fitting-modules-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("modules-section")).not.toBeInTheDocument();
+    // The header is unaffected — it only needs the ship, not the modules.
+    expect(screen.getByTestId("fitting-header")).toHaveTextContent(
+      "header:Loading:587",
+    );
+  });
+
+  it("renders the modules skeleton while isLoading even with no items yet", () => {
+    renderCard({
+      name: "Loading",
+      shipTypeId: 587,
+      isLoading: true,
+      items: [],
+    });
+    expect(screen.getByTestId("fitting-modules-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders neither the skeleton nor the sections when isLoading and hideModules are both set", () => {
+    renderCard({
+      name: "NoModules",
+      shipTypeId: 587,
+      isLoading: true,
+      hideModules: true,
+      items: FULL_ITEMS,
+    });
+    expect(
+      screen.queryByTestId("fitting-modules-skeleton"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("modules-section")).not.toBeInTheDocument();
+    expect(screen.getByTestId("fitting-header")).toBeInTheDocument();
+  });
+
+  it("renders no skeleton by default, so a resolved empty fitting still reads as empty", () => {
+    renderCard({ name: "Empty", shipTypeId: 587, items: [] });
+    expect(
+      screen.queryByTestId("fitting-modules-skeleton"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("modules-section")).not.toBeInTheDocument();
+  });
+
+  it("renders the sections rather than the skeleton once isLoading is false", () => {
+    renderCard({
+      name: "Loaded",
+      shipTypeId: 587,
+      isLoading: false,
+      items: FULL_ITEMS,
+    });
+    expect(
+      screen.queryByTestId("fitting-modules-skeleton"),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("modules-section")).toHaveLength(10);
   });
 });

--- a/packages/hooks/src/hooks/assets/useCharacterAssets.ts
+++ b/packages/hooks/src/hooks/assets/useCharacterAssets.ts
@@ -114,6 +114,16 @@ export const useCharacterAssets = (characterId?: number) => {
     locations,
     error,
     isLoading,
+    /**
+     * Whether pages are still outstanding.
+     *
+     * `isLoading` only covers the *first* page: react-query settles the query
+     * once page one lands, and the eager effect above then walks the rest with
+     * `fetchNextPage`, which reports through `isFetchingNextPage` instead. A
+     * consumer that needs the whole collection — rather than whatever has
+     * arrived so far — has to wait on this too.
+     */
+    hasNextPage,
     mutate: refetch,
   };
 };

--- a/packages/hooks/src/hooks/fittings/useCharacterCurrentFit.ts
+++ b/packages/hooks/src/hooks/fittings/useCharacterCurrentFit.ts
@@ -5,29 +5,83 @@ import { useMemo } from "react";
 import type { ItemsFlagEnum } from "@jitaspace/esi-client";
 
 import { useCharacterAssets } from "../assets";
+import { useAccessToken } from "../auth";
 import { useCharacterCurrentShip } from "../location";
 
 export type FittingItemFlag = ItemsFlagEnum;
 
-export const useCharacterCurrentFit = (characterId: number) => {
-  const { data: ship, hasToken: hasShipToken } =
-    useCharacterCurrentShip(characterId);
-  const { assets, hasToken: hasAssetsToken } = useCharacterAssets(characterId);
+export interface UseCharacterCurrentFitOptions {
+  /**
+   * Whether to resolve the fitted modules.
+   *
+   * Modules are not their own ESI resource — they are the character's assets
+   * that sit inside the active ship — so producing them costs a full
+   * multi-page walk of `/characters/{id}/assets/`. A caller rendering only the
+   * ship header (the collapsed cards on the landing page and the fittings page
+   * both pass `hideModules`) should pass `false` rather than pay for a result
+   * it discards. Defaults to `true`.
+   */
+  includeModules?: boolean;
+}
 
-  const modules = useMemo(() => {
-    if (!ship) return null;
-    return Object.values(assets).filter(
-      (asset) => asset.location_id === ship.data.ship_item_id,
-    );
-  }, [ship, assets]);
+export const useCharacterCurrentFit = (
+  characterId: number,
+  { includeModules = true }: UseCharacterCurrentFitOptions = {},
+) => {
+  const shipQuery = useCharacterCurrentShip(characterId);
+
+  // Read the assets token for THIS character separately from the query, so
+  // `hasToken` means the same thing whether or not the modules are fetched.
+  // useCharacterAssets(undefined) would resolve whichever logged-in character
+  // happens to hold the scope, which is not necessarily this one.
+  const { accessToken: assetsAccessToken } = useAccessToken({
+    characterId,
+    scopes: ["esi-assets.read_assets.v1"],
+  });
+
+  // Passing `undefined` leaves the query disabled, so the asset walk never
+  // starts. The hook itself is still called unconditionally.
+  const assetsQuery = useCharacterAssets(
+    includeModules ? characterId : undefined,
+  );
+
+  const ship = shipQuery.data;
+  const assets = assetsQuery.assets;
+
+  const items = useMemo(() => {
+    if (!includeModules || !ship) return undefined;
+    return Object.values(assets)
+      .filter((asset) => asset.location_id === ship.data.ship_item_id)
+      .map((module) => ({
+        ...module,
+        location_flag: module.location_flag as FittingItemFlag,
+      }));
+  }, [includeModules, ship, assets]);
 
   return {
-    hasToken: hasShipToken && hasAssetsToken,
+    hasToken: shipQuery.hasToken && assetsAccessToken !== null,
+    /**
+     * True while either query this fit is assembled from is still resolving.
+     * Without it an empty `items` is indistinguishable from a fitting whose
+     * asset pages are still streaming in, and the caller has nothing to key a
+     * skeleton off.
+     *
+     * `hasNextPage` is part of it because the assets query settles as soon as
+     * its FIRST page lands — the remaining pages are walked eagerly afterwards
+     * and report through `isFetchingNextPage`. Modules are filtered out of the
+     * whole collection, so a fit assembled from page one alone is missing
+     * whatever sits on the pages still in flight. An errored walk stops
+     * counting, otherwise a failed page would pin this true forever.
+     */
+    isLoading:
+      shipQuery.isLoading ||
+      (includeModules &&
+        (assetsQuery.isLoading ||
+          (assetsQuery.hasNextPage && !assetsQuery.error))),
+    /** The first failure of the two queries, or `null` if both are healthy. */
+    error: shipQuery.error ?? (includeModules ? assetsQuery.error : null),
     name: ship?.data.ship_name,
     shipTypeId: ship?.data.ship_type_id,
-    items: modules?.map((module) => ({
-      ...module,
-      location_flag: module.location_flag as FittingItemFlag,
-    })),
+    items,
   };
 };

--- a/packages/hooks/tests/useCharacterCurrentFit.test.tsx
+++ b/packages/hooks/tests/useCharacterCurrentFit.test.tsx
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { renderHook } from "@testing-library/react";
+
+// useCharacterCurrentFit assembles one fitting out of two independent queries:
+// the character's active ship, and the character's assets (the fitted modules
+// are just the assets sitting inside that ship). These tests pin the contract
+// between those two halves:
+//
+//  * the combined `isLoading` / `error` the caller keys its skeleton off — an
+//    empty module list must be distinguishable from an asset list that is
+//    still streaming in;
+//  * `includeModules: false`, which must skip the multi-page asset walk
+//    entirely (items undefined, assets query disabled) WITHOUT relaxing
+//    `hasToken` — the card is still gated on this character's assets scope.
+//
+// The dependency hooks are mocked (they reach the generated
+// @jitaspace/esi-client, which isn't built in this workspace) and, since
+// @swc/jest does not hoist jest.mock above imports, the hook under test is
+// required lazily.
+
+const mockUseCharacterAssets = jest.fn();
+const mockUseAccessToken = jest.fn();
+const mockUseCharacterCurrentShip = jest.fn();
+
+jest.mock("../src/hooks/assets", () => ({
+  __esModule: true,
+  useCharacterAssets: (...args: unknown[]) => mockUseCharacterAssets(...args),
+}));
+
+jest.mock("../src/hooks/auth", () => ({
+  __esModule: true,
+  useAccessToken: (...args: unknown[]) => mockUseAccessToken(...args),
+}));
+
+jest.mock("../src/hooks/location", () => ({
+  __esModule: true,
+  useCharacterCurrentShip: (...args: unknown[]) =>
+    mockUseCharacterCurrentShip(...args),
+}));
+
+const { useCharacterCurrentFit } =
+  require("../src/hooks/fittings/useCharacterCurrentFit") as typeof import("../src/hooks/fittings/useCharacterCurrentFit");
+
+const CHARACTER_ID = 2116129465;
+const SHIP_ITEM_ID = 1041234567890;
+const ASSETS_SCOPE = "esi-assets.read_assets.v1";
+
+/** GET /characters/{id}/ship/, wrapped the way the generated client returns it. */
+const SHIP = {
+  data: {
+    ship_item_id: SHIP_ITEM_ID,
+    ship_name: "Corvus",
+    ship_type_id: 17738,
+  },
+};
+
+/** Assets shaped like GET /characters/{id}/assets/ entries. */
+const FITTED_HIGH_SLOT = {
+  item_id: 1041000000001,
+  type_id: 2929,
+  location_id: SHIP_ITEM_ID,
+  location_flag: "HiSlot0",
+  location_type: "item",
+  quantity: 1,
+  is_singleton: true,
+};
+
+const FITTED_CARGO = {
+  item_id: 1041000000002,
+  type_id: 12608,
+  location_id: SHIP_ITEM_ID,
+  location_flag: "Cargo",
+  location_type: "item",
+  quantity: 200,
+  is_singleton: false,
+};
+
+/** Sits in a station hangar, not in the ship — must not show up as a module. */
+const HANGAR_ITEM = {
+  item_id: 1041000000003,
+  type_id: 34,
+  location_id: 60003760,
+  location_flag: "Hangar",
+  location_type: "station",
+  quantity: 5000,
+  is_singleton: false,
+};
+
+const ALL_ASSETS = {
+  [FITTED_HIGH_SLOT.item_id]: FITTED_HIGH_SLOT,
+  [FITTED_CARGO.item_id]: FITTED_CARGO,
+  [HANGAR_ITEM.item_id]: HANGAR_ITEM,
+};
+
+function mockShip(
+  overrides: {
+    hasToken?: boolean;
+    data?: typeof SHIP | undefined;
+    isLoading?: boolean;
+    error?: Error | null;
+  } = {},
+) {
+  mockUseCharacterCurrentShip.mockReturnValue({
+    hasToken: true,
+    data: SHIP,
+    isLoading: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+function mockAssets(
+  overrides: {
+    hasToken?: boolean;
+    assets?: Record<string, unknown>;
+    isLoading?: boolean;
+    hasNextPage?: boolean;
+    error?: Error | null;
+  } = {},
+) {
+  mockUseCharacterAssets.mockReturnValue({
+    hasToken: true,
+    assets: ALL_ASSETS,
+    locations: {},
+    isLoading: false,
+    // The assets query settles once its FIRST page lands and walks the rest
+    // eagerly, so `hasNextPage` is the flag that says the collection is still
+    // incomplete. Default to a fully-walked collection.
+    hasNextPage: false,
+    error: null,
+    ...overrides,
+  });
+}
+
+describe("useCharacterCurrentFit", () => {
+  beforeEach(() => {
+    // clearMocks wipes calls but keeps implementations, so reset explicitly.
+    mockUseCharacterAssets.mockReset();
+    mockUseAccessToken.mockReset();
+    mockUseCharacterCurrentShip.mockReset();
+
+    mockShip();
+    mockAssets();
+    // The logged-in character holds the assets scope.
+    mockUseAccessToken.mockReturnValue({
+      character: { characterId: CHARACTER_ID },
+      accessToken: "assets-token",
+      authHeaders: { Authorization: "Bearer assets-token" },
+    });
+  });
+
+  describe("isLoading", () => {
+    it("is true while the ship query is still resolving", () => {
+      mockShip({ data: undefined, isLoading: true });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.items).toBeUndefined();
+    });
+
+    it("is true while the assets are still streaming in, even once the ship has resolved", () => {
+      // The first asset page has not landed yet: the ship is known, but the
+      // module list is empty for the moment. Without isLoading this is
+      // indistinguishable from a ship that genuinely has nothing fitted.
+      mockAssets({ assets: {}, isLoading: true });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.items).toEqual([]);
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("is false once both queries have settled", () => {
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it("stays true while the eager walk is still fetching later asset pages", () => {
+      // react-query settles an infinite query as soon as page one lands — the
+      // remaining pages are fetched by useCharacterAssets' eager effect and
+      // report through isFetchingNextPage, not isLoading. Modules are filtered
+      // out of the WHOLE collection, so a fit built from page one alone is
+      // missing whatever sits on the pages still in flight. Keying the skeleton
+      // off isLoading alone would hand over to a half-populated module list.
+      mockAssets({ isLoading: false, hasNextPage: true });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it("stops waiting on the walk once a page has failed", () => {
+      // A failed page leaves hasNextPage true forever; without the error term
+      // the card would sit on the skeleton for the rest of the session instead
+      // of surfacing the failure.
+      mockAssets({
+        isLoading: false,
+        hasNextPage: true,
+        error: new Error("page 3 failed"),
+      });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeInstanceOf(Error);
+    });
+
+    it("ignores an unfinished asset walk when includeModules is false", () => {
+      mockAssets({ isLoading: true, hasNextPage: true });
+
+      const { result } = renderHook(() =>
+        useCharacterCurrentFit(CHARACTER_ID, { includeModules: false }),
+      );
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe("error", () => {
+    it("surfaces the ship query failure", () => {
+      const shipError = new Error("ship request failed");
+      mockShip({ data: undefined, error: shipError });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.error).toBe(shipError);
+    });
+
+    it("surfaces the assets failure when the ship itself resolved", () => {
+      const assetsError = new Error("assets request failed");
+      mockAssets({ assets: {}, error: assetsError });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.name).toBe("Corvus");
+      expect(result.current.error).toBe(assetsError);
+    });
+
+    it("is null when both queries are healthy", () => {
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+
+  describe("includeModules: false", () => {
+    it("leaves items undefined and ignores the assets query state", () => {
+      // Whatever the assets query is doing, a header-only caller must not be
+      // told to render a skeleton or an error for modules it never asked for.
+      mockAssets({
+        assets: {},
+        isLoading: true,
+        error: new Error("assets request failed"),
+      });
+
+      const { result } = renderHook(() =>
+        useCharacterCurrentFit(CHARACTER_ID, { includeModules: false }),
+      );
+
+      expect(result.current.items).toBeUndefined();
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+      // The ship header is still populated.
+      expect(result.current.name).toBe("Corvus");
+      expect(result.current.shipTypeId).toBe(17738);
+    });
+
+    it("disables the assets query by passing no character id", () => {
+      renderHook(() =>
+        useCharacterCurrentFit(CHARACTER_ID, { includeModules: false }),
+      );
+
+      // The hook is still called unconditionally, but with `undefined` so the
+      // multi-page asset walk never starts.
+      expect(mockUseCharacterAssets).toHaveBeenCalledWith(undefined);
+      expect(mockUseCharacterAssets).not.toHaveBeenCalledWith(CHARACTER_ID);
+    });
+
+    it("still reads THIS character's assets token, so hasToken does not widen", () => {
+      // The assets query is disabled, so its own hasToken says nothing useful.
+      mockAssets({ hasToken: false, assets: {} });
+
+      const { result } = renderHook(() =>
+        useCharacterCurrentFit(CHARACTER_ID, { includeModules: false }),
+      );
+
+      expect(mockUseAccessToken).toHaveBeenCalledWith({
+        characterId: CHARACTER_ID,
+        scopes: [ASSETS_SCOPE],
+      });
+      expect(result.current.hasToken).toBe(true);
+    });
+
+    it("reports no token when only another character holds the assets scope", () => {
+      // useCharacterAssets(undefined) would happily authorise with any
+      // logged-in character; gating the card on that would show one
+      // character's fit under another character's name.
+      mockUseAccessToken.mockReturnValue({
+        character: null,
+        accessToken: null,
+        authHeaders: {},
+      });
+      mockAssets({ hasToken: true, assets: {} });
+
+      const { result } = renderHook(() =>
+        useCharacterCurrentFit(CHARACTER_ID, { includeModules: false }),
+      );
+
+      expect(result.current.hasToken).toBe(false);
+    });
+
+    it("requires the ship scope as well", () => {
+      mockShip({ hasToken: false, data: undefined });
+
+      const { result } = renderHook(() =>
+        useCharacterCurrentFit(CHARACTER_ID, { includeModules: false }),
+      );
+
+      expect(result.current.hasToken).toBe(false);
+    });
+  });
+
+  describe("items", () => {
+    it("keeps only the assets inside the active ship, carrying location_flag through", () => {
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.items).toEqual([
+        { ...FITTED_HIGH_SLOT, location_flag: "HiSlot0" },
+        { ...FITTED_CARGO, location_flag: "Cargo" },
+      ]);
+      // The station hangar stack is not part of the fit.
+      expect(
+        result.current.items?.some(
+          (item) => item.item_id === HANGAR_ITEM.item_id,
+        ),
+      ).toBe(false);
+    });
+
+    it("is undefined until the ship is known, so no asset can be mistaken for a module", () => {
+      mockShip({ data: undefined, isLoading: true });
+
+      const { result } = renderHook(() => useCharacterCurrentFit(CHARACTER_ID));
+
+      expect(result.current.items).toBeUndefined();
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## The bug

`useCharacterCurrentFit` returned only `{ hasToken, name, shipTypeId, items }`, discarding the `isLoading` and `error` that both underlying queries expose. Neither consumer could tell *"the asset pages are still streaming in"* from *"this ship has nothing fitted"*, so the card painted a correct ship name next to an empty module list, then popped modules in later — with nothing to key a skeleton off.

Separately, producing `items` costs a **full multi-page walk of `/characters/{id}/assets/`** — modules aren't their own ESI resource, they're the assets sitting inside the active ship. Both landing sites (`AuthenticatedCharacterCard`, the fittings page) render the card with `hideModules` and throw that result away.

## The fix

`isLoading` and `error` are now returned, and `ShipFittingCard` grows an `isLoading` prop that renders placeholder rows in place of the module sections. It sits *inside* the `hideModules` gate, so a collapsed card stays silent while loading.

`isLoading` covers the **whole** eager walk, not just the first request. react-query settles an infinite query as soon as page one lands; `useCharacterAssets` then walks the rest via `fetchNextPage`, which reports through `isFetchingNextPage`. Since modules are filtered out of the whole collection, a fit assembled from page one alone is missing whatever sits on the pages still in flight — so `useCharacterAssets` now exposes `hasNextPage` and the fit stays loading until the walk completes. An errored walk stops counting, otherwise a failed page would pin the skeleton on for the rest of the session.

A new `includeModules` option leaves the assets query disabled when the caller isn't going to render modules, so the collapsed cards stop paying for the walk.

## What deliberately did *not* change

`hasToken` still requires **this character's** assets scope even when `includeModules` is false. The hook reads that token through `useAccessToken` directly rather than from the assets query, because `useCharacterAssets(undefined)` resolves whichever logged-in character happens to hold the scope — not necessarily this one. Getting that wrong would have silently widened who sees the card; there's a test asserting `useAccessToken` is called with the real `characterId`.

`{...otherProps}` still spreads last in `EsiCurrentShipFittingCard`, but `hideModules` is now destructured out of it, so it can't be clobbered — checked, since that ordering is a real hazard.

## Verification

Workspace-wide: type-check 38/38, tests 29/29 tasks (hooks 203, web 1155). `useCharacterCurrentFit.ts` and `useCharacterAssets.ts` both at 100% statement/branch/function coverage.

New/extended suites cover: loading during the ship query, loading while assets stream, **loading through the eager walk** (`hasNextPage`), the errored-walk escape, error precedence, `includeModules: false` disabling the query (asserted on the argument), the unchanged `hasToken` gating, and the skeleton's interaction with `hideModules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)