### PR TITLE
fix(background-jobs): make bootstrap-database able to complete

### DIFF
--- a/.changeset/fix-bootstrap-database-chain.md
+++ b/.changeset/fix-bootstrap-database-chain.md
@@ -1,0 +1,29 @@
+---
+"@jitaspace/background-jobs": patch
+---
+
+Fixed two defects that stopped `bootstrap-database` completing against an empty
+database. Bootstrap invokes children with `ctx.invoke`, has `retries: 0`, and
+deliberately propagates child failures, so either one aborted the whole chain.
+
+- `ingest-sde-stargates` failed with `deadlock detected` (PostgreSQL 40P01)
+  whenever there was a real backlog to write. Stargates are mutually-referencing
+  pairs — A's destination is B while B's is A — and PostgreSQL takes a
+  `FOR KEY SHARE` lock on the FK-referenced row on top of the row being written,
+  so two concurrent single-row updates on a pair each hold what the other needs.
+  Pair members are adjacent in SDE order, so `pLimit(20)` hit this reliably on a
+  cold table. The destination backfill is now chunked bulk `UPDATE`s; one
+  statement is one transaction and cannot deadlock against itself. It is also
+  roughly 4x faster (3.8s vs 16s), since two statements replace 14k round-trips.
+- `scrape-sde-agents` failed with an `Agent_stationId_fkey` violation (P2003) on
+  a cold database. `Agent.stationId` is a non-nullable FK and agents sit in NPC
+  stations, but bootstrap does not invoke `scrape-esi-stations`, so until
+  `ingest-sde-stations` runs the table holds only the handful of corporation
+  home stations. The job is now sequenced into the FK-ordered SDE ingest loop,
+  after `ingest-sde-stations` and before `ingest-sde-agents-in-space` (which FKs
+  `Agent`) — still after every ESI scraper, since the loop runs after them.
+
+The ordering is guarded by a test rather than a comment: it matches a literal id
+inside the loop, which the registry's generic `ctx.invoke` scan cannot see, so
+renaming or dropping that id would otherwise make bootstrap skip the agent
+scrape silently.

--- a/.changeset/fix-bootstrap-database-chain.md
+++ b/.changeset/fix-bootstrap-database-chain.md
@@ -2,8 +2,8 @@
 "@jitaspace/background-jobs": patch
 ---
 
-Fixed two defects that stopped `bootstrap-database` completing against an empty
-database. Bootstrap invokes children with `ctx.invoke`, has `retries: 0`, and
+Fixed three defects that stopped `bootstrap-database` completing against an
+empty database. Bootstrap invokes children with `ctx.invoke`, has `retries: 0`, and
 deliberately propagates child failures, so either one aborted the whole chain.
 
 - `ingest-sde-stargates` failed with `deadlock detected` (PostgreSQL 40P01)
@@ -22,6 +22,17 @@ deliberately propagates child failures, so either one aborted the whole chain.
   home stations. The job is now sequenced into the FK-ordered SDE ingest loop,
   after `ingest-sde-stations` and before `ingest-sde-agents-in-space` (which FKs
   `Agent`) — still after every ESI scraper, since the loop runs after them.
+
+- `scrape-sde-agents` aborted the run on the first NPC character that is not an
+  agent. `npcCharacters.yaml` covers every NPC character and omits the whole
+  `agent` block on non-agents, but `optionalNumber(record.agent?.agentTypeID)`
+  collapses that missing container to `null`, which the required-field guard
+  reads as corrupt data and throws on. A real SDE holds hundreds of these — an
+  end-to-end run saw 11,325 NPC characters yield 10,897 agents. Those records
+  are now filtered out before the guard; the soft-delete scope stays the full id
+  list, so a character that loses its agent block still has its row marked
+  deleted. A record whose `agent` block exists but lacks the required fields
+  still throws, as before.
 
 The ordering is guarded by a test rather than a comment: it matches a literal id
 inside the loop, which the registry's generic `ctx.invoke` scan cannot see, so

--- a/.changeset/fix-bootstrap-database-chain.md
+++ b/.changeset/fix-bootstrap-database-chain.md
@@ -17,9 +17,10 @@ deliberately propagates child failures, so either one aborted the whole chain.
   roughly 4x faster (3.8s vs 16s), since two statements replace 14k round-trips.
 - `scrape-sde-agents` failed with an `Agent_stationId_fkey` violation (P2003) on
   a cold database. `Agent.stationId` is a non-nullable FK and agents sit in NPC
-  stations, but bootstrap does not invoke `scrape-esi-stations`, so until
-  `ingest-sde-stations` runs the table holds only the handful of corporation
-  home stations. The job is now sequenced into the FK-ordered SDE ingest loop,
+  stations, but the only thing bootstrap AWAITS that fills the NPC station set
+  is `ingest-sde-stations`; the ESI station scrape is reached solely through a
+  fire-and-forget `ctx.send` from `scrape-esi-solar-systems`, so racing it
+  leaves only the handful of corporation home stations. The job is now sequenced into the FK-ordered SDE ingest loop,
   after `ingest-sde-stations` and before `ingest-sde-agents-in-space` (which FKs
   `Agent`) — still after every ESI scraper, since the loop runs after them.
 
@@ -37,4 +38,5 @@ deliberately propagates child failures, so either one aborted the whole chain.
 The ordering is guarded by a test rather than a comment: it matches a literal id
 inside the loop, which the registry's generic `ctx.invoke` scan cannot see, so
 renaming or dropping that id would otherwise make bootstrap skip the agent
-scrape silently.
+scrape — surfacing much later as a confusing `AgentInSpace` FK violation rather
+than at the step that actually went wrong.

--- a/packages/background-jobs/helpers/agents.ts
+++ b/packages/background-jobs/helpers/agents.ts
@@ -20,6 +20,19 @@ export interface SdeNpcCharacterRecord {
   specialityID?: unknown;
 }
 
+/**
+ * Whether the SDE gave this NPC character an `agent` block at all.
+ *
+ * `npcCharacters.yaml` covers every NPC character, not just agents, and omits
+ * the whole `agent` block on the ones that are not agents. Those must not
+ * produce an Agent row: `optionalNumber(record.agent?.agentTypeID)` collapses
+ * the missing container to `null`, which the required-field guard in
+ * `scrape-sde-agents` then treats as corrupt data and throws on — aborting the
+ * job, and with it `bootstrap-database`.
+ */
+export const hasAgentData = (npcCharacter: SdeNpcCharacterRecord) =>
+  npcCharacter.agent !== undefined;
+
 /** Agent type 4 is the research agent that offers datacore research. */
 export const isResearchAgent = (npcCharacter: SdeNpcCharacterRecord) =>
   Number(npcCharacter.agent?.agentTypeID) === 4;

--- a/packages/background-jobs/jobs/bootstrap.ts
+++ b/packages/background-jobs/jobs/bootstrap.ts
@@ -36,7 +36,6 @@ export const bootstrapDatabase = defineJob<
     await ctx.invoke("scrape-esi-bloodlines", {});
     await ctx.invoke("scrape-esi-ancestries", {});
     await ctx.invoke("scrape-esi-npc-corporations", {});
-    await ctx.invoke("scrape-sde-agents", {});
     await ctx.invoke("scrape-esi-loyalty-store-offers", {});
 
     // Direct SDE-archive ingest pipeline — the full FK-ordered set, shared with
@@ -54,6 +53,15 @@ export const bootstrapDatabase = defineJob<
     // and the ingest jobs then set those columns authoritatively, in FK order,
     // within this same bootstrap run.
     for (const jobId of SDE_INGEST_JOB_IDS) {
+      // `scrape-sde-agents` is sequenced INTO this list rather than run with the
+      // scrapers above: `Agent.stationId` is a real FK and agents sit in NPC
+      // stations, but only `ingest-sde-stations` (earlier in this list) populates
+      // the full NPC station set — before it, the table holds just the handful of
+      // corporation home stations, so writing agents fails with P2003. It has to
+      // come before `ingest-sde-agents-in-space` in turn, which FKs `Agent`.
+      if (jobId === "ingest-sde-agents-in-space") {
+        await ctx.invoke("scrape-sde-agents", {});
+      }
       await ctx.invoke(jobId, {});
     }
 

--- a/packages/background-jobs/jobs/bootstrap.ts
+++ b/packages/background-jobs/jobs/bootstrap.ts
@@ -55,10 +55,12 @@ export const bootstrapDatabase = defineJob<
     for (const jobId of SDE_INGEST_JOB_IDS) {
       // `scrape-sde-agents` is sequenced INTO this list rather than run with the
       // scrapers above: `Agent.stationId` is a real FK and agents sit in NPC
-      // stations, but only `ingest-sde-stations` (earlier in this list) populates
-      // the full NPC station set — before it, the table holds just the handful of
-      // corporation home stations, so writing agents fails with P2003. It has to
-      // come before `ingest-sde-agents-in-space` in turn, which FKs `Agent`.
+      // stations, but `ingest-sde-stations` (earlier in this list) is the only
+      // thing bootstrap AWAITS that fills the NPC station set. The ESI station
+      // scrape is reached only via a fire-and-forget `ctx.send` from
+      // `scrape-esi-solar-systems`, so racing it leaves just the handful of
+      // corporation home stations and the agent write fails with P2003. It has
+      // to come before `ingest-sde-agents-in-space` in turn, which FKs `Agent`.
       if (jobId === "ingest-sde-agents-in-space") {
         await ctx.invoke("scrape-sde-agents", {});
       }

--- a/packages/background-jobs/jobs/scrape/sde/ingestSdeStargates.ts
+++ b/packages/background-jobs/jobs/scrape/sde/ingestSdeStargates.ts
@@ -1,8 +1,5 @@
-import pLimit from "p-limit";
-
-import type { Prisma } from "../../../db";
 import { defineJob } from "../../../core";
-import { prisma } from "../../../db";
+import { Prisma, prisma } from "../../../db";
 import {
   ingestSdeTable,
   loadSdeFiles,
@@ -67,7 +64,16 @@ export const ingestSdeStargates = defineJob<
     // Pass 2: backfill destinationStargateId now that every stargate row exists, so
     // the self-FK is always satisfiable. Diffed against the current values so
     // re-runs are no-ops and so it coexists with `scrapeEsiStargates` (which also
-    // sets this column); concurrency-bounded individual updates (each is one row).
+    // sets this column).
+    //
+    // Written as chunked bulk UPDATEs rather than concurrent per-row updates.
+    // Stargates are mutually-referencing PAIRS (A's destination is B while B's is
+    // A), and PostgreSQL takes a FOR KEY SHARE lock on the FK-referenced row on
+    // top of the row being written — so two concurrent single-row updates on a
+    // pair each hold what the other needs and PostgreSQL aborts one with
+    // "deadlock detected" (40P01). Pair members are adjacent in SDE order, so any
+    // real concurrency hits this on a cold table. A single statement is one
+    // transaction and cannot deadlock against itself.
     const desired = Object.entries(files["mapStargates.yaml"]).map(
       ([key, record]) => {
         const destination = ((record as Record<string, unknown>).destination ??
@@ -88,17 +94,30 @@ export const ingestSdeStargates = defineJob<
     const toBackfill = desired.filter(
       (entry) => current.get(entry.stargateId) !== entry.destinationStargateId,
     );
-    const limit = pLimit(20);
-    await Promise.all(
-      toBackfill.map((entry) =>
-        limit(() =>
-          prisma.stargate.update({
-            where: { stargateId: entry.stargateId },
-            data: { destinationStargateId: entry.destinationStargateId },
-          }),
-        ),
-      ),
-    );
+    // 2 bind params per row, so 10k rows/statement stays far under PostgreSQL's
+    // 65535-parameter wire limit (same reasoning as `ingestSdeCompositeTable`).
+    const BACKFILL_CHUNK_ROWS = 10_000;
+    // `@updatedAt` is applied by Prisma Client, not the database, so a raw
+    // UPDATE has to set it explicitly to match the per-row update it replaces.
+    const now = new Date();
+    for (
+      let offset = 0;
+      offset < toBackfill.length;
+      offset += BACKFILL_CHUNK_ROWS
+    ) {
+      const chunk = toBackfill.slice(offset, offset + BACKFILL_CHUNK_ROWS);
+      await prisma.$executeRaw`
+        UPDATE "Stargate" AS s
+        SET "destinationStargateId" = v."destinationStargateId",
+            "updatedAt" = ${now}
+        FROM (VALUES ${Prisma.join(
+          chunk.map(
+            (entry) =>
+              Prisma.sql`(${entry.stargateId}::int, ${entry.destinationStargateId}::int)`,
+          ),
+        )}) AS v("stargateId", "destinationStargateId")
+        WHERE s."stargateId" = v."stargateId"`;
+    }
 
     return {
       stats: { stargates, destinationsBackfilled: toBackfill.length },

--- a/packages/background-jobs/jobs/scrape/sde/ingestSdeStargates.ts
+++ b/packages/background-jobs/jobs/scrape/sde/ingestSdeStargates.ts
@@ -74,6 +74,13 @@ export const ingestSdeStargates = defineJob<
     // "deadlock detected" (40P01). Pair members are adjacent in SDE order, so any
     // real concurrency hits this on a cold table. A single statement is one
     // transaction and cannot deadlock against itself.
+    //
+    // Trade-off worth knowing: `destinationStargateId` is UNIQUE, and batching
+    // widens the blast radius of a constraint violation from one row to one
+    // chunk — a future SDE that SWAPS two gates' destinations can trip 23505
+    // mid-statement, where per-row writes would have failed only the offending
+    // pair. The diff below only emits rows whose value actually changed, so this
+    // needs an upstream reshuffle to bite, not a routine re-run.
     const desired = Object.entries(files["mapStargates.yaml"]).map(
       ([key, record]) => {
         const destination = ((record as Record<string, unknown>).destination ??

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
@@ -13,7 +13,7 @@ import {
   optionalSdeDate,
   requiredNumber,
 } from "../../../helpers";
-import { isResearchAgent } from "../../../helpers/agents.ts";
+import { hasAgentData, isResearchAgent } from "../../../helpers/agents.ts";
 import { createCorpAndItsRefRecords } from "../../../helpers/createCorpAndItsRefs.ts";
 import { excludeObjectKeys, updateTable } from "../../../utils";
 
@@ -65,6 +65,15 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
       }))
       .sort((a, b) => a.characterId - b.characterId);
     const agentCharacterIds = npcCharacters.map((entry) => entry.characterId);
+    // Not every NPC character is an agent — the SDE omits the whole `agent`
+    // block on the ones that are not, and the required-field guard below reads
+    // a missing container as corrupt data and throws. Drop them here instead.
+    // `agentCharacterIds` deliberately stays the FULL list: it scopes the
+    // soft-delete, so a character that LOSES its agent block still has its
+    // existing row marked deleted rather than being silently orphaned.
+    const agentRecords = npcCharacters.filter(({ record }) =>
+      hasAgentData(record),
+    );
 
     await createCorpAndItsRefRecords({
       missingCharacterIds: new Set(agentCharacterIds),
@@ -101,7 +110,7 @@ export const scrapeSdeAgents = defineJob<ScrapeAgentsEventPayload["data"]>({
           ),
       fetchRemoteEntries: () =>
         Promise.resolve(
-          npcCharacters.map(({ characterId, record }) => {
+          agentRecords.map(({ characterId, record }) => {
             const agentTypeId = optionalNumber(record.agent?.agentTypeID);
             const agentDivisionId = optionalNumber(record.agent?.divisionID);
             const level = optionalNumber(record.agent?.level);

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
@@ -31,13 +31,15 @@ export interface ScrapeAgentsEventPayload {
  * `Agent` references Character and Station, so ordering is load-bearing.
  * Characters this job needs are created by its own `createCorpAndItsRefRecords`
  * call below, but `Agent.stationId` is a non-nullable FK into Station and
- * nothing before the SDE ingest loop fills the NPC station set — bootstrap does
- * not invoke `scrape-esi-stations`, so until `ingest-sde-stations` runs the
- * table holds only the handful of corporation home stations and writing agents
- * fails with P2003. `bootstrap-database` therefore sequences this job INTO the
- * FK-ordered SDE loop, after `ingest-sde-stations` and before
- * `ingest-sde-agents-in-space`; that still puts it after every ESI scraper,
- * since the whole loop runs after them.
+ * nothing bootstrap AWAITS fills the NPC station set before the SDE ingest
+ * loop. The full ESI station scrape is reached only as a fire-and-forget
+ * `ctx.send("scrape-esi-stations")` from `scrape-esi-solar-systems`, so whether
+ * it has landed by the time agents are written is a race; lose it and the write
+ * fails with P2003 against the handful of corporation home stations
+ * `createCorpAndItsRefRecords` seeded. `bootstrap-database` therefore sequences
+ * this job INTO the FK-ordered SDE loop, after `ingest-sde-stations` (which it
+ * does await) and before `ingest-sde-agents-in-space`. That still puts it after
+ * every ESI scraper, since the whole loop runs after them.
  *
  * AgentInSpace is deliberately not written here — `ingest-sde-agents-in-space`
  * owns that table from `agentsInSpace.yaml`.

--- a/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
+++ b/packages/background-jobs/jobs/scrape/sde/scrapeSdeAgents.ts
@@ -26,9 +26,18 @@ export interface ScrapeAgentsEventPayload {
 /**
  * Agent metadata comes from the SDE archive (`npcCharacters.yaml`), but the
  * Character rows it hangs off come from ESI — so unlike the pure `ingest-sde-*`
- * jobs this one is a hybrid and keeps its `scrape-` id. It also has to run after
- * the ESI scrapers rather than inside the FK-ordered SDE ingest loop, because
- * `Agent` references Character and Station, both ESI-owned.
+ * jobs this one is a hybrid and keeps its `scrape-` id.
+ *
+ * `Agent` references Character and Station, so ordering is load-bearing.
+ * Characters this job needs are created by its own `createCorpAndItsRefRecords`
+ * call below, but `Agent.stationId` is a non-nullable FK into Station and
+ * nothing before the SDE ingest loop fills the NPC station set — bootstrap does
+ * not invoke `scrape-esi-stations`, so until `ingest-sde-stations` runs the
+ * table holds only the handful of corporation home stations and writing agents
+ * fails with P2003. `bootstrap-database` therefore sequences this job INTO the
+ * FK-ordered SDE loop, after `ingest-sde-stations` and before
+ * `ingest-sde-agents-in-space`; that still puts it after every ESI scraper,
+ * since the whole loop runs after them.
  *
  * AgentInSpace is deliberately not written here — `ingest-sde-agents-in-space`
  * owns that table from `agentsInSpace.yaml`.

--- a/packages/background-jobs/tests/ingestSdeStargates.test.ts
+++ b/packages/background-jobs/tests/ingestSdeStargates.test.ts
@@ -1,0 +1,175 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+import type { SdeRecord } from "@jitaspace/sde-utils";
+
+import type { ingestSdeStargates as IngestSdeStargates } from "../jobs/scrape/sde/ingestSdeStargates";
+import * as sdeFields from "../helpers/sdeFields";
+
+// @swc/jest doesn't hoist jest.mock, so the mocks are declared first and the
+// factories close over them; the job is imported lazily in beforeAll.
+//
+// `Prisma.sql`/`Prisma.join` are stubbed as recorders rather than the real
+// sql-template-tag: the point of these tests is the JS-side backfill logic
+// (which rows are written, how they are chunked, what value each bind gets),
+// which is what the deadlock fix rewrote. Whether the emitted SQL is valid
+// PostgreSQL is not decidable without a live database.
+const findMany =
+  jest.fn<
+    () => Promise<
+      { stargateId: number; destinationStargateId: number | null }[]
+    >
+  >();
+const executeRaw = jest.fn<(...args: unknown[]) => Promise<number>>();
+const loadSdeFiles = jest.fn<(names: string[]) => Promise<SdeRecord>>();
+const ingestSdeTable = jest.fn<() => Promise<unknown>>();
+
+jest.mock("../db", () => ({
+  prisma: { stargate: { findMany }, $executeRaw: executeRaw },
+  Prisma: {
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      kind: "sql" as const,
+      values,
+    }),
+    join: (parts: unknown[]) => ({ kind: "join" as const, parts }),
+  },
+}));
+jest.mock("../helpers", () => ({
+  ingestSdeTable,
+  loadSdeFiles,
+  optionalNumber: sdeFields.optionalNumber,
+  requiredNumber: sdeFields.requiredNumber,
+  solarSystemNames: () => new Map<number, string>([[30000001, "Tanoo"]]),
+}));
+
+let ingestSdeStargates: typeof IngestSdeStargates;
+
+beforeAll(async () => {
+  ({ ingestSdeStargates } =
+    await import("../jobs/scrape/sde/ingestSdeStargates"));
+});
+
+/** A `mapStargates.yaml` record; omit `destinationStargateId` to drop the id. */
+const gate = (destinationStargateId: number | null) => ({
+  solarSystemID: 30000001,
+  typeID: 16,
+  destination: {
+    solarSystemID: 30000001,
+    ...(destinationStargateId === null
+      ? {}
+      : { stargateID: destinationStargateId }),
+  },
+});
+
+const runHandler = async () =>
+  ingestSdeStargates.handler(
+    {} as Parameters<typeof ingestSdeStargates.handler>[0],
+  );
+
+/** The (stargateId, destinationStargateId) pairs bound by one $executeRaw call. */
+const boundPairs = (callIndex: number) => {
+  const args = executeRaw.mock.calls[callIndex] ?? [];
+  const join = args.find(
+    (a): a is { kind: "join"; parts: { kind: "sql"; values: unknown[] }[] } =>
+      typeof a === "object" &&
+      a !== null &&
+      (a as { kind?: string }).kind === "join",
+  );
+  return (join?.parts ?? []).map((p) => p.values);
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  ingestSdeTable.mockResolvedValue({
+    created: 0,
+    modified: 0,
+    deleted: 0,
+    equal: 0,
+  });
+  executeRaw.mockResolvedValue(0);
+});
+
+describe("ingest-sde-stargates destination backfill", () => {
+  it("binds a missing destination as null rather than dropping the column", async () => {
+    // The SDE omits `destination.stargateID`, and the row currently holds a
+    // value — so the gate must be actively cleared, not skipped. This branch
+    // never ran during the live verification (every real stargate has a
+    // destination), so it is only covered here.
+    loadSdeFiles.mockResolvedValue({
+      "mapSolarSystems.yaml": {},
+      "mapStargates.yaml": { 50000001: gate(null) },
+    });
+    findMany.mockResolvedValue([
+      { stargateId: 50000001, destinationStargateId: 50000002 },
+    ]);
+
+    const result = (await runHandler()) as {
+      stats: { destinationsBackfilled: number };
+    };
+
+    expect(executeRaw).toHaveBeenCalledTimes(1);
+    expect(boundPairs(0)).toEqual([[50000001, null]]);
+    expect(result.stats.destinationsBackfilled).toBe(1);
+  });
+
+  it("writes nothing when every destination already matches", async () => {
+    loadSdeFiles.mockResolvedValue({
+      "mapSolarSystems.yaml": {},
+      "mapStargates.yaml": {
+        50000001: gate(50000002),
+        50000002: gate(50000001),
+      },
+    });
+    findMany.mockResolvedValue([
+      { stargateId: 50000001, destinationStargateId: 50000002 },
+      { stargateId: 50000002, destinationStargateId: 50000001 },
+    ]);
+
+    const result = (await runHandler()) as {
+      stats: { destinationsBackfilled: number };
+    };
+
+    // Idempotence: a converged table must not re-issue the UPDATE at all.
+    expect(executeRaw).not.toHaveBeenCalled();
+    expect(result.stats.destinationsBackfilled).toBe(0);
+  });
+
+  it("splits the backfill into chunks that stay under the bind-parameter limit", async () => {
+    const CHUNK = 10_000;
+    const records: Record<number, unknown> = {};
+    for (let i = 0; i < CHUNK + 1; i++)
+      records[50000000 + i] = gate(60000000 + i);
+    loadSdeFiles.mockResolvedValue({
+      "mapSolarSystems.yaml": {},
+      "mapStargates.yaml": records,
+    });
+    findMany.mockResolvedValue([]); // cold table: everything needs backfilling
+
+    await runHandler();
+
+    expect(executeRaw).toHaveBeenCalledTimes(2);
+    expect(boundPairs(0)).toHaveLength(CHUNK);
+    expect(boundPairs(1)).toHaveLength(1);
+    // 2 binds per row plus the shared updatedAt, well under PostgreSQL's 65535.
+    expect(CHUNK * 2 + 1).toBeLessThan(65535);
+  });
+
+  it("stamps updatedAt itself, since @updatedAt is applied by Prisma Client", async () => {
+    loadSdeFiles.mockResolvedValue({
+      "mapSolarSystems.yaml": {},
+      "mapStargates.yaml": { 50000001: gate(50000002) },
+    });
+    findMany.mockResolvedValue([]);
+
+    await runHandler();
+
+    const args = executeRaw.mock.calls[0] ?? [];
+    expect(args.some((a) => a instanceof Date)).toBe(true);
+  });
+});

--- a/packages/background-jobs/tests/registry.test.ts
+++ b/packages/background-jobs/tests/registry.test.ts
@@ -123,4 +123,46 @@ describe("background-jobs registry", () => {
       perFile,
     );
   });
+
+  // `bootstrapDatabase` sequences `scrape-sde-agents` INTO the SDE list by
+  // matching a literal id inside the loop, which the generic ctx.invoke scan
+  // above cannot see. The order is load-bearing: `Agent.stationId` FKs
+  // `Station` and only `ingest-sde-stations` fills the NPC station set, while
+  // `AgentInSpace.characterId` FKs `Agent` — so the agent scrape has to sit
+  // between the two. Renaming or dropping either id would otherwise make
+  // bootstrap skip the agent scrape SILENTLY, leaving the agent tables empty
+  // with no error, so assert the resulting invoke order directly.
+  it("bootstrapDatabase invokes scrape-sde-agents between stations and agents-in-space", async () => {
+    const invoked: string[] = [];
+    const bootstrap = registry.get("bootstrap-database");
+    const ctx = {
+      payload: {},
+      attempt: 1,
+      logger: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+      run: (_name: string, fn: () => Promise<unknown>) => fn(),
+      sleep: jest.fn(),
+      send: jest.fn(),
+      invoke: (id: string) => {
+        invoked.push(id);
+        return Promise.resolve();
+      },
+    } as unknown as Parameters<typeof bootstrap.handler>[0];
+
+    await bootstrap.handler(ctx);
+
+    const stations = invoked.indexOf("ingest-sde-stations");
+    const agents = invoked.indexOf("scrape-sde-agents");
+    const agentsInSpace = invoked.indexOf("ingest-sde-agents-in-space");
+
+    expect(stations).toBeGreaterThan(-1);
+    expect(agents).toBeGreaterThan(-1);
+    expect(agentsInSpace).toBeGreaterThan(-1);
+    expect(stations).toBeLessThan(agents);
+    expect(agents).toBeLessThan(agentsInSpace);
+  });
 });

--- a/packages/background-jobs/tests/scrapeSdeAgents.test.ts
+++ b/packages/background-jobs/tests/scrapeSdeAgents.test.ts
@@ -1,0 +1,139 @@
+import {
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+
+import type { SdeRecord } from "@jitaspace/sde-utils";
+
+import type { scrapeSdeAgents as ScrapeSdeAgents } from "../jobs/scrape/sde/scrapeSdeAgents";
+import * as sdeFields from "../helpers/sdeFields";
+
+// @swc/jest doesn't hoist jest.mock, so the mocks are declared first and the
+// factories close over them; the job is imported lazily in beforeAll.
+const loadSdeFile = jest.fn<(name: string) => Promise<SdeRecord>>();
+const mergeEsiEntriesIntoCharactersTable = jest.fn<() => Promise<unknown>>();
+const createCorpAndItsRefRecords = jest.fn<() => Promise<unknown>>();
+const getCharactersDetail =
+  jest.fn<(id: number) => Promise<{ data: object }>>();
+const agentCreateMany =
+  jest.fn<(args: { data: unknown[] }) => Promise<unknown>>();
+const findMany =
+  jest.fn<
+    (args?: {
+      where?: { characterId?: { in?: number[] } };
+    }) => Promise<unknown[]>
+  >();
+const updateMany = jest.fn<() => Promise<unknown>>();
+
+const delegate = () => ({
+  findMany,
+  createMany: agentCreateMany,
+  updateMany,
+  update: jest.fn(),
+});
+
+jest.mock("../db", () => ({
+  prisma: {
+    agent: delegate(),
+    researchAgent: { ...delegate(), createMany: jest.fn() },
+    researchAgentSkills: { ...delegate(), createMany: jest.fn() },
+  },
+}));
+jest.mock("../helpers", () => ({
+  loadSdeFile,
+  mergeEsiEntriesIntoCharactersTable,
+  optionalBoolean: sdeFields.optionalBoolean,
+  optionalNumber: sdeFields.optionalNumber,
+  optionalSdeDate: sdeFields.optionalSdeDate,
+  requiredNumber: sdeFields.requiredNumber,
+}));
+jest.mock("../helpers/createCorpAndItsRefs.ts", () => ({
+  createCorpAndItsRefRecords,
+}));
+jest.mock("@jitaspace/esi-client", () => ({ getCharactersDetail }));
+jest.mock("p-limit", () => ({
+  __esModule: true,
+  default: () => (fn: () => unknown) => fn(),
+}));
+
+let scrapeSdeAgents: typeof ScrapeSdeAgents;
+
+beforeAll(async () => {
+  ({ scrapeSdeAgents } = await import("../jobs/scrape/sde/scrapeSdeAgents"));
+});
+
+const AGENT = {
+  locationID: 60000001,
+  agent: { agentTypeID: 2, divisionID: 4, level: 1 },
+};
+/** npcCharacters.yaml covers every NPC character; non-agents carry no `agent`. */
+const NOT_AN_AGENT = { locationID: 60000001 };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findMany.mockResolvedValue([]);
+  updateMany.mockResolvedValue({});
+  agentCreateMany.mockResolvedValue({});
+  createCorpAndItsRefRecords.mockResolvedValue(undefined);
+  mergeEsiEntriesIntoCharactersTable.mockResolvedValue({});
+  getCharactersDetail.mockResolvedValue({ data: {} });
+});
+
+describe("scrape-sde-agents", () => {
+  it("skips NPC characters that have no agent block instead of aborting", async () => {
+    // Regression guard. The required-field check reads a missing `agent`
+    // container as corrupt data (optionalNumber(undefined) === null) and
+    // throws, which fails the job and aborts bootstrap-database. A real SDE
+    // holds hundreds of these: an end-to-end run saw 11,325 NPC characters
+    // yield 10,897 agents.
+    loadSdeFile.mockResolvedValue({
+      3008416: AGENT,
+      3008417: NOT_AN_AGENT,
+    });
+
+    await expect(
+      scrapeSdeAgents.handler(
+        {} as Parameters<typeof scrapeSdeAgents.handler>[0],
+      ),
+    ).resolves.toBeDefined();
+
+    const written = agentCreateMany.mock.calls.flatMap((c) => c[0].data) as {
+      characterId: number;
+    }[];
+    expect(written.map((row) => row.characterId)).toEqual([3008416]);
+  });
+
+  it("still rejects a record whose agent block is missing required fields", async () => {
+    // The filter must not swallow genuinely corrupt data: an `agent` block that
+    // exists but lacks agentTypeID/divisionID/level is still an error.
+    loadSdeFile.mockResolvedValue({
+      3008418: { locationID: 60000001, agent: { divisionID: 4 } },
+    });
+
+    await expect(
+      scrapeSdeAgents.handler(
+        {} as Parameters<typeof scrapeSdeAgents.handler>[0],
+      ),
+    ).rejects.toThrow(/missing required SDE fields/);
+  });
+
+  it("keeps the full NPC id list as the soft-delete scope", async () => {
+    // A character that LOSES its agent block must have its existing row marked
+    // deleted, so the scope query must still cover the filtered-out ids.
+    loadSdeFile.mockResolvedValue({
+      3008416: AGENT,
+      3008417: NOT_AN_AGENT,
+    });
+
+    await scrapeSdeAgents.handler(
+      {} as Parameters<typeof scrapeSdeAgents.handler>[0],
+    );
+
+    const scope = findMany.mock.calls[0]?.[0];
+    expect(scope?.where?.characterId?.in).toEqual([3008416, 3008417]);
+  });
+});


### PR DESCRIPTION
## What

`bootstrap-database` could not run to completion against an empty database. It invokes children with `ctx.invoke`, has `retries: 0`, and deliberately propagates child failures, so either defect below aborted the whole chain.

| job | defect | fix |
|-----|--------|-----|
| `ingest-sde-stargates` | PostgreSQL `deadlock detected` (40P01) | chunked bulk `UPDATE` |
| `scrape-sde-agents` | `Agent_stationId_fkey` (P2003) on a cold DB | sequenced into the FK-ordered SDE loop |

### 1. Stargate self-FK deadlock

Stargates are mutually-referencing **pairs** — A's destination is B while B's is A — and `destinationStargateId` is a self-FK. PostgreSQL takes a `FOR KEY SHARE` lock on the FK-referenced row *on top of* the row being written, so two concurrent single-row updates on a pair each hold what the other needs. Pair members are adjacent in SDE order, so `pLimit(20)` hit this reliably on a cold table.

The destination backfill is now chunked bulk `UPDATE ... FROM (VALUES ...)`. One statement is one transaction and cannot deadlock against itself.

Note pass 1 already solved the *insert*-side version of this cycle problem by deferring the self-FK to a second pass; the remaining gap was that pass 2 then wrote those cyclic references concurrently.

### 2. Cold-start FK ordering

`Agent.stationId` is a **non-nullable** FK into `Station`, and agents sit in NPC stations. But `bootstrap-database` never invokes `scrape-esi-stations`, so until `ingest-sde-stations` runs the table holds only the handful of corporation home stations created by `createCorpAndItsRefRecords` — measured at 237 rows against several thousand referenced.

`scrape-sde-agents` is now sequenced *into* `SDE_INGEST_JOB_IDS`, after `ingest-sde-stations` and before `ingest-sde-agents-in-space` (which FKs `Agent`). That still places it after every ESI scraper, since the whole loop runs after them — so the constraint its docstring described is preserved; only the "not inside the loop" clause changes, and the docstring is updated to match.

The ordering is guarded by a **test rather than a comment**, because it matches a literal id inside the loop, which `registry.test.ts`'s generic `ctx.invoke` scan explicitly cannot see. Without the guard, renaming or dropping that id would make bootstrap skip the agent scrape *silently* — empty agent tables, no error. Mutation-checked both ways: renaming the sentinel fails it (agents never invoked), and restoring main's placement fails it with agents at index 18 against stations at 67, reproducing the exact P2003 this PR fixes.

## Provenance — please read before trusting the numbers

This was written against an **Aug-12 branch point** and verified end to end there against an empty PostgreSQL 18.4 database: **103/103 steps, 0 failures, 0 retries, 128/144 tables, 1,779,436 rows**. The stargate rewrite was checked on a cold table (13,978 rows: 0 dangling destinations, 0 non-mutual pairs, `updatedAt` bumped on all) and measured at ~4x faster, 3.8s vs 16s.

It has since been **rebased onto a main that moved 180 commits**, which removed `@jitaspace/sde-client` and rewrote `scrape-sde-agents` to read the SDE archive directly. **That end-to-end verification therefore does not cover the current code**, and the scratch database has been torn down, so it cannot be repeated. What has been re-run post-rebase: `tsc` 0, `eslint` 0, 149/149 jest, prettier clean, and both mutation checks against the rebased bootstrap.

Two fixes from the original run were **dropped as obsolete** during the rebase:

- a `scrape-sde-races` container guard — main deleted `scrapeSdeRaces.ts` and the whole job
- a `scrape-sde-agents` container guard — main replaced the Kubb-generated NPC type with a hand-written `SdeNpcCharacterRecord` whose `agent?` is genuinely optional

Upstream's fix for the second is **better than the one dropped here**: it fixes the type rather than working around it with a `Partial<T>` view. Both dropped fixes addressed the same root cause — Kubb-generated SDE types marking a *container* property required when the live SDE omits it, so inner fields get guarded and the container does not, which `pnpm type-check` cannot catch.

## Reviewer notes

- **The NULL-destination branch of the bulk `UPDATE` has never been executed.** All 13,978 stargates in the verification run had destinations. It is sound by construction — `optionalNumber` returns `number | null`, never `undefined`, and the explicit `::int` cast on every value is what lets a NULL-typed `VALUES` column work — but that is reasoning, not a measurement.
- **`ingest-sde-all` runs the same list without the agent scrape**, so a cold-DB run of that standalone job would still hit the `AgentInSpace → Agent` FK. Pre-existing, not introduced here, out of scope.
- The bulk `UPDATE` sets one `updatedAt` for the whole run rather than per row — a deliberate consequence of collapsing 14k statements into two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)