### PR TITLE
docs(changeset): stop the Kubb v4 note naming a package that no longer exists

### DIFF
--- a/.changeset/kubb-v4-upgrade.md
+++ b/.changeset/kubb-v4-upgrade.md
@@ -3,6 +3,6 @@
 "@jitaspace/background-jobs": patch
 ---
 
-Upgrade the Kubb API-client generator from v3 to v4 (`4.38.0`) across all five generated client packages (esi-client, sde-client, evekill-client, evetycoon-client, fuzzworks-market-client). The generated public API is preserved: `enumTypeSuffix: ""` keeps the existing `…Enum` type names (v4 defaults to a `Key` suffix), and the custom ESI client now exports the `Client` type that v4-generated code imports. The obsolete `@kubb/react` dependency was dropped (v4 plugins use `@kubb/react-fabric` internally).
+Upgrade the Kubb API-client generator from v3 to v4 (`4.38.0`) across all four generated client packages (esi-client, evekill-client, evetycoon-client, fuzzworks-market-client). The generated public API is preserved: `enumTypeSuffix: ""` keeps the existing `…Enum` type names (v4 defaults to a `Key` suffix), and the custom ESI client now exports the `Client` type that v4-generated code imports. The obsolete `@kubb/react` dependency was dropped (v4 plugins use `@kubb/react-fabric` internally).
 
 Two v4 codegen bugs that affected the ESI schema — object-array response types collapsing to a bare enum array (e.g. `UniverseNamesPost`, character/corporation assets, contacts, market orders), and private-identifier-shaped enum keys (e.g. mail-label colours like `#ccff9a`) being emitted unquoted — were fixed upstream ([kubb-labs/kubb#3475](https://github.com/kubb-labs/kubb/pull/3475), [#3476](https://github.com/kubb-labs/kubb/pull/3476)) and ship in `@kubb/plugin-ts@4.38.0`, so no local patch is required.


### PR DESCRIPTION
`.changeset/kubb-v4-upgrade.md` still described the Kubb v3 → v4 upgrade as covering "all **five** generated client packages (esi-client, **sde-client**, evekill-client, evetycoon-client, fuzzworks-market-client)".

`@jitaspace/sde-client` was removed in `82406a19` ("refactor: remove @jitaspace/sde-client, source SDE data from our database"), which landed *after* that changeset was written. Four remain, each with its own `kubb.config.ts`:

```
packages/esi-client/            packages/evetycoon-client/
packages/evekill-client/        packages/fuzzworks-market-client/
```

Changesets here are the release-notes queue rather than a release trigger — `changeset version`/`publish` are never run in CI, so entries accumulate as a changelog and ship as written. This one would have pointed readers at a package that isn't in the repo.

## What I checked and did *not* change

Every other claim in the note was re-verified against the tree and still holds, so none of it is touched:

| claim | evidence |
| --- | --- |
| `enumTypeSuffix: ""` preserves the `…Enum` names | present in all four remaining `kubb.config.ts` |
| the custom ESI client exports the `Client` type | `packages/esi-client/src/client.ts:62` |
| `@kubb/react` was dropped | no `package.json` in the repo references it |
| ships in `@kubb/plugin-ts@4.38.0` | pinned at `^4.38.0` |
| object-array responses no longer collapse to a bare enum array | `UniverseNamesPost.ts` is generated as an object array |
| `#`-shaped enum keys are emitted quoted | `CharactersCharacterIdMailLabelsGet.ts:8` — `"#0000fe": "#0000fe"` |

The `"@jitaspace/background-jobs": patch` bump in the frontmatter also stays: that package depends on `esi-client` and `evekill-client`, not on the one that was removed.

`grep -rn "sde-client" .changeset/` now returns nothing.

## Testing

Prose only — one line, no code touched. `pnpm format:check` (the `lint.yml` gate) passes.

No changeset for this PR: it edits the changeset queue itself, and adding an entry about fixing an entry would be noise. The changeset-bot warning is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)