### PR TITLE
fix(turbo): stop hashing web-only client vars into every package

### DIFF
--- a/.changeset/killmail-and-footer-link-security.md
+++ b/.changeset/killmail-and-footer-link-security.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": patch
+---
+
+Fixed three external links (the EVE-Kill and zKillboard links on killmails, and
+the EVE Partner badge in the footer) that opened new tabs without the protection
+that stops the destination page from tampering with the tab it came from.

--- a/.changeset/killmail-and-footer-link-security.md
+++ b/.changeset/killmail-and-footer-link-security.md
@@ -1,7 +1,0 @@
----
-"@jitaspace/web": patch
----
-
-Fixed three external links (the EVE-Kill and zKillboard links on killmails, and
-the EVE Partner badge in the footer) that opened new tabs without the protection
-that stops the destination page from tampering with the tab it came from.

--- a/.changeset/outbound-link-referrer.md
+++ b/.changeset/outbound-link-referrer.md
@@ -1,0 +1,6 @@
+---
+"@jitaspace/web": patch
+---
+
+Outbound links to zKillboard and EVE-Kill on killmails, and to the EVE Partner
+page in the footer, no longer tell those sites which page you came from.

--- a/.changeset/restore-posthog-and-react-lint.md
+++ b/.changeset/restore-posthog-and-react-lint.md
@@ -1,7 +1,0 @@
----
-"@jitaspace/web": patch
----
-
-Fixed PostHog analytics never starting on the live site. The production build was dropping the PostHog configuration before it reached the app, so no usage data was ever recorded.
-
-Also fixed three external links (the EVE-Kill and zKillboard links on killmails, and the EVE Partner badge in the footer) that opened new tabs without the protection that stops the destination page from tampering with the tab it came from.

--- a/turbo.json
+++ b/turbo.json
@@ -19,24 +19,13 @@
     "NEXTAUTH_URL",
     "NEXT_PUBLIC_DISCORD_INVITE_LINK",
     "NEXT_PUBLIC_GOOGLE_TAG_ID",
-    // Read by apps/web/env.ts and inlined into the client bundle at build time.
-    // Listed here for the same reason as the NEXT_PUBLIC_* entries around them:
-    // to keep the set explicit and greppable. They are NOT load-bearing for the
-    // web build. Turbo detects apps/web as `nextjs`, and framework inference
-    // supplies every NEXT_PUBLIC_* var to that package's tasks whether or not it
-    // is declared here, so `envMode: "strict"` never stripped these from the
-    // Vercel build.
-    //
-    // Verified by swapping the web `build` script for an env probe and running
-    // it through turbo: an undeclared NEXT_PUBLIC_ZZZ_TEST arrived with its
-    // value, while an undeclared non-prefixed var arrived `undefined` — strict
-    // mode was active and stripping, and the NEXT_PUBLIC_ prefix survived it
-    // anyway. Note a `--dry-run=json` is NOT sufficient to show this: its
-    // `inferred` list describes the task hash, not the process environment.
-    "NEXT_PUBLIC_POSTHOG_HOST",
-    "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
+    // A NEXT_PUBLIC_* var read only by apps/web does NOT belong here: turbo
+    // infers that package as `nextjs` and already supplies and hashes the whole
+    // prefix for it, while a globalEnv entry hashes it into all 29 packages, so
+    // changing it turns over caches that never saw the value. SENTRY_DSN is
+    // listed because packages/background-jobs-triggerdev reads it too, and that
+    // package gets no framework inference.
     "NEXT_PUBLIC_SENTRY_DSN",
-    "NEXT_PUBLIC_SITE_URL",
     "NEXT_PUBLIC_UMAMI_WEBSITE_ID",
     "REDIS_URL",
     "SENTRY_AUTH_TOKEN",
@@ -123,8 +112,8 @@
     },
     // Not a kubb task at all: the script is `tsx scripts/generate-scopes.ts`,
     // and this package has neither a kubb.config.ts nor a swagger.json. Under
-    // the shared task's `inputs` no file matched, so the hash was constant and
-    // the task was a permanent cache hit — bumping the pinned ESI spec left the
+    // the shared task's `inputs` nothing it actually reads matched, so the hash
+    // was constant and the task was a permanent cache hit — bumping the pinned ESI spec left the
     // scope tables stale while reporting success. Declare what it actually
     // reads, including the sibling package's spec via $TURBO_ROOT$.
     "@jitaspace/esi-metadata#kubb:generate": {

--- a/turbo.json
+++ b/turbo.json
@@ -22,12 +22,17 @@
     // Read by apps/web/env.ts and inlined into the client bundle at build time.
     // Listed here for the same reason as the NEXT_PUBLIC_* entries around them:
     // to keep the set explicit and greppable. They are NOT load-bearing for the
-    // web build. Turbo detects apps/web as `nextjs` and framework inference
-    // already adds every NEXT_PUBLIC_* var to that package's task env and hash,
-    // whether or not it is declared — confirmed with
-    // `turbo run build --filter=@jitaspace/web --dry-run=json`, where an
-    // undeclared NEXT_PUBLIC_ probe still appears under `inferred`. So
-    // `envMode: "strict"` never stripped these from the Vercel build.
+    // web build. Turbo detects apps/web as `nextjs`, and framework inference
+    // supplies every NEXT_PUBLIC_* var to that package's tasks whether or not it
+    // is declared here, so `envMode: "strict"` never stripped these from the
+    // Vercel build.
+    //
+    // Verified by swapping the web `build` script for an env probe and running
+    // it through turbo: an undeclared NEXT_PUBLIC_ZZZ_TEST arrived with its
+    // value, while an undeclared non-prefixed var arrived `undefined` — strict
+    // mode was active and stripping, and the NEXT_PUBLIC_ prefix survived it
+    // anyway. Note a `--dry-run=json` is NOT sufficient to show this: its
+    // `inferred` list describes the task hash, not the process environment.
     "NEXT_PUBLIC_POSTHOG_HOST",
     "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
     "NEXT_PUBLIC_SENTRY_DSN",

--- a/turbo.json
+++ b/turbo.json
@@ -20,11 +20,15 @@
     "NEXT_PUBLIC_DISCORD_INVITE_LINK",
     "NEXT_PUBLIC_GOOGLE_TAG_ID",
     // A NEXT_PUBLIC_* var read only by apps/web does NOT belong here: turbo
-    // infers that package as `nextjs` and already supplies and hashes the whole
-    // prefix for it, while a globalEnv entry hashes it into all 29 packages, so
-    // changing it turns over caches that never saw the value. SENTRY_DSN is
-    // listed because packages/background-jobs-triggerdev reads it too, and that
-    // package gets no framework inference.
+    // infers that package as `nextjs` and hashes the whole prefix for it, so a
+    // globalEnv entry only adds the var to the other 25 packages' hashes,
+    // turning over caches that never saw the value. Delivery is not a reason
+    // either way — turbo passes NEXT_* through to every task process under
+    // envMode strict, declared or not. SENTRY_DSN stays for a different
+    // reason: packages/background-jobs-triggerdev reads it (src/trigger/
+    // init.ts:12) and has no `next` dependency, so eslint-plugin-turbo does
+    // not infer it either, and without this entry the
+    // turbo/no-undeclared-env-vars rule fails `pnpm lint`.
     "NEXT_PUBLIC_SENTRY_DSN",
     "NEXT_PUBLIC_UMAMI_WEBSITE_ID",
     "REDIS_URL",
@@ -112,8 +116,8 @@
     },
     // Not a kubb task at all: the script is `tsx scripts/generate-scopes.ts`,
     // and this package has neither a kubb.config.ts nor a swagger.json. Under
-    // the shared task's `inputs` nothing it actually reads matched, so the hash
-    // was constant and the task was a permanent cache hit — bumping the pinned ESI spec left the
+    // the shared task's `inputs` no file matched, so the hash was constant and
+    // the task was a permanent cache hit — bumping the pinned ESI spec left the
     // scope tables stale while reporting success. Declare what it actually
     // reads, including the sibling package's spec via $TURBO_ROOT$.
     "@jitaspace/esi-metadata#kubb:generate": {

--- a/turbo.json
+++ b/turbo.json
@@ -19,15 +19,15 @@
     "NEXTAUTH_URL",
     "NEXT_PUBLIC_DISCORD_INVITE_LINK",
     "NEXT_PUBLIC_GOOGLE_TAG_ID",
-    // The PostHog pair and NEXT_PUBLIC_SITE_URL are read by apps/web/env.ts and
-    // inlined into the client bundle at build time. Turbo defaults to
-    // `envMode: "strict"`, which REMOVES undeclared vars from the task process —
-    // not just from the hash. Locally `with-env` re-injects them from the root
-    // .env after turbo has filtered, but on Vercel there is no .env file, so
-    // they arrived undefined and `posthog.init` silently never ran. Declaring
-    // them here restores them to the build and puts them in the cache key, so
-    // rotating a token invalidates the build instead of restoring a .next with
-    // the old value baked in.
+    // Read by apps/web/env.ts and inlined into the client bundle at build time.
+    // Listed here for the same reason as the NEXT_PUBLIC_* entries around them:
+    // to keep the set explicit and greppable. They are NOT load-bearing for the
+    // web build. Turbo detects apps/web as `nextjs` and framework inference
+    // already adds every NEXT_PUBLIC_* var to that package's task env and hash,
+    // whether or not it is declared — confirmed with
+    // `turbo run build --filter=@jitaspace/web --dry-run=json`, where an
+    // undeclared NEXT_PUBLIC_ probe still appears under `inferred`. So
+    // `envMode: "strict"` never stripped these from the Vercel build.
     "NEXT_PUBLIC_POSTHOG_HOST",
     "NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN",
     "NEXT_PUBLIC_SENTRY_DSN",


### PR DESCRIPTION
#738 added three `NEXT_PUBLIC_*` entries to `globalEnv` to fix a production outage that never happened — [the claim is retracted](https://github.com/joaomlneto/jitaspace/pull/738#issuecomment-5386251151). This removes them, because they are not merely redundant: they cost cache.

## The measurement

A `globalEnv` entry feeds the **global** hash. Measured on `@jitaspace/utils#test` — a package that cannot read these values:

| run | `@jitaspace/utils#test` hash |
|---|---|
| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=aaa` | `a84b0643510d2bb4` |
| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN=bbb` | **`61ee4a6e3aaca41f`** ← cache turned over |
| undeclared `NEXT_PUBLIC_ZZZ_CONTROL`, either value | `a84b0643510d2bb4` (unchanged) |

The control is the point: an undeclared `NEXT_PUBLIC_*` var doesn't move a non-Next package's hash, because Turbo's `nextjs` framework inference hashes the prefix only for the packages it infers. A `globalEnv` entry hashes it for everything. After removal the hash holds at `fb7c3855ee77c8e6` across both values.

Four of the 29 workspaces infer `nextjs`, so the entries were adding a spurious hash input to the other 25.

**The win is real but small, and worth stating plainly:** no CI workflow sets any of these, so their value is constant there; `globalDependencies: ["**/.env"]` already flushes everything when a dev edits the root `.env`, which is where these live locally; and none has changed value since introduction. It costs three deleted lines in a file this PR was already touching.

## `NEXT_PUBLIC_SENTRY_DSN` stays — for a lint reason, not a runtime one

An earlier revision of this PR justified keeping it with "removing all four would have silently stopped Sentry reporting on Trigger.dev." **That was false, and it was the same invented-mechanism error this PR exists to retract.** Turbo passes `NEXT_*` to every task process under `envMode: strict` regardless of declaration or inference — inference governs *hashing*, not delivery. Verified by removing the entry entirely and probing that package's task:

```
@jitaspace/background-jobs-triggerdev:dsnprobe: DSN=https://real@sentry.io/123 CTRL=undefined
```

The DSN arrives with zero declarations; the control var is stripped in the same run, proving strict filtering was active.

The entry does need to stay, for a reason the earlier revision never gave. With it removed:

```
packages/background-jobs-triggerdev/src/trigger/init.ts
  12:8  error  NEXT_PUBLIC_SENTRY_DSN is not listed as a dependency in turbo.json  turbo/no-undeclared-env-vars
```

That package has no `next` dependency, so `eslint-plugin-turbo`'s own inference doesn't cover it. `apps/web` lints clean with the three entries removed because the plugin *does* infer that package. That asymmetry is the real one.

## The changeset is reworded, not deleted

An earlier revision deleted `restore-posthog-and-react-lint.md` outright, arguing that `CLAUDE.md`'s "`@jitaspace/web` — always for user-visible changes" excluded it. That reads a floor as a ceiling, and `apps/web/app/changelog/page.tsx` renders `CHANGELOG.md` at a public `/changelog` route, so the queue does reach users. #738's `rel="noreferrer"` additions are a real shipped change and deserve an accurate note rather than none.

The old note claimed they stop "the destination page from tampering with the tab it came from." They don't — `target="_blank"` already implies `rel="noopener"` in current browsers, so what these add is Referer suppression. It also implied a completeness it doesn't have: `apps/web` has 130 `target="_blank"` sites and roughly 115 carry no `rel`, including the same zkillboard destination at `app/kill/[killId]/page.client.tsx:149`, because the lint rule sees literal `<a>` and not `<Link>`/`<Anchor>`. Replaced with a note that claims only what the change does.

Real link hardening would be a codemod over the remaining sites plus a rule that understands `<Link>`/`<Anchor>` — its own PR.

## Verification

`pnpm lint` (0 errors, `manypkg` valid), `pnpm type-check` (41/41), `pnpm format:check` all pass. Both Cypress jobs went green on a full cold cache with the entries removed, which is the useful signal: the web build is not starved of the vars.

**Limits of the review:** an end-to-end check — build with a sentinel token and grep `.next` for it — was attempted but not completed. The evidence that the vars still reach the build is the task-process probe plus green CI builds, not a bundle grep.

## Follow-up, not in this PR

Four more claims merged by #738–#741 that don't survive testing. They live in files this PR doesn't touch:

- `tooling/eslint/base.ts:113` — "Next requires rewrites/redirects/headers to be `async`" is false; Next 16 types them `() => Promise<T> | T`.
- `tooling/eslint/react.ts:27` — "version-gated rules fall back to their most conservative behaviour" is backwards; the fallback is `999.999.999`, the most permissive.
- `.github/workflows/cypress.yml:41` — "the smoke suite hit it immediately" is false: four `cy.request` calls cannot evaluate the client bundle. So nothing in CI currently guards the placeholders that comment exists to justify.
- `.github/copilot-instructions.md:101` — "(parallel, 2 containers)" is stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdFxafXuCYmL5xgfvY2ZT8