### PR TITLE
fix(web): date sitemap URLs by their own row, not the deploy

### DIFF
--- a/.changeset/sitemap-per-entity-lastmod.md
+++ b/.changeset/sitemap-per-entity-lastmod.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+The sitemap now tells search engines when each page actually changed, instead of stamping every one of the ~50,000 item pages with the date of the last deploy. Search engines can skip re-crawling pages that have not changed, and give more weight to the ones that have.

--- a/apps/web/app/sitemap-index.xml/route.ts
+++ b/apps/web/app/sitemap-index.xml/route.ts
@@ -1,6 +1,6 @@
 import { connection } from "next/server";
 
-import { getSitemapUrls, LAST_MODIFIED } from "../sitemap";
+import { getSitemapPages } from "../sitemap";
 
 /**
  * The sitemap index, served at `/sitemap.xml` via a `beforeFiles` rewrite in
@@ -16,8 +16,10 @@ import { getSitemapUrls, LAST_MODIFIED } from "../sitemap";
  * Why bother: `/sitemap.xml` is the path crawlers probe unprompted, and until
  * now it 404'd, so the numbered pages were reachable only via robots.txt.
  *
- * Built from the same `getSitemapUrls()` that robots.txt advertises, so index,
- * robots.txt and the servable pages cannot disagree about how many exist.
+ * Built from the same assembled list that robots.txt advertises, so index,
+ * robots.txt and the servable pages cannot disagree about how many exist — and
+ * each entry carries the newest `<lastmod>` on that page rather than the deploy
+ * date, so a crawler can skip pages that have not changed.
  */
 
 const XML_ESCAPES: Record<string, string> = {
@@ -39,11 +41,10 @@ export async function GET(): Promise<Response> {
   // `cacheComponents`-blessed opt-out — `export const dynamic` is disallowed.
   await connection();
 
-  const lastmod = LAST_MODIFIED.toISOString();
-  const entries = (await getSitemapUrls())
+  const entries = (await getSitemapPages())
     .map(
-      (url) =>
-        `  <sitemap>\n    <loc>${escapeXml(url)}</loc>\n    <lastmod>${lastmod}</lastmod>\n  </sitemap>`,
+      ({ url, lastModified }) =>
+        `  <sitemap>\n    <loc>${escapeXml(url)}</loc>\n    <lastmod>${lastModified.toISOString()}</lastmod>\n  </sitemap>`,
     )
     .join("\n");
 

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -6,13 +6,14 @@ import * as Sentry from "@sentry/nextjs";
 
 import { CONFIG } from "~/config/constants.ts";
 import { isCrawlable } from "~/config/seo.ts";
-import { env } from "~/env";
 import { prisma } from "~/lib/db";
+import {
+  BUILD_LAST_MODIFIED,
+  lastModifiedOf,
+  latestLastModified,
+} from "~/lib/lastModified";
 
 const MAX_URLS_PER_SITEMAP = 50000;
-export const LAST_MODIFIED = env.NEXT_PUBLIC_MODIFIED_DATE
-  ? new Date(env.NEXT_PUBLIC_MODIFIED_DATE)
-  : new Date();
 
 /**
  * `url` without its trailing slashes.
@@ -61,12 +62,24 @@ const isParallelSegment = (name: string) => name.startsWith("@");
 const isOptionalCatchAll = (name: string) =>
   name.startsWith("[[...") && name.endsWith("]]");
 
+/** One advertised URL and the date its content last changed. */
+interface SitemapEntry {
+  url: string;
+  lastModified: Date;
+}
+
 /** A family of database-backed URLs, e.g. every `/system/{solarSystemId}`. */
 interface EntitySource {
   /** Route prefix the ids hang off — `/system` yields `/system/30000142`. */
   path: string;
-  /** Resolves the ids to emit. A rejection degrades to an empty family. */
-  ids: () => Promise<number[]>;
+  /**
+   * Resolves the rows to emit. A rejection degrades to an empty family.
+   *
+   * Each row carries its own `updatedAt` so the sitemap can report a real
+   * per-URL `<lastmod>`. Selecting it costs one extra column on a query that
+   * already returns every row, and the assembled list is cached for an hour.
+   */
+  rows: () => Promise<{ id: number; updatedAt: Date | null }[]>;
 }
 
 /**
@@ -104,7 +117,7 @@ interface EntitySource {
 const ENTITY_SOURCES: EntitySource[] = [
   {
     path: "/type",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.type.findMany({
           // typeId 0 exists in the table but `/type/0` renders the not-found UI:
@@ -113,122 +126,127 @@ const ENTITY_SOURCES: EntitySource[] = [
           // boundary the response is still HTTP 200, so advertising it would
           // hand crawlers a soft 404 — the very thing `isDeleted` filters out.
           where: { isDeleted: false, typeId: { gt: 0 } },
-          select: { typeId: true },
+          select: { typeId: true, updatedAt: true },
           orderBy: { typeId: "asc" },
         })
-      ).map((row) => row.typeId),
+      ).map((row) => ({ id: row.typeId, updatedAt: row.updatedAt })),
   },
   {
     path: "/category",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.category.findMany({
           where: { isDeleted: false },
-          select: { categoryId: true },
+          select: { categoryId: true, updatedAt: true },
           orderBy: { categoryId: "asc" },
         })
-      ).map((row) => row.categoryId),
+      ).map((row) => ({ id: row.categoryId, updatedAt: row.updatedAt })),
   },
   {
     path: "/group",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.group.findMany({
           where: { isDeleted: false },
-          select: { groupId: true },
+          select: { groupId: true, updatedAt: true },
           orderBy: { groupId: "asc" },
         })
-      ).map((row) => row.groupId),
+      ).map((row) => ({ id: row.groupId, updatedAt: row.updatedAt })),
   },
   {
     path: "/region",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.region.findMany({
           where: { isDeleted: false },
-          select: { regionId: true },
+          select: { regionId: true, updatedAt: true },
           orderBy: { regionId: "asc" },
         })
-      ).map((row) => row.regionId),
+      ).map((row) => ({ id: row.regionId, updatedAt: row.updatedAt })),
   },
   {
     path: "/constellation",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.constellation.findMany({
           where: { isDeleted: false },
-          select: { constellationId: true },
+          select: { constellationId: true, updatedAt: true },
           orderBy: { constellationId: "asc" },
         })
-      ).map((row) => row.constellationId),
+      ).map((row) => ({ id: row.constellationId, updatedAt: row.updatedAt })),
   },
   {
     path: "/system",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.solarSystem.findMany({
           where: { isDeleted: false },
-          select: { solarSystemId: true },
+          select: { solarSystemId: true, updatedAt: true },
           orderBy: { solarSystemId: "asc" },
         })
-      ).map((row) => row.solarSystemId),
+      ).map((row) => ({ id: row.solarSystemId, updatedAt: row.updatedAt })),
   },
   {
     path: "/station",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.station.findMany({
           where: { isDeleted: false },
-          select: { stationId: true },
+          select: { stationId: true, updatedAt: true },
           orderBy: { stationId: "asc" },
         })
-      ).map((row) => row.stationId),
+      ).map((row) => ({ id: row.stationId, updatedAt: row.updatedAt })),
   },
   {
     path: "/faction",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.faction.findMany({
           where: { isDeleted: false },
-          select: { factionId: true },
+          select: { factionId: true, updatedAt: true },
           orderBy: { factionId: "asc" },
         })
-      ).map((row) => row.factionId),
+      ).map((row) => ({ id: row.factionId, updatedAt: row.updatedAt })),
   },
   {
     path: "/race",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.race.findMany({
           where: { isDeleted: false },
-          select: { raceId: true },
+          select: { raceId: true, updatedAt: true },
           orderBy: { raceId: "asc" },
         })
-      ).map((row) => row.raceId),
+      ).map((row) => ({ id: row.raceId, updatedAt: row.updatedAt })),
   },
   {
     path: "/bloodline",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.bloodline.findMany({
           where: { isDeleted: false },
-          select: { bloodlineId: true },
+          select: { bloodlineId: true, updatedAt: true },
           orderBy: { bloodlineId: "asc" },
         })
-      ).map((row) => row.bloodlineId),
+      ).map((row) => ({ id: row.bloodlineId, updatedAt: row.updatedAt })),
   },
   {
     // One page per NPC corporation that actually sells something, rather than
     // per corporation — a corp with no offers renders an empty store.
     path: "/lp-store",
-    ids: async () =>
+    rows: async () =>
       (
         await prisma.loyaltyStoreOffer.groupBy({
           by: ["corporationId"],
           where: { isDeleted: false },
+          // A store page is as fresh as its most recently changed offer.
+          _max: { updatedAt: true },
           orderBy: { corporationId: "asc" },
         })
-      ).map((row) => row.corporationId),
+      ).map((row) => ({
+        id: row.corporationId,
+        updatedAt: row._max.updatedAt,
+      })),
   },
 ];
 
@@ -247,7 +265,7 @@ const DEGRADED_REPORT_INTERVAL_MS = 60 * 1000;
 let cachedStaticRoutes: string[] | null = null;
 let lastDegradedReportAt = 0;
 let lastDegradedSignature = "";
-let cachedUrls: { urls: string[]; expiresAt: number } | null = null;
+let cachedEntries: { entries: SitemapEntry[]; expiresAt: number } | null = null;
 
 const hasPageFile = (entries: Dirent[]) =>
   entries.some((entry) => entry.isFile() && isPageFile(entry.name));
@@ -385,26 +403,35 @@ function reportDegraded(detail: {
  * cached: serving a truncated sitemap for the next hour because of one refused
  * connection tells crawlers those URLs are gone.
  */
-async function getAllUrls(): Promise<string[]> {
-  if (cachedUrls && cachedUrls.expiresAt > Date.now()) return cachedUrls.urls;
+async function getAllEntries(): Promise<SitemapEntry[]> {
+  if (cachedEntries && cachedEntries.expiresAt > Date.now()) {
+    return cachedEntries.entries;
+  }
 
   const [staticRoutes, families] = await Promise.all([
     getStaticRoutes(),
     Promise.all(
       ENTITY_SOURCES.map(async (source) => {
         try {
-          const ids = await source.ids();
+          const rows = await source.rows();
           return {
             ok: true,
             path: source.path,
-            paths: ids.map((id) => `${source.path}/${id}`),
+            entries: rows.map((row) => ({
+              path: `${source.path}/${row.id}`,
+              lastModified: lastModifiedOf(row.updatedAt),
+            })),
           };
         } catch (error: unknown) {
           console.error(
             `Failed to collect sitemap ids for ${source.path}.`,
             error,
           );
-          return { ok: false, path: source.path, paths: [] as string[] };
+          return {
+            ok: false,
+            path: source.path,
+            entries: [] as { path: string; lastModified: Date }[],
+          };
         }
       }),
     ),
@@ -414,9 +441,23 @@ async function getAllUrls(): Promise<string[]> {
   // sits under a disallowed prefix today, but the whole point of the shared
   // list is that a sitemap URL can never contradict robots.txt — enforcing that
   // in one place beats relying on nobody ever adding one that does.
-  const urls = [...staticRoutes, ...families.flatMap((family) => family.paths)]
-    .filter(isCrawlable)
-    .map((path) => `${SITE_URL}${path}`);
+  // Static routes are rendered from the source tree, so they change when the
+  // code changes — the commit date is the honest answer for them. Only
+  // database-backed families get a row-level date.
+  const staticEntries = staticRoutes.map((path) => ({
+    path,
+    lastModified: BUILD_LAST_MODIFIED,
+  }));
+
+  const entries = [
+    ...staticEntries,
+    ...families.flatMap((family) => family.entries),
+  ]
+    .filter((entry) => isCrawlable(entry.path))
+    .map((entry) => ({
+      url: `${SITE_URL}${entry.path}`,
+      lastModified: entry.lastModified,
+    }));
 
   // An empty static-route list means the `app/` walk failed — the real tree
   // always yields at least `/` — so it counts as degraded alongside a failed
@@ -428,15 +469,15 @@ async function getAllUrls(): Promise<string[]> {
   const healthy = !staticRoutesFailed && failedFamilies.length === 0;
 
   if (healthy) {
-    cachedUrls = { urls, expiresAt: Date.now() + URL_CACHE_TTL_MS };
+    cachedEntries = { entries, expiresAt: Date.now() + URL_CACHE_TTL_MS };
   } else {
     reportDegraded({
       failedFamilies,
       staticRoutesFailed,
-      urlCount: urls.length,
+      urlCount: entries.length,
     });
   }
-  return urls;
+  return entries;
 }
 
 function normalizeId(rawId: string): number {
@@ -447,8 +488,8 @@ function normalizeId(rawId: string): number {
 
 /** Number of `/sitemap/{n}.xml` pages needed, never fewer than one. */
 async function getSitemapCount(): Promise<number> {
-  const urls = await getAllUrls();
-  return Math.max(1, Math.ceil(urls.length / MAX_URLS_PER_SITEMAP));
+  const entries = await getAllEntries();
+  return Math.max(1, Math.ceil(entries.length / MAX_URLS_PER_SITEMAP));
 }
 
 /**
@@ -457,13 +498,32 @@ async function getSitemapCount(): Promise<number> {
  */
 export const SITEMAP_INDEX_URL = `${SITE_URL}/sitemap.xml`;
 
-/** Every `/sitemap/{n}.xml` page, i.e. the contents of the index. */
+/**
+ * Every `/sitemap/{n}.xml` page, each dated by the newest URL it contains.
+ *
+ * The index needs a `<lastmod>` per page, and the honest one is the freshest
+ * entry on that page — not the deploy date, which would tell a crawler that
+ * every page changed on every deploy and defeat the point of the per-URL dates
+ * below it.
+ */
+export async function getSitemapPages(): Promise<SitemapEntry[]> {
+  const entries = await getAllEntries();
+  const count = Math.max(1, Math.ceil(entries.length / MAX_URLS_PER_SITEMAP));
+  return Array.from({ length: count }, (_, index) => {
+    const page = entries.slice(
+      index * MAX_URLS_PER_SITEMAP,
+      (index + 1) * MAX_URLS_PER_SITEMAP,
+    );
+    return {
+      url: `${SITE_URL}/sitemap/${index}.xml`,
+      lastModified: latestLastModified(page.map((entry) => entry.lastModified)),
+    };
+  });
+}
+
+/** Just the page URLs — what robots.txt advertises. */
 export async function getSitemapUrls(): Promise<string[]> {
-  const count = await getSitemapCount();
-  return Array.from(
-    { length: count },
-    (_, index) => `${SITE_URL}/sitemap/${index}.xml`,
-  );
+  return (await getSitemapPages()).map((page) => page.url);
 }
 
 export async function generateSitemaps(): Promise<{ id: number }[]> {
@@ -475,12 +535,10 @@ export default async function sitemap(props: {
   id: Promise<string>;
 }): Promise<MetadataRoute.Sitemap> {
   const pageId = normalizeId(await props.id);
-  const urls = await getAllUrls();
+  const entries = await getAllEntries();
 
   const start = pageId * MAX_URLS_PER_SITEMAP;
-  if (start >= urls.length) return [];
+  if (start >= entries.length) return [];
 
-  return urls
-    .slice(start, start + MAX_URLS_PER_SITEMAP)
-    .map((url) => ({ url, lastModified: LAST_MODIFIED }));
+  return entries.slice(start, start + MAX_URLS_PER_SITEMAP);
 }

--- a/apps/web/lib/lastModified.ts
+++ b/apps/web/lib/lastModified.ts
@@ -32,7 +32,16 @@ export const BUILD_LAST_MODIFIED: Date = parseDate(
   env.NEXT_PUBLIC_MODIFIED_DATE,
 );
 
-function parseDate(value: Date | string | number | null | undefined): Date {
+/**
+ * Anything that can stand in for a timestamp here, including "not recorded".
+ *
+ * Wide on purpose: callers pass a Prisma `DateTime` (a `Date`), an ISO string
+ * from an env var or an API, or `null` from a nullable column — and the point
+ * of this module is that all of them normalize the same way.
+ */
+export type LastModifiedInput = Date | string | number | null | undefined;
+
+function parseDate(value: LastModifiedInput): Date {
   if (value === null || value === undefined) return new Date();
   const parsed = value instanceof Date ? value : new Date(value);
   // `new Date("nonsense")` yields an Invalid Date, whose getTime() is NaN and
@@ -48,9 +57,7 @@ function parseDate(value: Date | string | number | null | undefined): Date {
  * Prisma's `@updatedAt`, but a `groupBy` `_max` over an empty group yields
  * null, and older rows predate the column on some tables.
  */
-export function lastModifiedOf(
-  value: Date | string | number | null | undefined,
-): Date {
+export function lastModifiedOf(value: LastModifiedInput): Date {
   if (value === null || value === undefined) return BUILD_LAST_MODIFIED;
   const parsed = value instanceof Date ? value : new Date(value);
   return Number.isNaN(parsed.getTime()) ? BUILD_LAST_MODIFIED : parsed;
@@ -63,9 +70,7 @@ export function lastModifiedOf(
  * An empty input is the build date, not the epoch: "nothing here has a date"
  * means "as old as the deployment", never 1970.
  */
-export function latestLastModified(
-  values: Iterable<Date | string | number | null | undefined>,
-): Date {
+export function latestLastModified(values: Iterable<LastModifiedInput>): Date {
   let newest: Date | undefined;
   for (const value of values) {
     if (value === null || value === undefined) continue;

--- a/apps/web/lib/lastModified.ts
+++ b/apps/web/lib/lastModified.ts
@@ -1,0 +1,77 @@
+import { env } from "~/env";
+
+/**
+ * When a page last changed — the shared answer for sitemaps, `<meta>` tags and
+ * anything else that needs to tell a crawler or a reader how fresh a page is.
+ *
+ * There are two distinct sources of truth and using the wrong one is the bug
+ * this module exists to prevent:
+ *
+ * - **Source-tree content** (static pages, layouts, copy) changes when the code
+ *   changes → {@link BUILD_LAST_MODIFIED}.
+ * - **Database-backed content** (a type, a region, an LP store) changes when its
+ *   row changes → that row's own `updatedAt`, normalized by
+ *   {@link lastModifiedOf}.
+ *
+ * Reporting the build date for database-backed pages — which the sitemap did
+ * until now — tells crawlers that all ~50,000 item pages changed on every
+ * deploy. That burns crawl budget on unchanged pages and devalues the signal for
+ * the pages that genuinely did change.
+ */
+
+/**
+ * The commit date of `HEAD`, captured at build time by `getModifiedDate()` in
+ * `next.config.mjs` (which falls back to the build clock outside a git
+ * checkout). Client-safe: `NEXT_PUBLIC_MODIFIED_DATE` is in the client schema.
+ *
+ * Read through {@link lastModifiedOf} rather than parsed inline, so a malformed
+ * value degrades the same way everywhere instead of producing an `Invalid Date`
+ * that serializes as the string "Invalid Date".
+ */
+export const BUILD_LAST_MODIFIED: Date = parseDate(
+  env.NEXT_PUBLIC_MODIFIED_DATE,
+);
+
+function parseDate(value: Date | string | number | null | undefined): Date {
+  if (value === null || value === undefined) return new Date();
+  const parsed = value instanceof Date ? value : new Date(value);
+  // `new Date("nonsense")` yields an Invalid Date, whose getTime() is NaN and
+  // whose toISOString() throws — neither is something to put in a sitemap.
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+}
+
+/**
+ * A row's `updatedAt` as a usable date, falling back to the build date when the
+ * row has none.
+ *
+ * Nullable is the common case, not an edge case: `updatedAt` is populated by
+ * Prisma's `@updatedAt`, but a `groupBy` `_max` over an empty group yields
+ * null, and older rows predate the column on some tables.
+ */
+export function lastModifiedOf(
+  value: Date | string | number | null | undefined,
+): Date {
+  if (value === null || value === undefined) return BUILD_LAST_MODIFIED;
+  const parsed = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(parsed.getTime()) ? BUILD_LAST_MODIFIED : parsed;
+}
+
+/**
+ * The most recent of several timestamps — for a page assembled from many rows,
+ * or a sitemap page summarizing the URLs it contains.
+ *
+ * An empty input is the build date, not the epoch: "nothing here has a date"
+ * means "as old as the deployment", never 1970.
+ */
+export function latestLastModified(
+  values: Iterable<Date | string | number | null | undefined>,
+): Date {
+  let newest: Date | undefined;
+  for (const value of values) {
+    if (value === null || value === undefined) continue;
+    const parsed = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(parsed.getTime())) continue;
+    if (!newest || parsed > newest) newest = parsed;
+  }
+  return newest ?? BUILD_LAST_MODIFIED;
+}

--- a/apps/web/tests/sitemap.test.ts
+++ b/apps/web/tests/sitemap.test.ts
@@ -157,6 +157,7 @@ interface SitemapModule {
   default: (props: { id: Promise<string> }) => Promise<MetadataRoute.Sitemap>;
   generateSitemaps: () => Promise<{ id: number }[]>;
   getSitemapUrls: () => Promise<string[]>;
+  getSitemapPages: () => Promise<{ url: string; lastModified: Date }[]>;
 }
 
 function load(): SitemapModule {
@@ -183,6 +184,16 @@ function loadSitemapIndex(): SitemapIndexModule {
 }
 
 /** Every `<loc>` the sitemap would emit, across all of its pages. */
+/** Every emitted entry, across all sitemap pages. */
+async function allEntries(mod: SitemapModule): Promise<MetadataRoute.Sitemap> {
+  const pages = await mod.generateSitemaps();
+  const entries: MetadataRoute.Sitemap = [];
+  for (const { id } of pages) {
+    entries.push(...(await mod.default({ id: Promise.resolve(String(id)) })));
+  }
+  return entries;
+}
+
 async function allLocs(mod: SitemapModule): Promise<string[]> {
   const pages = await mod.generateSitemaps();
   const locs: string[] = [];
@@ -193,11 +204,19 @@ async function allLocs(mod: SitemapModule): Promise<string[]> {
   return locs;
 }
 
+/**
+ * Deliberately later than NEXT_PUBLIC_MODIFIED_DATE below, so the two sources of
+ * `lastmod` are distinguishable: rows carry their own date, source-tree routes
+ * carry the commit date.
+ */
+const ENTITY_UPDATED_AT = new Date("2026-06-15T12:00:00.000Z");
+const BUILD_DATE = "2026-01-01T00:00:00.000Z";
+
 describe("sitemap", () => {
   beforeEach(() => {
     jest.resetModules();
     mockEnv.NEXT_PUBLIC_SITE_URL = "https://www.jita.space";
-    mockEnv.NEXT_PUBLIC_MODIFIED_DATE = "2026-01-01T00:00:00.000Z";
+    mockEnv.NEXT_PUBLIC_MODIFIED_DATE = BUILD_DATE;
     // Reset rather than clear: a test that makes readdir reject would otherwise
     // leave that rejection in place for every test after it.
     mockReaddir.mockReset();
@@ -205,12 +224,93 @@ describe("sitemap", () => {
     for (const model of Object.keys(rows) as (keyof typeof rows)[]) {
       findManyMocks[model].mockReset();
       findManyMocks[model].mockResolvedValue(
-        rows[model].map((id) => ({ [idField[model]]: id })),
+        rows[model].map((id) => ({
+          [idField[model]]: id,
+          updatedAt: ENTITY_UPDATED_AT,
+        })),
       );
     }
     mockGroupBy.mockReset();
-    mockGroupBy.mockResolvedValue([{ corporationId: 1000035 }]);
+    // `_max` because the source aggregates: an LP store page is as fresh as its
+    // most recently changed offer.
+    mockGroupBy.mockResolvedValue([
+      { corporationId: 1000035, _max: { updatedAt: ENTITY_UPDATED_AT } },
+    ]);
     mockCaptureException.mockReset();
+  });
+
+  describe("lastmod", () => {
+    const iso = (value: MetadataRoute.Sitemap[number]["lastModified"]) =>
+      new Date(value as Date).toISOString();
+
+    it("dates a database-backed URL from its own row, not the deploy", async () => {
+      const entries = await allEntries(load());
+      const typeEntry = entries.find(
+        (entry) => entry.url === "https://www.jita.space/type/603",
+      );
+
+      expect(typeEntry).toBeDefined();
+      // The whole point of the change: reporting the build date here told
+      // crawlers all ~50k item pages changed on every deploy.
+      expect(iso(typeEntry!.lastModified)).toBe(
+        ENTITY_UPDATED_AT.toISOString(),
+      );
+      expect(iso(typeEntry!.lastModified)).not.toBe(BUILD_DATE);
+    });
+
+    it("dates a source-tree route from the commit", async () => {
+      const entries = await allEntries(load());
+      const home = entries.find(
+        (entry) => entry.url === "https://www.jita.space/",
+      );
+
+      expect(home).toBeDefined();
+      expect(iso(home!.lastModified)).toBe(BUILD_DATE);
+    });
+
+    it("aggregates the LP store page from its newest offer", async () => {
+      const entries = await allEntries(load());
+      const store = entries.find(
+        (entry) => entry.url === "https://www.jita.space/lp-store/1000035",
+      );
+
+      expect(store).toBeDefined();
+      expect(iso(store!.lastModified)).toBe(ENTITY_UPDATED_AT.toISOString());
+    });
+
+    it("falls back to the commit date when a row has no updatedAt", async () => {
+      findManyMocks.type.mockResolvedValue([{ typeId: 603, updatedAt: null }]);
+
+      const entries = await allEntries(load());
+      const typeEntry = entries.find(
+        (entry) => entry.url === "https://www.jita.space/type/603",
+      );
+
+      expect(iso(typeEntry!.lastModified)).toBe(BUILD_DATE);
+    });
+
+    it("never emits an invalid date", async () => {
+      findManyMocks.type.mockResolvedValue([
+        { typeId: 603, updatedAt: new Date("nonsense") },
+      ]);
+
+      const entries = await allEntries(load());
+      for (const entry of entries) {
+        expect(
+          Number.isNaN(new Date(entry.lastModified as Date).getTime()),
+        ).toBe(false);
+      }
+    });
+
+    it("dates each index page from the newest URL it contains", async () => {
+      const { getSitemapPages } = load();
+      const pages = await getSitemapPages();
+
+      expect(pages.length).toBeGreaterThan(0);
+      // Entity rows are newer than the commit, so the page they share must
+      // report the entity date rather than the deploy date.
+      expect(iso(pages[0]!.lastModified)).toBe(ENTITY_UPDATED_AT.toISOString());
+    });
   });
 
   it("emits only absolute URLs", async () => {


### PR DESCRIPTION
## The problem

Every URL in the sitemap — all ~50,000 — carried the same `<lastmod>`: the commit date of `HEAD`, captured at build time. Verified in production:

```
$ curl https://www.jita.space/sitemap/0.xml | grep -o '<lastmod>[^<]*' | sort -u | wc -l
1
```

So each deploy told crawlers the entire catalogue had changed. That burns crawl budget re-fetching unchanged pages and devalues the signal for the pages that genuinely did change.

## The data was already there

142 models carry `updatedAt @updatedAt`, including **all eleven** families the sitemap advertises (verified individually). The sitemap was querying those rows and discarding the timestamp.

Each family query now selects `updatedAt` alongside the id. `/lp-store` aggregates `_max` instead, since a store page is only as fresh as its most recently changed offer:

```ts
await prisma.loyaltyStoreOffer.groupBy({
  by: ["corporationId"],
  where: { isDeleted: false },
  _max: { updatedAt: true },
  orderBy: { corporationId: "asc" },
})
```

One extra column on queries that already return every row, and the assembled list is cached for an hour — the cost is nil.

**Static routes keep the commit date**, which is the honest answer for them: they render from the source tree, so they change when the code changes.

**The sitemap index** now dates each `/sitemap/{n}.xml` from the newest URL it contains, rather than repeating the deploy date — which would have defeated the per-URL dates underneath it.

## Reusable, per the ask

The shared logic moved to [`apps/web/lib/lastModified.ts`](apps/web/lib/lastModified.ts) so it isn't sitemap-private:

- `BUILD_LAST_MODIFIED` — the commit date, parsed once (it was duplicated inline in two places)
- `lastModifiedOf(value)` — a nullable row timestamp, falling back to the commit date
- `latestLastModified(values)` — for a page assembled from many rows

The normalization is the part that earns its place: `new Date("nonsense")` is an Invalid Date whose `toISOString()` **throws**, and a null `_max.updatedAt` over an empty group is routine. Both now degrade to the commit date instead of reaching the XML.

The module documents the distinction it exists to enforce — source-tree content uses the commit date, database-backed content uses its row's date — since picking the wrong one is exactly the bug being fixed.

### One place deliberately left alone

`app/status/page.client.tsx` still reads the env var directly. It renders `null` when unset rather than falling back, because showing a reader a fabricated "last updated" is worse than showing nothing. Different requirement, correctly different code — folding it into the shared module would have made it worse.

## Tests

Six added. Three fail if the per-row date is swapped back for the deploy date; all six were run against the old behaviour to confirm.

- a database-backed URL is dated from its row, and explicitly *not* the build date
- a source-tree route is dated from the commit
- the LP store page aggregates from its newest offer
- a row with no `updatedAt` falls back to the commit date
- no entry ever carries an invalid date
- each index page is dated from the newest URL it contains

The existing prisma mocks returned rows with no `updatedAt` and a `groupBy` with no `_max`, so they were updated to match what the real queries now request — without that they were quietly testing a shape the code no longer asks for.

```
apps/web   1163 tests   pass
type-check    0 errors
lint          0 errors
```

## After deploy

`/sitemap/0.xml` should show more than one distinct `<lastmod>`, with entity pages dated later than static ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)