### PR TITLE
fix: stop the killmail ingest wedging its cursor, and correct two killmail defects

### DIFF
--- a/.changeset/killmail-ingest-cursor-stall.md
+++ b/.changeset/killmail-ingest-cursor-stall.md
@@ -1,0 +1,16 @@
+---
+"@jitaspace/background-jobs": patch
+---
+
+Stopped the zKillboard killmail ingest wedging its cursor, and fixed the victim corporation ids the EVE Ref backfill was collecting.
+
+`scrape-zkillboard-recent-kills` only advanced its R2Z2 cursor after a successful insert, and runs with `retries: 0`. A batch that could never be inserted — most likely a killmail naming a type the SDE had not delivered yet, since Type, SolarSystem and Moon are never created on demand — therefore blocked the feed permanently: every later run re-fetched the same sequences and failed identically. Four changes:
+
+- References the database cannot satisfy are now resolved before the insert. A killmail missing a *required* one (solar system, victim ship, item type) is dropped and logged; missing *optional* ones (moon, attacker ship, attacker weapon) are nulled instead of discarding the kill.
+- The four `createMany` calls run in one transaction. A failure part-way through used to leave `Killmail` rows committed with no victim, attackers or items, and `skipDuplicates` then treated those orphans as complete.
+- A batch that still fails is retried on the next run and skipped after three attempts, so a transient database error is retried but an unprocessable batch cannot block the cursor.
+- A single missing sequence is stepped over rather than ending the run. Previously the first hole stopped collection, and the following run fast-forwarded the cursor to the head of the feed — discarding every killmail between the hole and the head. Fast-forwarding is now reserved for an unbroken run of 25 misses, which is what an expired feed actually looks like.
+
+Skipped ranges — expired or quarantined — are recorded to a capped Redis list so they can be found and replayed rather than vanishing silently.
+
+Separately, `backfill-everef-killmails` built its set of corporation ids to pre-create from each victim's `alliance_id` instead of `corporation_id`, so victim corporations were never resolved and alliance ids were fed to the corporation lookup.

--- a/.changeset/killmail-singleton-docs.md
+++ b/.changeset/killmail-singleton-docs.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/db": patch
+---
+
+Corrected the documentation on `KillmailVictimItems.singleton`, which described it as "the unique ID of the item". It is not an item ID, and it is not the assets API's `is_singleton` boolean either — across a full day of killmails (228,676 items) it takes only two values: `0` for an ordinary item, including fitted and assembled modules, and `2` for a blueprint copy.

--- a/apps/web/components/Fitting/ShipFittingCard/EsiKillmailFittingCard.tsx
+++ b/apps/web/components/Fitting/ShipFittingCard/EsiKillmailFittingCard.tsx
@@ -83,7 +83,8 @@ export const EsiKillmailFittingCard = memo(
         items={(data?.data.victim.items ?? []).map((item) => ({
           typeId: item.item_type_id,
           flag: killmailFlagToEnum[item.flag] ?? "Invalid",
-          quantity: item.quantity_destroyed ?? 0 + (item.quantity_dropped ?? 0),
+          quantity:
+            (item.quantity_destroyed ?? 0) + (item.quantity_dropped ?? 0),
         }))}
         {...otherProps}
       />

--- a/apps/web/tests/EsiKillmailFittingCard.test.tsx
+++ b/apps/web/tests/EsiKillmailFittingCard.test.tsx
@@ -1,0 +1,143 @@
+import "@testing-library/jest-dom/jest-globals";
+
+import { describe, expect, it, jest } from "@jest/globals";
+import { MantineProvider } from "@mantine/core";
+import { render, screen } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// EsiKillmailFittingCard is a thin mapper: it pulls a killmail from ESI and
+// projects victim.items onto <ShipFittingCard>'s items prop. Stub both sides —
+// useKillmail for the input, ShipFittingCard for the output — so the assertions
+// are about the projection itself and nothing else.
+// jest.mock is NOT auto-hoisted here, so the component is lazy-require()d
+// inside each test AFTER the mocks are registered.
+// ---------------------------------------------------------------------------
+
+const mockUseKillmail = jest.fn();
+
+jest.mock("@jitaspace/hooks", () => ({
+  useKillmail: (...args: unknown[]) => mockUseKillmail(...args),
+}));
+
+jest.mock("~/components/Fitting/ShipFittingCard/ShipFittingCard", () => ({
+  ShipFittingCard: ({
+    items,
+  }: {
+    items: { typeId: number; flag: string; quantity: number }[];
+  }) => (
+    <div data-testid="fitting">
+      {items.map((item, index) => (
+        <span key={index} data-testid={`item-${item.typeId}`}>
+          {`${item.flag}:${item.quantity}`}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+interface Item {
+  item_type_id: number;
+  flag: number;
+  quantity_destroyed?: number;
+  quantity_dropped?: number;
+  singleton: number;
+}
+
+const renderWithItems = (items: Item[]) => {
+  mockUseKillmail.mockReturnValue({
+    data: {
+      data: {
+        killmail_id: 137867814,
+        victim: { ship_type_id: 670, items },
+      },
+    },
+  });
+
+  const {
+    EsiKillmailFittingCard,
+  } = require("~/components/Fitting/ShipFittingCard/EsiKillmailFittingCard");
+
+  render(
+    <MantineProvider>
+      <EsiKillmailFittingCard killmailId={137867814} killmailHash="deadbeef" />
+    </MantineProvider>,
+  );
+};
+
+describe("EsiKillmailFittingCard", () => {
+  it("sums destroyed and dropped quantities rather than preferring destroyed", () => {
+    // Regression: this was written `a ?? 0 + (b ?? 0)`, which parses as
+    // `a ?? (0 + (b ?? 0))` because `+` binds tighter than `??`, so a stack
+    // reporting both counts yielded only the destroyed one.
+    //
+    // That never actually misrendered, because ESI sets exactly one of the two
+    // per item row — 0 of 228,676 rows in a full day of killmails carried both,
+    // and the buggy form is accidentally correct for one-sided rows. The
+    // invariant is undocumented and unguaranteed, so this pins the arithmetic
+    // rather than the accident.
+    renderWithItems([
+      {
+        item_type_id: 21898,
+        flag: 5,
+        quantity_destroyed: 3,
+        quantity_dropped: 5,
+        singleton: 0,
+      },
+    ]);
+
+    expect(screen.getByTestId("item-21898")).toHaveTextContent("Cargo:8");
+  });
+
+  it("treats a missing destroyed or dropped count as zero", () => {
+    renderWithItems([
+      {
+        item_type_id: 488,
+        flag: 27,
+        quantity_dropped: 7,
+        singleton: 0,
+      },
+      {
+        item_type_id: 2048,
+        flag: 11,
+        quantity_destroyed: 2,
+        singleton: 0,
+      },
+      { item_type_id: 3178, flag: 19, singleton: 0 },
+    ]);
+
+    expect(screen.getByTestId("item-488")).toHaveTextContent("HiSlot0:7");
+    expect(screen.getByTestId("item-2048")).toHaveTextContent("LoSlot0:2");
+    expect(screen.getByTestId("item-3178")).toHaveTextContent("MedSlot0:0");
+  });
+
+  it("falls back to Invalid for flags outside the fitting enum", () => {
+    // Flag 89 is Implant — a real killmail flag with no member in ESI's
+    // fitting-only ItemsFlagEnum, so it cannot be mapped to a slot.
+    renderWithItems([
+      {
+        item_type_id: 33077,
+        flag: 89,
+        quantity_destroyed: 1,
+        singleton: 2,
+      },
+    ]);
+
+    expect(screen.getByTestId("item-33077")).toHaveTextContent("Invalid:1");
+  });
+
+  it("renders no items while the killmail is still loading", () => {
+    mockUseKillmail.mockReturnValue({ data: undefined });
+
+    const {
+      EsiKillmailFittingCard,
+    } = require("~/components/Fitting/ShipFittingCard/EsiKillmailFittingCard");
+
+    render(
+      <MantineProvider>
+        <EsiKillmailFittingCard killmailId={137867814} killmailHash="deadbeef" />
+      </MantineProvider>,
+    );
+
+    expect(screen.getByTestId("fitting")).toBeEmptyDOMElement();
+  });
+});

--- a/packages/background-jobs/jobs/scrape/everef/backfillKillmails.ts
+++ b/packages/background-jobs/jobs/scrape/everef/backfillKillmails.ts
@@ -92,7 +92,7 @@ export const backfillEveRefKillmails = defineJob<
               remoteEntries
                 .flatMap((killmail) => [
                   ...killmail.attackers.map((a) => a.corporation_id),
-                  killmail.victim.alliance_id,
+                  killmail.victim.corporation_id,
                 ])
                 .filter((id) => id != null),
             ),

--- a/packages/background-jobs/jobs/scrape/zkillboard/scrapeRecentKills.ts
+++ b/packages/background-jobs/jobs/scrape/zkillboard/scrapeRecentKills.ts
@@ -305,6 +305,44 @@ const quarantineExhaustedBatch = async (
   return true;
 };
 
+type LatestSequence =
+  | { rateLimited: false; sequence: bigint; raw: string }
+  | { rateLimited: true; retryAfterSeconds: number | null };
+
+/**
+ * Read the head of the feed, separating "we are throttled" — which the caller
+ * backs off from quietly — from "the feed is broken", which is a real failure.
+ */
+const fetchLatestSequence = async (
+  ctx: JobContext,
+): Promise<LatestSequence> => {
+  const value = await ctx.run("Fetch latest R2Z2 sequence", async () => {
+    const payload = await fetchJson(R2Z2_SEQUENCE_URL);
+    if (payload.status === 429) return payload;
+    if (payload.status === 404 || !payload.data) {
+      throw new Error("R2Z2 sequence.json not available");
+    }
+    return parseSequenceId(payload.data);
+  });
+
+  if (!value) {
+    throw new Error("Invalid latest sequence value from R2Z2.");
+  }
+
+  // The step above returns the raw payload only on a 429, so an object here
+  // means throttled and nothing else.
+  if (typeof value === "object") {
+    return {
+      rateLimited: true,
+      retryAfterSeconds:
+        (value as { retryAfterSeconds?: number | null }).retryAfterSeconds ??
+        null,
+    };
+  }
+
+  return { rateLimited: false, sequence: BigInt(value), raw: value };
+};
+
 /** Load the stored cursor, seeding it at the feed head on the very first run. */
 const loadCursor = async (
   ctx: JobContext,
@@ -676,34 +714,13 @@ export const scrapeZkillboardRecentKills =
       let rateLimitUntilMs: number | null = null;
 
       try {
-        const latestSequenceValue = await ctx.run(
-          "Fetch latest R2Z2 sequence",
-          async () => {
-            const sequencePayload = await fetchJson(R2Z2_SEQUENCE_URL);
-            if (sequencePayload.status === 429) {
-              return sequencePayload;
-            }
-            if (sequencePayload.status === 404 || !sequencePayload.data) {
-              throw new Error("R2Z2 sequence.json not available");
-            }
-            return parseSequenceId(sequencePayload.data);
-          },
-        );
+        const latest = await fetchLatestSequence(ctx);
 
-        if (!latestSequenceValue) {
-          throw new Error("Invalid latest sequence value from R2Z2.");
-        }
-
-        if (
-          typeof latestSequenceValue === "object" &&
-          (latestSequenceValue as { status?: number }).status === 429
-        ) {
-          const retryAfterSeconds = (
-            latestSequenceValue as { retryAfterSeconds?: number | null }
-          ).retryAfterSeconds;
+        if (latest.rateLimited) {
           rateLimitUntilMs =
             Date.now() +
-            (retryAfterSeconds ?? RATE_LIMIT_FALLBACK_SLEEP_SECONDS) * 1000;
+            (latest.retryAfterSeconds ?? RATE_LIMIT_FALLBACK_SLEEP_SECONDS) *
+              1000;
           await postUpdateCard({
             status: "rate_limited",
             summary: "Rate limited while fetching sequence.json.",
@@ -712,7 +729,7 @@ export const scrapeZkillboardRecentKills =
           return {
             processed: 0,
             rateLimited: true,
-            retryAfterSeconds: retryAfterSeconds ?? null,
+            retryAfterSeconds: latest.retryAfterSeconds,
           };
           /*
         const sleepFor = toSleepDuration(retryAfterSeconds);
@@ -727,9 +744,9 @@ export const scrapeZkillboardRecentKills =
         });*/
         }
 
-        latestSequence = BigInt(latestSequenceValue as string);
+        latestSequence = latest.sequence;
 
-        cursor = await loadCursor(ctx, redis, latestSequenceValue as string);
+        cursor = await loadCursor(ctx, redis, latest.raw);
         startCursor = cursor;
 
         const collected = await collectKillmailPackages(

--- a/packages/background-jobs/jobs/scrape/zkillboard/scrapeRecentKills.ts
+++ b/packages/background-jobs/jobs/scrape/zkillboard/scrapeRecentKills.ts
@@ -12,8 +12,25 @@ const R2Z2_BASE_URL = "https://r2z2.zkillboard.com/ephemeral";
 const R2Z2_SEQUENCE_URL = `${R2Z2_BASE_URL}/sequence.json`;
 const R2Z2_CURSOR_KEY = "zkillboard:r2z2:next-sequence";
 const R2Z2_RATE_LIMIT_UNTIL_KEY = "zkillboard:r2z2:rate-limit-until";
+/** `"<startCursor>:<count>"` — consecutive failed attempts at the same batch. */
+const R2Z2_BATCH_FAILURE_KEY = "zkillboard:r2z2:batch-failures";
+/** Ranges the job gave up on, newest first, so nothing vanishes unrecorded. */
+const R2Z2_SKIPPED_RANGES_KEY = "zkillboard:r2z2:skipped-ranges";
 const USER_AGENT = "www.jita.space - Joao Neto - joao@jita.space";
 const MAX_KILLMAILS_PER_RUN = 100;
+/**
+ * How many sequences in an unbroken run may 404 before we conclude the feed has
+ * expired past us rather than that we hit an ordinary hole.
+ */
+const MAX_CONSECUTIVE_MISSING_SEQUENCES = 25;
+/**
+ * How many times one batch may fail before it is skipped. Transient failures (a
+ * database blip) get retried; a genuinely unprocessable batch is quarantined
+ * instead of blocking the cursor forever.
+ */
+const MAX_BATCH_FAILURES = 3;
+/** Cap on the skipped-range list so it cannot grow without bound. */
+const MAX_SKIPPED_RANGES_KEPT = 200;
 const RATE_LIMIT_FALLBACK_SLEEP_SECONDS = 60;
 const RATE_LIMIT_MIN_INTERVAL_MS = 50;
 let lastRequestAt = 0;
@@ -194,6 +211,56 @@ const formatLag = (latest: bigint | null, cursor: bigint | null) => {
   return (latest > cursor ? latest - cursor : 0n).toString();
 };
 
+/**
+ * Note a range the job moved past without ingesting.
+ *
+ * Skipping is always a last resort — the feed aged out from under us, or a
+ * batch failed often enough to be quarantined — but it has to be recoverable
+ * and visible rather than silent, so every skip lands in a capped Redis list
+ * that a backfill can replay from.
+ */
+const recordSkippedRange = async (
+  redis: Awaited<ReturnType<typeof getRedis>>,
+  from: bigint,
+  toExclusive: bigint,
+  reason: string,
+) => {
+  if (toExclusive <= from) return;
+  await redis.lPush(
+    R2Z2_SKIPPED_RANGES_KEY,
+    JSON.stringify({
+      from: from.toString(),
+      to: (toExclusive - 1n).toString(),
+      count: (toExclusive - from).toString(),
+      reason,
+    }),
+  );
+  await redis.lTrim(R2Z2_SKIPPED_RANGES_KEY, 0, MAX_SKIPPED_RANGES_KEPT - 1);
+};
+
+/**
+ * Record a failed attempt at the batch starting at `startCursor` and return how
+ * many consecutive attempts that batch has now cost.
+ *
+ * The count is keyed on the batch's own start sequence, so moving on resets it:
+ * three unrelated failures at three different cursors are three first attempts,
+ * not one batch about to be quarantined.
+ */
+const countBatchFailure = async (
+  redis: Awaited<ReturnType<typeof getRedis>>,
+  startCursor: bigint,
+): Promise<number> => {
+  const stored = await redis.get(R2Z2_BATCH_FAILURE_KEY);
+  const [storedCursor, storedCount] = stored?.split(":") ?? [];
+  const previous =
+    storedCursor === startCursor.toString()
+      ? Number.parseInt(storedCount ?? "0", 10)
+      : 0;
+  const failures = (Number.isFinite(previous) ? previous : 0) + 1;
+  await redis.set(R2Z2_BATCH_FAILURE_KEY, `${startCursor}:${failures}`);
+  return failures;
+};
+
 interface KillmailRows {
   killmailRows: Prisma.KillmailCreateManyInput[];
   victimRows: Prisma.KillmailVictimCreateManyInput[];
@@ -309,20 +376,132 @@ const buildKillmailRows = (packages: R2Z2Package[]): KillmailRows => {
   };
 };
 
+/**
+ * Drop references the database cannot satisfy, so the insert cannot trip a
+ * foreign key.
+ *
+ * `createCorpAndItsRefRecords` resolves the entities it is able to create on
+ * demand, but Type, SolarSystem and Moon are written only by the SDE ingest. A
+ * killmail that names something the SDE has not delivered yet — a module first
+ * seen on patch day, most likely — would otherwise fail the whole batch on a
+ * constraint, which is exactly the failure the cursor used to wedge on.
+ *
+ * A missing *required* reference (solar system, victim ship, item type) means
+ * the killmail cannot be stored at all, so it is dropped and reported. Missing
+ * *optional* ones (moon, attacker ship, attacker weapon) are nulled instead —
+ * ESI leaves those out routinely, so a null is a shape the readers already
+ * expect, and keeping the kill beats discarding it over an unknown weapon.
+ */
+const dropUnresolvableReferences = async (
+  rows: KillmailRows,
+): Promise<{ rows: KillmailRows; droppedKillmailIds: string[] }> => {
+  const typeIds = new Set<number>();
+  const solarSystemIds = new Set<number>();
+  const moonIds = new Set<number>();
+
+  for (const killmail of rows.killmailRows) {
+    solarSystemIds.add(killmail.solarSystemId);
+    if (killmail.moonId != null) moonIds.add(killmail.moonId);
+  }
+  for (const victim of rows.victimRows) typeIds.add(victim.shipTypeId);
+  for (const item of rows.itemRows) typeIds.add(item.typeId);
+  for (const attacker of rows.attackerRows) {
+    if (attacker.shipTypeId != null) typeIds.add(attacker.shipTypeId);
+    if (attacker.weaponTypeId != null) typeIds.add(attacker.weaponTypeId);
+  }
+
+  const [knownTypes, knownSolarSystems, knownMoons] = await Promise.all([
+    typeIds.size > 0
+      ? prisma.type.findMany({
+          select: { typeId: true },
+          where: { typeId: { in: [...typeIds] } },
+        })
+      : [],
+    solarSystemIds.size > 0
+      ? prisma.solarSystem.findMany({
+          select: { solarSystemId: true },
+          where: { solarSystemId: { in: [...solarSystemIds] } },
+        })
+      : [],
+    moonIds.size > 0
+      ? prisma.moon.findMany({
+          select: { moonId: true },
+          where: { moonId: { in: [...moonIds] } },
+        })
+      : [],
+  ]);
+
+  const knownTypeIds = new Set(knownTypes.map((type) => type.typeId));
+  const knownSolarSystemIds = new Set(
+    knownSolarSystems.map((system) => system.solarSystemId),
+  );
+  const knownMoonIds = new Set(knownMoons.map((moon) => moon.moonId));
+
+  // Key on the string form: `killmailId` is typed `bigint | number`, and 1n and
+  // 1 are different Set members.
+  const dropped = new Set<string>();
+  for (const killmail of rows.killmailRows) {
+    if (!knownSolarSystemIds.has(killmail.solarSystemId)) {
+      dropped.add(killmail.killmailId.toString());
+    }
+  }
+  for (const victim of rows.victimRows) {
+    if (!knownTypeIds.has(victim.shipTypeId)) {
+      dropped.add(victim.killmailId.toString());
+    }
+  }
+  for (const item of rows.itemRows) {
+    if (!knownTypeIds.has(item.typeId)) {
+      dropped.add(item.killmailId.toString());
+    }
+  }
+
+  const kept = <T extends { killmailId: bigint | number }>(list: T[]) =>
+    list.filter((row) => !dropped.has(row.killmailId.toString()));
+
+  const knownTypeOrNull = (typeId: number | null | undefined) =>
+    typeId != null && knownTypeIds.has(typeId) ? typeId : null;
+
+  return {
+    rows: {
+      ...rows,
+      killmailRows: kept(rows.killmailRows).map((killmail) => ({
+        ...killmail,
+        moonId:
+          killmail.moonId != null && knownMoonIds.has(killmail.moonId)
+            ? killmail.moonId
+            : null,
+      })),
+      victimRows: kept(rows.victimRows),
+      attackerRows: kept(rows.attackerRows).map((attacker) => ({
+        ...attacker,
+        shipTypeId: knownTypeOrNull(attacker.shipTypeId),
+        weaponTypeId: knownTypeOrNull(attacker.weaponTypeId),
+      })),
+      itemRows: kept(rows.itemRows),
+    },
+    droppedKillmailIds: [...dropped],
+  };
+};
+
 /** Poll R2Z2 from `startCursor`, returning the packages and the advanced cursor / throttle time. */
 const collectKillmailPackages = async (
   ctx: JobContext,
-  redis: Awaited<ReturnType<typeof getRedis>>,
   startCursor: bigint,
   latestSequence: bigint,
 ): Promise<{
   packages: R2Z2Package[];
   cursor: bigint;
   rateLimitUntilMs: number | null;
+  missingSequences: number;
+  expiredFrom: bigint | null;
 }> => {
   const packages: R2Z2Package[] = [];
   let cursor = startCursor;
   let rateLimitUntilMs: number | null = null;
+  let consecutiveMisses = 0;
+  let missingSequences = 0;
+  let expiredFrom: bigint | null = null;
 
   for (let i = 0; i < MAX_KILLMAILS_PER_RUN; i++) {
     const response = await fetchJson(`${R2Z2_BASE_URL}/${cursor}.json`);
@@ -343,13 +522,27 @@ const collectKillmailPackages = async (
     }
 
     if (response.status === 404) {
-      // If we're behind and hit a 404 immediately, re-prime to latest.
-      if (packages.length === 0 && cursor < latestSequence) {
+      // Nothing published at or beyond this sequence yet: we have caught up.
+      // Leave the cursor here so the next run picks the entry up once it lands.
+      if (cursor >= latestSequence) break;
+
+      // We are behind and this particular sequence is gone. R2Z2 is ephemeral,
+      // so isolated holes are normal — step over one rather than abandoning
+      // every killmail after it. Only an unbroken run of misses means the feed
+      // has aged past the cursor, which is the sole case worth fast-forwarding.
+      consecutiveMisses += 1;
+      missingSequences += 1;
+      if (consecutiveMisses >= MAX_CONSECUTIVE_MISSING_SEQUENCES) {
+        expiredFrom = cursor - BigInt(consecutiveMisses) + 1n;
         cursor = latestSequence;
-        await redis.set(R2Z2_CURSOR_KEY, cursor.toString());
+        break;
       }
-      break;
+
+      cursor += 1n;
+      continue;
     }
+
+    consecutiveMisses = 0;
 
     const payload = response.data as Partial<R2Z2Package> | null;
     if (!payload?.esi || !payload.zkb) {
@@ -364,7 +557,7 @@ const collectKillmailPackages = async (
     cursor += 1n;
   }
 
-  return { packages, cursor, rateLimitUntilMs };
+  return { packages, cursor, rateLimitUntilMs, missingSequences, expiredFrom };
 };
 
 export type ScrapeRecentKillsEventPayload = Record<string, never>;
@@ -460,7 +653,6 @@ export const scrapeZkillboardRecentKills =
 
         const collected = await collectKillmailPackages(
           ctx,
-          redis,
           cursor,
           latestSequence,
         );
@@ -468,7 +660,25 @@ export const scrapeZkillboardRecentKills =
         cursor = collected.cursor;
         rateLimitUntilMs = collected.rateLimitUntilMs;
 
+        if (collected.expiredFrom !== null) {
+          await recordSkippedRange(
+            redis,
+            collected.expiredFrom,
+            latestSequence,
+            "expired from the R2Z2 feed",
+          );
+          ctx.logger.warn("R2Z2 aged past the cursor; fast-forwarded.", {
+            from: collected.expiredFrom.toString(),
+            to: latestSequence.toString(),
+          });
+        }
+
         if (killmailPackages.length === 0) {
+          // Nothing to insert, but the cursor may still have moved — past holes
+          // we stepped over, or forward to `latestSequence` because the feed
+          // aged out. Persist it, or the next run re-walks the same 404s.
+          await redis.set(R2Z2_CURSOR_KEY, cursor.toString());
+
           await postUpdateCard({
             status: "idle",
             summary: "No new killmails processed this run.",
@@ -488,17 +698,14 @@ export const scrapeZkillboardRecentKills =
           };
         }
 
+        const built = buildKillmailRows(killmailPackages);
         const {
-          killmailRows,
-          victimRows,
-          attackerRows,
-          itemRows,
           missingAllianceIds,
           missingCharacterIds,
           missingCorporationIds,
           missingFactionIds,
           missingWarIds,
-        } = buildKillmailRows(killmailPackages);
+        } = built;
 
         await ctx.run("Ensure related entities exist", async () => {
           await createCorpAndItsRefRecords({
@@ -510,33 +717,54 @@ export const scrapeZkillboardRecentKills =
           });
         });
 
+        const { rows: resolved, droppedKillmailIds } = await ctx.run(
+          "Drop unresolvable references",
+          async () => dropUnresolvableReferences(built),
+        );
+        const { killmailRows, victimRows, attackerRows, itemRows } = resolved;
+
+        if (droppedKillmailIds.length > 0) {
+          ctx.logger.warn(
+            "Skipped killmails referencing rows the SDE has not delivered yet.",
+            { killmailIds: droppedKillmailIds },
+          );
+        }
+
         await ctx.run("Insert killmail records", async () => {
-          await prisma.killmail.createMany({
-            data: killmailRows,
-            skipDuplicates: true,
-          });
-
-          await prisma.killmailVictim.createMany({
-            data: victimRows,
-            skipDuplicates: true,
-          });
-
-          await prisma.killmailAttacker.createMany({
-            data: attackerRows,
-            skipDuplicates: true,
-          });
-
-          await prisma.killmailVictimItems.createMany({
-            data: itemRows,
-            skipDuplicates: true,
-          });
+          // One transaction: a failure part-way through used to leave Killmail
+          // rows committed with no victim, attackers or items, and those orphans
+          // then looked complete to `skipDuplicates` on the next attempt.
+          await prisma.$transaction([
+            prisma.killmail.createMany({
+              data: killmailRows,
+              skipDuplicates: true,
+            }),
+            prisma.killmailVictim.createMany({
+              data: victimRows,
+              skipDuplicates: true,
+            }),
+            prisma.killmailAttacker.createMany({
+              data: attackerRows,
+              skipDuplicates: true,
+            }),
+            prisma.killmailVictimItems.createMany({
+              data: itemRows,
+              skipDuplicates: true,
+            }),
+          ]);
         });
 
         await redis.set(R2Z2_CURSOR_KEY, cursor.toString());
+        await redis.del(R2Z2_BATCH_FAILURE_KEY);
+
+        const droppedNote =
+          droppedKillmailIds.length > 0
+            ? ` Skipped ${droppedKillmailIds.length} referencing unknown SDE rows.`
+            : "";
 
         await postUpdateCard({
           status: "success",
-          summary: `Processed ${killmailRows.length} killmails.`,
+          summary: `Processed ${killmailRows.length} killmails.${droppedNote}`,
           processed: killmailRows.length,
           range: formatRange(startCursor, cursor),
           lag: formatLag(latestSequence, cursor),
@@ -558,9 +786,42 @@ export const scrapeZkillboardRecentKills =
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
+
+        // The cursor only advances on success, so a batch that can never be
+        // processed used to block the feed permanently: `retries: 0` means no
+        // retry, and every later run re-fetched the same sequences and failed
+        // the same way. Count attempts per batch instead — a transient failure
+        // is retried on the next run, and a batch that keeps failing is skipped
+        // (and recorded) so the feed keeps moving.
+        let quarantined = false;
+        if (startCursor !== null && cursor !== null && cursor > startCursor) {
+          const failures = await countBatchFailure(redis, startCursor);
+          if (failures >= MAX_BATCH_FAILURES) {
+            await recordSkippedRange(
+              redis,
+              startCursor,
+              cursor,
+              `failed ${failures} times: ${message}`,
+            );
+            await redis.set(R2Z2_CURSOR_KEY, cursor.toString());
+            await redis.del(R2Z2_BATCH_FAILURE_KEY);
+            quarantined = true;
+            ctx.logger.error(
+              "Quarantined an unprocessable R2Z2 batch and advanced the cursor.",
+              {
+                range: formatRange(startCursor, cursor),
+                attempts: failures,
+                error: message,
+              },
+            );
+          }
+        }
+
         await postUpdateCard({
           status: "failed",
-          summary: `Error: ${message}`,
+          summary: quarantined
+            ? `Error: ${message} — gave up on ${formatRange(startCursor, cursor)} after ${MAX_BATCH_FAILURES} attempts and advanced the cursor.`
+            : `Error: ${message}`,
           range: formatRange(startCursor, cursor),
           lag: formatLag(latestSequence, cursor),
           latestSequence,

--- a/packages/background-jobs/jobs/scrape/zkillboard/scrapeRecentKills.ts
+++ b/packages/background-jobs/jobs/scrape/zkillboard/scrapeRecentKills.ts
@@ -261,6 +261,67 @@ const countBatchFailure = async (
   return failures;
 };
 
+/**
+ * Count this failure and, once a batch has failed too often, skip past it.
+ *
+ * The cursor only advances on success, so a batch that can never be processed
+ * used to block the feed permanently: `retries: 0` means no retry, and every
+ * later run re-fetched the same sequences and failed the same way. Counting
+ * attempts lets a transient failure be retried while an unprocessable batch is
+ * given up on, so the feed keeps moving either way.
+ *
+ * Returns whether the batch was abandoned.
+ */
+const quarantineExhaustedBatch = async (
+  ctx: JobContext,
+  redis: Awaited<ReturnType<typeof getRedis>>,
+  startCursor: bigint | null,
+  cursor: bigint | null,
+  message: string,
+): Promise<boolean> => {
+  if (startCursor === null || cursor === null || cursor <= startCursor) {
+    return false;
+  }
+
+  const failures = await countBatchFailure(redis, startCursor);
+  if (failures < MAX_BATCH_FAILURES) return false;
+
+  await recordSkippedRange(
+    redis,
+    startCursor,
+    cursor,
+    `failed ${failures} times: ${message}`,
+  );
+  await redis.set(R2Z2_CURSOR_KEY, cursor.toString());
+  await redis.del(R2Z2_BATCH_FAILURE_KEY);
+  ctx.logger.error(
+    "Quarantined an unprocessable R2Z2 batch and advanced the cursor.",
+    {
+      range: formatRange(startCursor, cursor),
+      attempts: failures,
+      error: message,
+    },
+  );
+  return true;
+};
+
+/** Load the stored cursor, seeding it at the feed head on the very first run. */
+const loadCursor = async (
+  ctx: JobContext,
+  redis: Awaited<ReturnType<typeof getRedis>>,
+  latestSequenceValue: string,
+): Promise<bigint> => {
+  const stored = await ctx.run("Load R2Z2 cursor", async () =>
+    redis.get(R2Z2_CURSOR_KEY),
+  );
+  if (stored) return BigInt(stored);
+
+  await ctx.run("Initialize R2Z2 cursor", async () => {
+    await redis.set(R2Z2_CURSOR_KEY, latestSequenceValue);
+  });
+  return BigInt(latestSequenceValue);
+};
+
 interface KillmailRows {
   killmailRows: Prisma.KillmailCreateManyInput[];
   victimRows: Prisma.KillmailVictimCreateManyInput[];
@@ -376,25 +437,8 @@ const buildKillmailRows = (packages: R2Z2Package[]): KillmailRows => {
   };
 };
 
-/**
- * Drop references the database cannot satisfy, so the insert cannot trip a
- * foreign key.
- *
- * `createCorpAndItsRefRecords` resolves the entities it is able to create on
- * demand, but Type, SolarSystem and Moon are written only by the SDE ingest. A
- * killmail that names something the SDE has not delivered yet — a module first
- * seen on patch day, most likely — would otherwise fail the whole batch on a
- * constraint, which is exactly the failure the cursor used to wedge on.
- *
- * A missing *required* reference (solar system, victim ship, item type) means
- * the killmail cannot be stored at all, so it is dropped and reported. Missing
- * *optional* ones (moon, attacker ship, attacker weapon) are nulled instead —
- * ESI leaves those out routinely, so a null is a shape the readers already
- * expect, and keeping the kill beats discarding it over an unknown weapon.
- */
-const dropUnresolvableReferences = async (
-  rows: KillmailRows,
-): Promise<{ rows: KillmailRows; droppedKillmailIds: string[] }> => {
+/** Every SDE-owned id a batch references, grouped by the table that owns it. */
+const collectReferencedIds = (rows: KillmailRows) => {
   const typeIds = new Set<number>();
   const solarSystemIds = new Set<number>();
   const moonIds = new Set<number>();
@@ -410,7 +454,16 @@ const dropUnresolvableReferences = async (
     if (attacker.weaponTypeId != null) typeIds.add(attacker.weaponTypeId);
   }
 
-  const [knownTypes, knownSolarSystems, knownMoons] = await Promise.all([
+  return { typeIds, solarSystemIds, moonIds };
+};
+
+/** Which of those ids the database actually holds. */
+const findKnownIds = async ({
+  typeIds,
+  solarSystemIds,
+  moonIds,
+}: ReturnType<typeof collectReferencedIds>) => {
+  const [types, solarSystems, moons] = await Promise.all([
     typeIds.size > 0
       ? prisma.type.findMany({
           select: { typeId: true },
@@ -431,30 +484,75 @@ const dropUnresolvableReferences = async (
       : [],
   ]);
 
-  const knownTypeIds = new Set(knownTypes.map((type) => type.typeId));
-  const knownSolarSystemIds = new Set(
-    knownSolarSystems.map((system) => system.solarSystemId),
-  );
-  const knownMoonIds = new Set(knownMoons.map((moon) => moon.moonId));
+  return {
+    knownTypeIds: new Set(types.map((type) => type.typeId)),
+    knownSolarSystemIds: new Set(
+      solarSystems.map((system) => system.solarSystemId),
+    ),
+    knownMoonIds: new Set(moons.map((moon) => moon.moonId)),
+  };
+};
 
-  // Key on the string form: `killmailId` is typed `bigint | number`, and 1n and
-  // 1 are different Set members.
-  const dropped = new Set<string>();
+/**
+ * Killmails naming a required row the database lacks, so they cannot be stored
+ * at all.
+ *
+ * Keyed on the string form: `killmailId` is typed `bigint | number`, and 1n and
+ * 1 are different Set members.
+ */
+const findUnstorableKillmailIds = (
+  rows: KillmailRows,
+  knownTypeIds: ReadonlySet<number>,
+  knownSolarSystemIds: ReadonlySet<number>,
+) => {
+  const unstorable = new Set<string>();
+
   for (const killmail of rows.killmailRows) {
     if (!knownSolarSystemIds.has(killmail.solarSystemId)) {
-      dropped.add(killmail.killmailId.toString());
+      unstorable.add(killmail.killmailId.toString());
     }
   }
   for (const victim of rows.victimRows) {
     if (!knownTypeIds.has(victim.shipTypeId)) {
-      dropped.add(victim.killmailId.toString());
+      unstorable.add(victim.killmailId.toString());
     }
   }
   for (const item of rows.itemRows) {
     if (!knownTypeIds.has(item.typeId)) {
-      dropped.add(item.killmailId.toString());
+      unstorable.add(item.killmailId.toString());
     }
   }
+
+  return unstorable;
+};
+
+/**
+ * Drop references the database cannot satisfy, so the insert cannot trip a
+ * foreign key.
+ *
+ * `createCorpAndItsRefRecords` resolves the entities it is able to create on
+ * demand, but Type, SolarSystem and Moon are written only by the SDE ingest. A
+ * killmail that names something the SDE has not delivered yet — a module first
+ * seen on patch day, most likely — would otherwise fail the whole batch on a
+ * constraint, which is exactly the failure the cursor used to wedge on.
+ *
+ * A missing *required* reference (solar system, victim ship, item type) means
+ * the killmail cannot be stored at all, so it is dropped and reported. Missing
+ * *optional* ones (moon, attacker ship, attacker weapon) are nulled instead —
+ * ESI leaves those out routinely, so a null is a shape the readers already
+ * expect, and keeping the kill beats discarding it over an unknown weapon.
+ */
+const dropUnresolvableReferences = async (
+  rows: KillmailRows,
+): Promise<{ rows: KillmailRows; droppedKillmailIds: string[] }> => {
+  const { knownTypeIds, knownSolarSystemIds, knownMoonIds } =
+    await findKnownIds(collectReferencedIds(rows));
+
+  const dropped = findUnstorableKillmailIds(
+    rows,
+    knownTypeIds,
+    knownSolarSystemIds,
+  );
 
   const kept = <T extends { killmailId: bigint | number }>(list: T[]) =>
     list.filter((row) => !dropped.has(row.killmailId.toString()));
@@ -631,24 +729,7 @@ export const scrapeZkillboardRecentKills =
 
         latestSequence = BigInt(latestSequenceValue as string);
 
-        let nextSequenceValue: string | null = await ctx.run(
-          "Load R2Z2 cursor",
-          async () => {
-            const stored = await redis.get(R2Z2_CURSOR_KEY);
-            if (!stored) return null;
-            return stored;
-          },
-        );
-
-        if (nextSequenceValue === null) {
-          const initialCursor = latestSequenceValue as string;
-          nextSequenceValue = initialCursor;
-          await ctx.run("Initialize R2Z2 cursor", async () => {
-            await redis.set(R2Z2_CURSOR_KEY, initialCursor);
-          });
-        }
-
-        cursor = BigInt(nextSequenceValue);
+        cursor = await loadCursor(ctx, redis, latestSequenceValue as string);
         startCursor = cursor;
 
         const collected = await collectKillmailPackages(
@@ -787,35 +868,13 @@ export const scrapeZkillboardRecentKills =
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
 
-        // The cursor only advances on success, so a batch that can never be
-        // processed used to block the feed permanently: `retries: 0` means no
-        // retry, and every later run re-fetched the same sequences and failed
-        // the same way. Count attempts per batch instead — a transient failure
-        // is retried on the next run, and a batch that keeps failing is skipped
-        // (and recorded) so the feed keeps moving.
-        let quarantined = false;
-        if (startCursor !== null && cursor !== null && cursor > startCursor) {
-          const failures = await countBatchFailure(redis, startCursor);
-          if (failures >= MAX_BATCH_FAILURES) {
-            await recordSkippedRange(
-              redis,
-              startCursor,
-              cursor,
-              `failed ${failures} times: ${message}`,
-            );
-            await redis.set(R2Z2_CURSOR_KEY, cursor.toString());
-            await redis.del(R2Z2_BATCH_FAILURE_KEY);
-            quarantined = true;
-            ctx.logger.error(
-              "Quarantined an unprocessable R2Z2 batch and advanced the cursor.",
-              {
-                range: formatRange(startCursor, cursor),
-                attempts: failures,
-                error: message,
-              },
-            );
-          }
-        }
+        const quarantined = await quarantineExhaustedBatch(
+          ctx,
+          redis,
+          startCursor,
+          cursor,
+          message,
+        );
 
         await postUpdateCard({
           status: "failed",

--- a/packages/background-jobs/tests/scrapeRecentKills.test.ts
+++ b/packages/background-jobs/tests/scrapeRecentKills.test.ts
@@ -1,0 +1,403 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { scrapeZkillboardRecentKills as ScrapeRecentKills } from "../jobs/scrape/zkillboard/scrapeRecentKills";
+
+// @swc/jest doesn't hoist jest.mock, so the mock fns are declared first and the
+// factories close over them; the job is imported lazily in beforeAll (after the
+// mocks register). Everything the job touches outside its own logic — Redis,
+// Prisma, Discord, the entity resolver and the R2Z2 feed itself — is stubbed,
+// so what is under test is the cursor bookkeeping and the reference filter.
+
+const CURSOR_KEY = "zkillboard:r2z2:next-sequence";
+const FAILURE_KEY = "zkillboard:r2z2:batch-failures";
+const SKIPPED_KEY = "zkillboard:r2z2:skipped-ranges";
+
+let store: Map<string, string>;
+let lists: Map<string, string[]>;
+
+const redis = {
+  get: jest.fn((key: string) => Promise.resolve(store.get(key) ?? null)),
+  set: jest.fn((key: string, value: string) => {
+    store.set(key, value);
+    return Promise.resolve("OK");
+  }),
+  del: jest.fn((key: string) => Promise.resolve(store.delete(key) ? 1 : 0)),
+  lPush: jest.fn((key: string, value: string) => {
+    const list = lists.get(key) ?? [];
+    list.unshift(value);
+    lists.set(key, list);
+    return Promise.resolve(list.length);
+  }),
+  lTrim: jest.fn(() => Promise.resolve("OK")),
+};
+
+const createCorpAndItsRefRecords = jest.fn(() => Promise.resolve(undefined));
+const postUpdateCard = jest.fn(() => Promise.resolve(undefined));
+
+const createMany = {
+  killmail: jest.fn((args: unknown) => args),
+  victim: jest.fn((args: unknown) => args),
+  attacker: jest.fn((args: unknown) => args),
+  items: jest.fn((args: unknown) => args),
+};
+const transaction = jest.fn((ops: unknown[]) => Promise.resolve(ops));
+const knownTypeIds = new Set<number>();
+const knownSolarSystemIds = new Set<number>();
+const knownMoonIds = new Set<number>();
+
+const prisma = {
+  $transaction: transaction,
+  killmail: { createMany: createMany.killmail },
+  killmailVictim: { createMany: createMany.victim },
+  killmailAttacker: { createMany: createMany.attacker },
+  killmailVictimItems: { createMany: createMany.items },
+  type: {
+    findMany: jest.fn((args: { where: { typeId: { in: number[] } } }) =>
+      Promise.resolve(
+        args.where.typeId.in
+          .filter((id) => knownTypeIds.has(id))
+          .map((typeId) => ({ typeId })),
+      ),
+    ),
+  },
+  solarSystem: {
+    findMany: jest.fn(
+      (args: { where: { solarSystemId: { in: number[] } } }) =>
+        Promise.resolve(
+          args.where.solarSystemId.in
+            .filter((id) => knownSolarSystemIds.has(id))
+            .map((solarSystemId) => ({ solarSystemId })),
+        ),
+    ),
+  },
+  moon: {
+    findMany: jest.fn((args: { where: { moonId: { in: number[] } } }) =>
+      Promise.resolve(
+        args.where.moonId.in
+          .filter((id) => knownMoonIds.has(id))
+          .map((moonId) => ({ moonId })),
+      ),
+    ),
+  },
+};
+
+jest.mock("../kv", () => ({ getRedis: () => Promise.resolve(redis) }));
+jest.mock("../db", () => ({ prisma }));
+jest.mock("../chat", () => ({ postUpdateCard }));
+jest.mock("../helpers/createCorpAndItsRefs.ts", () => ({
+  createCorpAndItsRefRecords,
+}));
+
+let scrapeZkillboardRecentKills: typeof ScrapeRecentKills;
+
+beforeAll(async () => {
+  ({ scrapeZkillboardRecentKills } = await import(
+    "../jobs/scrape/zkillboard/scrapeRecentKills"
+  ));
+});
+
+/** A minimal but schema-shaped R2Z2 package for `sequence`. */
+const packageAt = (
+  sequence: number,
+  {
+    shipTypeId = 670,
+    itemTypeId = 21898,
+    weaponTypeId = 2488,
+    solarSystemId = 30001403,
+  } = {},
+) => ({
+  killmail_id: 137000000 + sequence,
+  hash: `hash-${sequence}`,
+  sequence_id: sequence,
+  uploaded_at: 0,
+  esi: {
+    killmail_id: 137000000 + sequence,
+    killmail_time: "2026-08-20T20:06:08Z",
+    solar_system_id: solarSystemId,
+    victim: {
+      character_id: 2124562369,
+      corporation_id: 98000001,
+      ship_type_id: shipTypeId,
+      damage_taken: 2460,
+      position: { x: 1, y: 2, z: 3 },
+      items: [
+        {
+          flag: 5,
+          item_type_id: itemTypeId,
+          quantity_dropped: 7,
+          singleton: 0,
+        },
+      ],
+    },
+    attackers: [
+      {
+        character_id: 95000001,
+        corporation_id: 98000002,
+        ship_type_id: 11365,
+        weapon_type_id: weaponTypeId,
+        damage_done: 2460,
+        final_blow: true,
+        security_status: 4.2,
+      },
+    ],
+  },
+  zkb: { locationID: 40330952, hash: `hash-${sequence}` },
+});
+
+/**
+ * Drive one run against a fake feed. `feed` maps a sequence number to its
+ * package; anything absent 404s, exactly like R2Z2's ephemeral window.
+ */
+const run = async ({
+  latest,
+  feed,
+  insertFails = false,
+}: {
+  latest: number;
+  feed: Map<number, unknown>;
+  insertFails?: boolean;
+}) => {
+  transaction.mockImplementation((ops: unknown[]) =>
+    insertFails
+      ? Promise.reject(new Error("foreign key violation"))
+      : Promise.resolve(ops),
+  );
+
+  global.fetch = jest.fn((url: unknown) => {
+    const target = String(url);
+    if (target.endsWith("sequence.json")) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: () => Promise.resolve({ sequence: latest }),
+      });
+    }
+    const sequence = Number(target.split("/").pop()?.replace(".json", ""));
+    const payload = feed.get(sequence);
+    if (!payload) {
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        headers: { get: () => null },
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: () => Promise.resolve(payload),
+    });
+  }) as unknown as typeof fetch;
+
+  const ctx = {
+    payload: {},
+    attempt: 1,
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+    send: jest.fn(),
+    invoke: jest.fn(),
+    run: (_name: string, fn: () => unknown) => fn(),
+    sleep: jest.fn(),
+  } as unknown as Parameters<typeof scrapeZkillboardRecentKills.handler>[0];
+
+  return scrapeZkillboardRecentKills.handler(ctx);
+};
+
+const cursor = () => store.get(CURSOR_KEY);
+const skipped = () =>
+  (lists.get(SKIPPED_KEY) ?? []).map(
+    (entry) => JSON.parse(entry) as Record<string, string>,
+  );
+
+beforeEach(() => {
+  store = new Map([[CURSOR_KEY, "100"]]);
+  lists = new Map();
+  knownTypeIds.clear();
+  knownSolarSystemIds.clear();
+  knownMoonIds.clear();
+  [670, 21898, 2488, 11365].forEach((id) => knownTypeIds.add(id));
+  knownSolarSystemIds.add(30001403);
+});
+
+describe("scrape-zkillboard-recent-kills — cursor advance", () => {
+  it("steps over a single missing sequence instead of abandoning the tail", async () => {
+    // 101 is a hole. The killmail at 102 must still be ingested: the old code
+    // broke out at the hole, then fast-forwarded to latest on the next run and
+    // lost everything between.
+    const feed = new Map<number, unknown>([
+      [100, packageAt(100)],
+      [102, packageAt(102)],
+    ]);
+
+    const result = await run({ latest: 103, feed });
+
+    expect(result).toMatchObject({ processed: 2 });
+    expect(cursor()).toBe("103");
+    expect(skipped()).toHaveLength(0);
+  });
+
+  it("stops at the head without burning requests on unpublished sequences", async () => {
+    const feed = new Map<number, unknown>([[100, packageAt(100)]]);
+
+    await run({ latest: 101, feed });
+
+    expect(cursor()).toBe("101");
+    // sequence.json, 100, then 101 (the not-yet-published head). Nothing more.
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("fast-forwards and records the range once the feed has aged past the cursor", async () => {
+    const result = await run({ latest: 5_000, feed: new Map() });
+
+    expect(result).toMatchObject({ processed: 0 });
+    expect(cursor()).toBe("5000");
+    expect(skipped()).toEqual([
+      expect.objectContaining({
+        from: "100",
+        to: "4999",
+        reason: "expired from the R2Z2 feed",
+      }),
+    ]);
+  });
+});
+
+describe("scrape-zkillboard-recent-kills — batch failures", () => {
+  const failingRun = () =>
+    run({
+      latest: 102,
+      feed: new Map<number, unknown>([
+        [100, packageAt(100)],
+        [101, packageAt(101)],
+      ]),
+      insertFails: true,
+    });
+
+  it("retries a failing batch rather than skipping it immediately", async () => {
+    await expect(failingRun()).rejects.toThrow("foreign key violation");
+
+    expect(cursor()).toBe("100");
+    expect(store.get(FAILURE_KEY)).toBe("100:1");
+    expect(skipped()).toHaveLength(0);
+  });
+
+  it("quarantines the batch and advances the cursor once retries are exhausted", async () => {
+    await expect(failingRun()).rejects.toThrow();
+    await expect(failingRun()).rejects.toThrow();
+    expect(cursor()).toBe("100");
+
+    await expect(failingRun()).rejects.toThrow();
+
+    // The feed keeps moving: this is the stall the cursor used to hit forever.
+    expect(cursor()).toBe("102");
+    expect(store.get(FAILURE_KEY)).toBeUndefined();
+    expect(skipped()).toEqual([
+      expect.objectContaining({
+        from: "100",
+        to: "101",
+        count: "2",
+        reason: expect.stringContaining("failed 3 times"),
+      }),
+    ]);
+  });
+
+  it("does not carry a failure count across to a different batch", async () => {
+    await expect(failingRun()).rejects.toThrow();
+    expect(store.get(FAILURE_KEY)).toBe("100:1");
+
+    store.set(CURSOR_KEY, "200");
+    await expect(
+      run({
+        latest: 201,
+        feed: new Map<number, unknown>([[200, packageAt(200)]]),
+        insertFails: true,
+      }),
+    ).rejects.toThrow();
+
+    expect(store.get(FAILURE_KEY)).toBe("200:1");
+  });
+
+  it("clears the failure count after a successful run", async () => {
+    await expect(failingRun()).rejects.toThrow();
+    expect(store.get(FAILURE_KEY)).toBe("100:1");
+
+    await run({
+      latest: 102,
+      feed: new Map<number, unknown>([
+        [100, packageAt(100)],
+        [101, packageAt(101)],
+      ]),
+    });
+
+    expect(store.get(FAILURE_KEY)).toBeUndefined();
+    expect(cursor()).toBe("102");
+  });
+});
+
+describe("scrape-zkillboard-recent-kills — unresolvable references", () => {
+  const dataOf = (mock: { mock: { calls: unknown[][] } }) =>
+    (mock.mock.calls[0]?.[0] as { data: Record<string, unknown>[] }).data;
+
+  it("drops a killmail whose victim ship type the SDE has not delivered", async () => {
+    const feed = new Map<number, unknown>([
+      [100, packageAt(100, { shipTypeId: 999999 })],
+      [101, packageAt(101)],
+    ]);
+
+    const result = await run({ latest: 102, feed });
+
+    expect(result).toMatchObject({ processed: 1 });
+    expect(dataOf(createMany.killmail)).toEqual([
+      expect.objectContaining({ killmailId: 137000101n }),
+    ]);
+    // The dropped killmail takes its children with it — no orphans.
+    expect(dataOf(createMany.victim)).toHaveLength(1);
+    expect(dataOf(createMany.items)).toHaveLength(1);
+    expect(cursor()).toBe("102");
+  });
+
+  it("drops a killmail whose item type is unknown", async () => {
+    const feed = new Map<number, unknown>([
+      [100, packageAt(100, { itemTypeId: 999999 })],
+    ]);
+
+    const result = await run({ latest: 101, feed });
+
+    expect(result).toMatchObject({ processed: 0 });
+  });
+
+  it("nulls an unknown attacker weapon rather than dropping the killmail", async () => {
+    const feed = new Map<number, unknown>([
+      [100, packageAt(100, { weaponTypeId: 999999 })],
+    ]);
+
+    const result = await run({ latest: 101, feed });
+
+    expect(result).toMatchObject({ processed: 1 });
+    expect(dataOf(createMany.attacker)).toEqual([
+      expect.objectContaining({ weaponTypeId: null, shipTypeId: 11365 }),
+    ]);
+  });
+
+  it("drops a killmail in a solar system the database does not have", async () => {
+    knownSolarSystemIds.clear();
+    const feed = new Map<number, unknown>([[100, packageAt(100)]]);
+
+    const result = await run({ latest: 101, feed });
+
+    expect(result).toMatchObject({ processed: 0 });
+  });
+
+  it("writes all four tables in one transaction", async () => {
+    const feed = new Map<number, unknown>([[100, packageAt(100)]]);
+
+    await run({ latest: 101, feed });
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+    expect(transaction.mock.calls[0]?.[0]).toHaveLength(4);
+  });
+});

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1160,7 +1160,12 @@ model KillmailVictimItems {
    */
   quantityDropped   Int?
   /**
-   * The unique ID of the item, if it was a singleton.
+   * Whether the item was a blueprint copy: 0 = ordinary item, 2 = blueprint copy.
+   *
+   * Despite the name this is not an item ID, and it is not the assets API's
+   * `is_singleton` boolean either — fitted, assembled modules also report 0.
+   * ESI documents no values for it, but across a full day of killmails
+   * (228,676 items) it takes only 0 and 2, and every 2 is a blueprint.
    */
   singleton         BigInt
   /**


### PR DESCRIPTION
Three independent fixes, one per package, found while checking whether the `@jitaspace/db` schema can fully model an EVE killmail. Each is a separate commit.

## `fix(background-jobs)` — the ingest cursor stall

`scrape-zkillboard-recent-kills` advanced its R2Z2 cursor **only after a successful insert**, and runs with `retries: 0`. A batch that could never be inserted therefore blocked the feed permanently — every later run re-fetched the same sequences and failed identically. The likeliest trigger is a killmail naming a type the SDE has not delivered yet, since `Type`, `SolarSystem` and `Moon` (unlike alliances, characters and corporations) are never created on demand, and `KillmailVictim.shipTypeId` / `KillmailVictimItems.typeId` are required FKs.

Four changes, because fixing only the symptom would trade a wedge for silent data loss:

- **Prevent the poison.** Type/SolarSystem/Moon references are resolved before the insert, using the `findMany`-prefilter pattern `createCorpAndItsRefs.ts` already uses. A missing *required* reference drops the killmail; missing *optional* ones (moon, attacker ship, attacker weapon) are nulled instead — a shape ESI produces routinely, and better than discarding a kill over an unknown weapon.
- **Make the batch atomic.** The four `createMany` calls now run in one `$transaction`. A mid-batch failure used to leave `Killmail` rows committed with no victim, attackers or items, and `skipDuplicates` then read those orphans as complete on the next attempt.
- **Un-wedge on failure.** Failures are counted per batch, keyed on its own start sequence, so three failures at three different cursors are three first attempts rather than one batch about to be quarantined. Transient failures retry; after three attempts the batch is skipped and the cursor advances.
- **Stop discarding the tail behind a hole.** This was the larger data-loss path and needed no failure at all. R2Z2 is ephemeral, so holes are normal — but the first one ended collection, and the *next* run then fast-forwarded the cursor to the head of the feed, throwing away every killmail in between. A single miss is now stepped over; fast-forwarding is reserved for 25 consecutive misses, which is what an expired feed actually looks like.

Skipped ranges — expired or quarantined — are recorded to a capped Redis list so they stay replayable rather than vanishing silently.

Also in this commit: `backfill-everef-killmails` built its corporation-id set from each victim's `alliance_id` instead of `corporation_id`, so victim corporations were never resolved and alliance ids were fed to the corporation lookup.

## `fix(web)` — killmail item quantities

`a ?? 0 + (b ?? 0)` parses as `a ?? (0 + (b ?? 0))`, since `+` binds tighter than `??`.

**This never misrendered**, and there is deliberately no `@jitaspace/web` changeset: ESI sets exactly one of `quantity_destroyed`/`quantity_dropped` per item row — 0 of 228,676 rows across a full day of killmails carried both — so the old form was accidentally correct for every real input. The invariant is undocumented and unguaranteed, so the change pins the arithmetic rather than the accident.

## `docs(db)` — what `singleton` actually means

`KillmailVictimItems.singleton` was documented as "the unique ID of the item". It is not, and never has been. ESI documents no values for it, but across a full day of killmails it takes only **0** (99.69%) and **2** (0.31%), and every `2` resolves to a Blueprint — it marks blueprint copies. It is also not the assets API's `is_singleton` boolean: fitted, assembled modules report `0` too, so "packaged" would be wrong as well.

Comment-only, so the client regenerates with no DDL change and no `db:push` is needed.

## Testing

`scrapeRecentKills.ts` and `EsiKillmailFittingCard.tsx` both had **zero** coverage, which is why these survived. Now 82% and 100% respectively, via 16 new tests.

Both suites were checked to fail against the old code rather than merely pass against the new:

- reverting the 404 handling → the hole-stepping and fast-forward tests fail (2 failed, 10 passed)
- reverting the catch block → all four quarantine tests fail (4 failed, 8 passed)
- reverting the precedence fix → the summing test fails

`SKIP_ENV_VALIDATION=1 pnpm lint && pnpm type-check && pnpm test` — lint 25/25, type-check 38/38, tests 29/29 workspaces.

## Notes for review

- **The job is dormant.** It is `trigger: { type: "event" }` with no cron and no in-repo caller, so none of this runs until it is scheduled. The tables are populated (~539k rows across the four), but nothing reads them, so there is no user-visible change in this PR.
- **`createCorpAndItsRefs.ts` has the same poison-pill shape** (`fetchWarsFromEsi` has no 404 handling; the resolver throws `Some entities still missing after 20 rounds`). Left alone — the new quarantine turns that into a skipped batch rather than a permanent stall, so it degrades instead of stopping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
