### PR TITLE
perf(web): halve the /lp-store/all payload by dropping repeated key names

### DIFF
--- a/.changeset/lp-store-all-payload.md
+++ b/.changeset/lp-store-all-payload.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+The "All LP Store Offers" page is a lot lighter. It was sending about 8 MB to your browser on every visit, most of which was structural overhead rather than actual offer data, and the page now sends roughly half that — so it loads and becomes responsive noticeably faster, especially on mobile.

--- a/apps/web/app/lp-store/all/encoding.ts
+++ b/apps/web/app/lp-store/all/encoding.ts
@@ -1,0 +1,84 @@
+/**
+ * Positional encoding for the "all LP store offers" payload.
+ *
+ * This page hands ~33,000 offers from a server component to a client one, which
+ * means every offer is serialized twice: once into the rendered HTML and again
+ * into the RSC flight payload the browser parses to hydrate. Measured against
+ * production before this existed, the document was 7.9 MB and **75% of the
+ * flight payload was repeated JSON key names** — `"corporationId":` alone
+ * appeared 69,192 times, `"typeId":` 72,443. The numbers themselves were only
+ * about 2 MB of it.
+ *
+ * Tuples carry the same numbers without the keys. Nothing else changes: the
+ * client decodes them back into objects before rendering, so
+ * `LoyaltyPointsTable` still receives exactly the shape it always did.
+ *
+ * The labelled tuple elements below are the documentation — read them as the
+ * column order, and change `encodeOffer`/`decodeOffer` together if it ever
+ * moves.
+ */
+
+/** `[typeId, quantity]` — what an offer costs in items, besides ISK and LP. */
+export type EncodedRequiredItem = [typeId: number, quantity: number];
+
+export type EncodedOffer = [
+  offerId: number,
+  corporationId: number,
+  typeId: number,
+  quantity: number,
+  akCost: number | null,
+  lpCost: number,
+  iskCost: number,
+  requiredItems: EncodedRequiredItem[],
+];
+
+/** The decoded shape, i.e. what `LoyaltyPointsTable` consumes. */
+export interface LpStoreOffer {
+  offerId: number;
+  corporationId: number;
+  typeId: number;
+  quantity: number;
+  akCost: number | null;
+  lpCost: number;
+  iskCost: number;
+  requiredItems: { typeId: number; quantity: number }[];
+}
+
+export function encodeOffer(offer: LpStoreOffer): EncodedOffer {
+  return [
+    offer.offerId,
+    offer.corporationId,
+    offer.typeId,
+    offer.quantity,
+    offer.akCost,
+    offer.lpCost,
+    offer.iskCost,
+    offer.requiredItems.map((item) => [item.typeId, item.quantity]),
+  ];
+}
+
+export function decodeOffer(offer: EncodedOffer): LpStoreOffer {
+  const [
+    offerId,
+    corporationId,
+    typeId,
+    quantity,
+    akCost,
+    lpCost,
+    iskCost,
+    requiredItems,
+  ] = offer;
+  return {
+    offerId,
+    corporationId,
+    typeId,
+    quantity,
+    akCost,
+    lpCost,
+    iskCost,
+    requiredItems: requiredItems.map(([itemTypeId, itemQuantity]) => ({
+      typeId: itemTypeId,
+      quantity: itemQuantity,
+    })),
+  };
+}

--- a/apps/web/app/lp-store/all/page.client.tsx
+++ b/apps/web/app/lp-store/all/page.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import Link from "next/link";
 import {
   Anchor,
@@ -12,24 +13,19 @@ import {
 
 import { LPStoreIcon } from "@jitaspace/eve-icons";
 
+import type { EncodedOffer } from "./encoding";
 import { LoyaltyPointsTable } from "~/components/LPStore";
+import { decodeOffer } from "./encoding";
 
 export interface LPStoreAllPageProps {
   corporations: { corporationId: number; name: string }[];
   types: { typeId: number; name: string }[];
-  offers: {
-    offerId: number;
-    corporationId: number;
-    typeId: number;
-    quantity: number;
-    akCost: number | null;
-    lpCost: number;
-    iskCost: number;
-    requiredItems: {
-      typeId: number;
-      quantity: number;
-    }[];
-  }[];
+  /**
+   * Positionally encoded — see ./encoding. Every offer crosses the
+   * server/client boundary twice (rendered HTML plus the RSC flight payload),
+   * so at ~33,000 offers the repeated JSON key names cost more than the data.
+   */
+  offers: EncodedOffer[];
 }
 
 export default function LPStoreAllPage({
@@ -37,6 +33,10 @@ export default function LPStoreAllPage({
   types,
   offers,
 }: Readonly<LPStoreAllPageProps>) {
+  // Decoded once per payload, not per render: the table wants objects, and
+  // rebuilding 33,000 of them on every render would undo the point.
+  const decodedOffers = useMemo(() => offers.map(decodeOffer), [offers]);
+
   return (
     <Container size="xl">
       <Stack>
@@ -53,7 +53,7 @@ export default function LPStoreAllPage({
         </Breadcrumbs>
         <LoyaltyPointsTable
           corporations={corporations}
-          offers={offers}
+          offers={decodedOffers}
           types={types}
         />
       </Stack>

--- a/apps/web/app/lp-store/all/page.tsx
+++ b/apps/web/app/lp-store/all/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import type { LPStoreAllPageProps } from "./page.client";
 import { prisma } from "~/lib/db";
 import { collectLpStoreOfferTypeIds } from "./collectTypeIds";
+import { encodeOffer } from "./encoding";
 import LPStoreAllPage from "./page.client";
 
 export const metadata = {
@@ -51,21 +52,38 @@ export default async function Page() {
       select: {
         typeId: true,
         quantity: true,
+        // Needed to join, not to render — `encodeOffer` drops both, since an
+        // item nested under its offer already knows which offer it belongs to.
         offerId: true,
         corporationId: true,
       },
     });
 
-    offers = offersWithoutRequiredItems.map((offer) => ({
-      ...offer,
-      requiredItems: requiredItems.filter(
-        (item) =>
-          item.offerId === offer.offerId &&
-          item.corporationId === offer.corporationId,
-      ),
-      iskCost: Number(offer.iskCost),
-      lpCost: Number(offer.lpCost),
-    }));
+    // An offer is identified by (offerId, corporationId): the same offerId
+    // recurs across corporations. Grouping once turns what was a `.filter()`
+    // per offer — 33k offers x 36k items, about 1.2 billion comparisons on
+    // every cache fill — into a single pass.
+    const itemsByOffer = new Map<
+      string,
+      { typeId: number; quantity: number }[]
+    >();
+    for (const item of requiredItems) {
+      const key = `${item.offerId}:${item.corporationId}`;
+      const group = itemsByOffer.get(key);
+      const entry = { typeId: item.typeId, quantity: item.quantity };
+      if (group) group.push(entry);
+      else itemsByOffer.set(key, [entry]);
+    }
+
+    offers = offersWithoutRequiredItems.map((offer) =>
+      encodeOffer({
+        ...offer,
+        requiredItems:
+          itemsByOffer.get(`${offer.offerId}:${offer.corporationId}`) ?? [],
+        iskCost: Number(offer.iskCost),
+        lpCost: Number(offer.lpCost),
+      }),
+    );
 
     const typeIds = collectLpStoreOfferTypeIds(
       offersWithoutRequiredItems,

--- a/apps/web/tests/lpStoreAllPage.test.tsx
+++ b/apps/web/tests/lpStoreAllPage.test.tsx
@@ -14,9 +14,13 @@ import { render, screen } from "@testing-library/react";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
-    <a href={typeof href === "string" ? href : "#"}>{children}</a>
-  ),
+  default: ({
+    children,
+    href,
+  }: {
+    children?: React.ReactNode;
+    href?: string;
+  }) => <a href={typeof href === "string" ? href : "#"}>{children}</a>,
 }));
 
 jest.mock("@jitaspace/eve-icons", () => ({
@@ -35,6 +39,11 @@ jest.mock("~/components/LPStore", () => ({
   }) => (
     <div data-testid="lp-table">
       {`corps:${corporations.length} offers:${offers.length} types:${types.length}`}
+      {/* Serialized so the test can assert the table receives DECODED objects,
+          not the positional tuples the payload actually carries. */}
+      <span data-testid="lp-table-first-offer">
+        {JSON.stringify(offers[0] ?? null)}
+      </span>
     </div>
   ),
 }));
@@ -49,18 +58,22 @@ const TYPES = [
   { typeId: 34, name: "Tritanium" },
 ];
 
-const OFFERS = [
-  {
-    offerId: 1,
-    corporationId: 1000035,
-    typeId: 2929,
-    quantity: 1,
-    akCost: null,
-    lpCost: 1500,
-    iskCost: 5_000_000,
-    requiredItems: [{ typeId: 34, quantity: 10 }],
-  },
-];
+// Positionally encoded, matching what page.tsx now ships — see
+// ~/app/lp-store/all/encoding. Order: offerId, corporationId, typeId,
+// quantity, akCost, lpCost, iskCost, requiredItems.
+const OFFERS = [[1, 1000035, 2929, 1, null, 1500, 5_000_000, [[34, 10]]]];
+
+/** What the table must receive once the page has decoded the payload. */
+const DECODED_FIRST_OFFER = {
+  offerId: 1,
+  corporationId: 1000035,
+  typeId: 2929,
+  quantity: 1,
+  akCost: null,
+  lpCost: 1500,
+  iskCost: 5_000_000,
+  requiredItems: [{ typeId: 34, quantity: 10 }],
+};
 
 function renderPage(props: Record<string, unknown> = {}) {
   const Page = require("~/app/lp-store/all/page.client").default;
@@ -95,6 +108,19 @@ describe("LP Store all-offers page (client)", () => {
     expect(screen.getByTestId("lp-table")).toHaveTextContent(
       "corps:2 offers:1 types:2",
     );
+  });
+
+  it("decodes the positional payload before handing it to the table", () => {
+    renderPage();
+
+    // The wire format is tuples — 75% of this page's payload used to be
+    // repeated JSON key names — but the table's contract is unchanged, so the
+    // decode has to happen here.
+    const forwarded: unknown = JSON.parse(
+      screen.getByTestId("lp-table-first-offer").textContent,
+    );
+    expect(forwarded).toEqual(DECODED_FIRST_OFFER);
+    expect(Array.isArray(forwarded)).toBe(false);
   });
 
   it("renders with empty data sets", () => {

--- a/apps/web/tests/lpStoreEncoding.test.ts
+++ b/apps/web/tests/lpStoreEncoding.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { LpStoreOffer } from "~/app/lp-store/all/encoding";
+import { decodeOffer, encodeOffer } from "~/app/lp-store/all/encoding";
+
+const OFFER: LpStoreOffer = {
+  offerId: 1,
+  corporationId: 1000035,
+  typeId: 2929,
+  quantity: 1,
+  akCost: null,
+  lpCost: 1500,
+  iskCost: 5_000_000,
+  requiredItems: [
+    { typeId: 34, quantity: 10 },
+    { typeId: 35, quantity: 20 },
+  ],
+};
+
+describe("LP store offer encoding", () => {
+  it("round-trips an offer unchanged", () => {
+    expect(decodeOffer(encodeOffer(OFFER))).toEqual(OFFER);
+  });
+
+  it("round-trips an offer with no required items", () => {
+    const bare: LpStoreOffer = { ...OFFER, requiredItems: [] };
+    expect(decodeOffer(encodeOffer(bare))).toEqual(bare);
+  });
+
+  it("preserves a null akCost rather than coercing it", () => {
+    // akCost is nullable in the schema and 0 is a legitimate value, so the
+    // encoding must keep the two distinguishable.
+    expect(decodeOffer(encodeOffer({ ...OFFER, akCost: null })).akCost).toBeNull();
+    expect(decodeOffer(encodeOffer({ ...OFFER, akCost: 0 })).akCost).toBe(0);
+  });
+
+  it("survives a JSON round-trip, which is what the RSC payload does", () => {
+    const wire = JSON.parse(
+      JSON.stringify(encodeOffer(OFFER)),
+    ) as ReturnType<typeof encodeOffer>;
+    expect(decodeOffer(wire)).toEqual(OFFER);
+  });
+
+  it("is materially smaller on the wire than the object form", () => {
+    const asObject = JSON.stringify(OFFER).length;
+    const asTuple = JSON.stringify(encodeOffer(OFFER)).length;
+
+    // The whole point: repeated key names were 75% of this page's 7.9 MB
+    // payload. Guard the property, not a specific ratio.
+    expect(asTuple).toBeLessThan(asObject / 2);
+  });
+});


### PR DESCRIPTION
## Measured, not guessed

Fetched from production and analysed:

```
document                8,261,898 B  (7.9 MB)
└─ RSC flight payload   7,952,406 B  (96% of it)
   └─ repeated JSON key names ~5,924,867 B  (75% of the flight payload)
```

| key | occurrences | ≈ bytes |
| --- | ---: | ---: |
| `"corporationId"` | 69,192 | 1,314,648 |
| `"quantity"` | 69,011 | 966,154 |
| `"offerId"` | 69,011 | 897,143 |
| `"typeId"` | 72,443 | 869,316 |
| `"requiredItems"` | 32,881 | 624,739 |

The numbers themselves are only ~2 MB. Every offer crosses the server/client boundary **twice** — once rendered into HTML, once into the flight payload the browser parses to hydrate — so at ~33,000 offers the key names cost more than the data they label.

Brotli hides this on the wire (~206 KB), which is presumably why it went unnoticed. The browser still parses and hydrates all 7.9 MB.

## The change

Offers are positionally encoded in [`encoding.ts`](apps/web/app/lp-store/all/encoding.ts) and decoded on the client before rendering, so `LoyaltyPointsTable` receives **exactly the shape it always did** and is untouched.

```ts
// before, per offer (~130 B)
{"offerId":3418,"corporationId":1000144,"typeId":14298,"quantity":1,
 "akCost":0,"lpCost":2500,"iskCost":2500000,"requiredItems":[]}

// after (~40 B)
[3418,1000144,14298,1,0,2500,2500000,[]]
```

Projected against the real row counts (32,935 offers, 36,076 required items): the offers array drops **~5.2 MB → ~1.6 MB (68%)**, taking the document to roughly 4.5 MB.

Labelled tuple elements carry the column order in the type, so it reads as documentation rather than magic indices.

## Two things fall out of the same change

**~36,000 rows were carrying two dead fields.** The required-items query selects `offerId` and `corporationId` to do the join and then shipped them — the client's prop type only ever declared `{typeId, quantity}`, but excess-property checking doesn't fire on a value passed through a variable, so nothing caught it. The encoder drops them: an item nested under its offer already knows which offer it belongs to.

**The join was ~1.2 billion comparisons.** A `.filter()` over every required item, per offer — 32,935 × 36,076 — on every cache fill. Now one pass into a `Map` keyed `(offerId, corporationId)`. The *pair* matters: the same `offerId` recurs across corporations, which is exactly why the original predicate compared both.

## Tests

The page test's fixture moves to the encoded shape and now asserts the table receives **decoded objects**, so the round trip is covered end to end rather than assumed.

Five encoding tests: the round trip, the empty-required-items case, `akCost: null` staying distinguishable from `0` (both legitimate — one means "no Analysis Kredit cost", the other means "free"), a JSON round trip matching what the payload actually does, and that the tuple form is materially smaller — asserted as a property (`< half`), not a brittle ratio.

```
apps/web   1208 tests   pass
type-check    0 errors
lint          ✖ 30 problems (0 errors, 30 warnings)
```

## Not addressed here

The page still ships ~33,000 offers to the client. Encoding makes that ~1.6 MB instead of ~5.2 MB, but the structural fix — not sending rows nobody scrolls to — is pagination or server-side filtering, which changes the UX of a page whose whole point is "all offers". Worth a separate conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)