### PR TITLE
docs: correct two comments, after testing five others that were fine

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,8 +37,11 @@ jobs:
       # in the browser it reads as undefined and apps/web/env.ts runs the client
       # schema regardless. A build without the required NEXT_PUBLIC_* values
       # therefore produces a bundle that throws "Invalid environment variables"
-      # on module evaluation of every page. That went unnoticed because the old
-      # example specs never loaded the app; the smoke suite hit it immediately.
+      # on module evaluation of every page. The old example specs never loaded
+      # the app, so it went unnoticed; the smoke suite's original `cy.visit` on
+      # /about caught it at once. That assertion was dropped in 8cabf0d8 (see
+      # the header of smoke.cy.ts), so nothing re-checks this today: cy.request
+      # never executes page JS, and these placeholders are currently unguarded.
       SKIP_ENV_VALIDATION: "1"
       DATABASE_URL: "postgresql://root@localhost:26257/jitaspace?sslmode=disable"
       REDIS_URL: "redis://localhost:6379"

--- a/tooling/eslint/base.ts
+++ b/tooling/eslint/base.ts
@@ -112,9 +112,10 @@ export const baseConfig = defineConfig(
   // and redirects) and the Sentry init files. They run in plain Node, and
   // several hooks in them are written `async` while never awaiting: rewrites,
   // redirects and headers in next.config.mjs, plus the `defineConfig(async
-  // () => …)` callbacks in the evetycoon and fuzzworks kubb configs. Nothing
-  // requires that: Next types all three as `() => T | Promise<T>`. It is our
-  // own convention, so require-await is off here rather than churning them.
+  // () => …)` callbacks in the evetycoon and fuzzworks kubb configs. Neither
+  // requires it — Next types all three as `() => T | Promise<T>`, and Kubb's
+  // defineConfig takes a PossiblePromise. Turning require-await off here is
+  // our own convention rather than churning the call sites.
   {
     files: ["**/*.config.{js,cjs,mjs,ts}", "**/scripts/**/*.{js,cjs,mjs,ts}"],
     languageOptions: {

--- a/tooling/eslint/base.ts
+++ b/tooling/eslint/base.ts
@@ -109,8 +109,12 @@ export const baseConfig = defineConfig(
   // Build/tooling configuration and standalone scripts. These were previously
   // excluded from lint wholesale by an `**/*.config.*` ignore — which caught
   // real executed code, including next.config.mjs (the CSP, security headers
-  // and redirects) and the Sentry init files. They run in plain Node, and Next
-  // requires rewrites/redirects/headers to be `async` even with no await.
+  // and redirects) and the Sentry init files. They run in plain Node, and
+  // several hooks in them are written `async` while never awaiting: rewrites,
+  // redirects and headers in next.config.mjs, plus the `defineConfig(async
+  // () => …)` callbacks in the evetycoon and fuzzworks kubb configs. Nothing
+  // requires that: Next types all three as `() => T | Promise<T>`. It is our
+  // own convention, so require-await is off here rather than churning them.
   {
     files: ["**/*.config.{js,cjs,mjs,ts}", "**/scripts/**/*.{js,cjs,mjs,ts}"],
     languageOptions: {


### PR DESCRIPTION
Follow-up to #744. An audit flagged seven mechanism claims in comments merged by #738–#741. Testing them empirically kept **two** and cleared **five** — including two I had already reported as false. The cleared five are documented below rather than quietly dropped, because "we checked and it was fine" is the useful half of this.

## Changed

### `tooling/eslint/base.ts` — the stated reason is false, the override is not

The comment claimed *"Next requires rewrites/redirects/headers to be `async` even with no await."* Next 16 types all three with a synchronous branch — `node_modules/next/dist/server/config-shared.d.ts`:

```ts
920:  headers?:   () => Promise<Header[]> | Header[];
926:  rewrites?:  () => Promise<Rewrite[] | { ... }>;
940:  redirects?: () => Promise<Redirect[]> | Redirect[];
```

**The `require-await` override stays — it is load-bearing.** Running the rule directly:

```
apps/web/next.config.mjs
  149:3  error  Async method 'rewrites' has no 'await' expression
  214:3  error  Async method 'redirects' has no 'await' expression
  235:3  error  Async method 'headers' has no 'await' expression
```

plus `defineConfig(async () => …)` in `packages/evetycoon-client/kubb.config.ts:8` and `packages/fuzzworks-market-client/kubb.config.ts:8`. Writing these `async` is our own convention, not a framework requirement, and the comment now says that.

### `.github/workflows/cypress.yml` — true when written, misleading now

*"the smoke suite hit it immediately"* was accurate: the suite's original `cy.visit` on `/about` did catch the unloadable client bundle. `8cabf0d8` dropped that assertion, leaving four `cy.request` calls — which never execute page JS.

So **nothing in CI currently re-checks the three `NEXT_PUBLIC_*` placeholders that comment sits above.** Remove them and CI stays green while the bundle throws on load. That is a coverage gap, and the comment now says so where someone will read it. Closing it means restoring a browser-render assertion, which is blocked on the React #418 hydration mismatch — its own PR.

## Left alone, after testing

**`tooling/eslint/react.ts`** — I reported *"version-gated rules fall back to their most conservative behaviour"* as backwards. **It is not.** `makeNoMethodSetStateRule.js:41-44`:

```js
function shouldBeNoop(context, methodName) {
  return methodName in methodNoopsAsOf
    && testReactVersion(context, methodNoopsAsOf[methodName])
    && !testReactVersion(context, '999.999.999'); // for when the version is not specified
}
```

The gate is negated. Unset makes the inner call true, so `shouldBeNoop` is **false** and the rule *runs*; a detected version noops it. The fallback checks more, not less. Correcting this would have written a false statement into shared tooling config.

**`.github/copilot-instructions.md:101`** — I reported *"(parallel, 2 containers)"* as stale. The `containers: [1, 2]` matrix carries no `if:`, so two containers always run; only `record` and `parallel` are gated on `CYPRESS_RECORD_KEY`. The line paraphrases the matrix and is accurate.

**`CLAUDE.md`** — *"the same codegen edges as `build`"*. The `dependsOn` arrays are not character-identical, but `^build` already supplies the generator closure, so the operative claim — that `pnpm lint` can no longer run ahead of the generators — holds.

**`AGENTS.md:18`** — the audit misread it; it never attributes a `db:generate` edge to `test`. **`AGENTS.md:79`** — "four-assertion" describes four `it()` cases, and two `cy.request` calls carry implicit status assertions, so no cleaner count exists.

## Verification

`pnpm lint` (0 errors, `manypkg` valid) and `pnpm format:check` pass. Comment-only changes; no behaviour is altered. The one new comment line was rewrapped to stay within the file's 80-column convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VdFxafXuCYmL5xgfvY2ZT8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdFxafXuCYmL5xgfvY2ZT8)_