### PR TITLE
feat(web): summarise corporation assets by value, items and locations

### DIFF
--- a/.changeset/corp-assets-value-summary.md
+++ b/.changeset/corp-assets-value-summary.md
@@ -1,0 +1,7 @@
+---
+"@jitaspace/web": minor
+---
+
+Corporation Assets now opens with a summary of what the corporation is holding — total value, number of items, and number of locations — in place of the plain asset count that was there before. This matches the header the Assets page already shows, so the two pages read the same way.
+
+The value covers everything the corporation owns, including items packed inside containers and ships. The table underneath deliberately lists only what sits directly in a station or structure, so the total will usually be higher than the rows you can see add up to.

--- a/apps/web/app/assets/character/page.tsx
+++ b/apps/web/app/assets/character/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { ReactNode } from "react";
 import { useCallback, useDeferredValue, useMemo, useState } from "react";
 import {
   ActionIcon,
@@ -28,20 +27,10 @@ import {
 import { ISKAmount } from "@jitaspace/ui";
 
 import { AssetSearchResults } from "~/components/Assets/AssetSearchResults";
+import { AssetStat } from "~/components/Assets/AssetStat";
 import { buildAssetTree } from "~/components/Assets/assetTree";
 import { CharacterAssetsTree } from "~/components/Assets/AssetTreeView";
 import { ScopeGuard } from "~/components/ScopeGuard";
-
-function Stat({ label, value }: Readonly<{ label: string; value: ReactNode }>) {
-  return (
-    <Stack gap={2}>
-      <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
-        {label}
-      </Text>
-      {value}
-    </Stack>
-  );
-}
 
 export default function Page() {
   // Every logged-in character that granted the assets scope, not just the
@@ -135,13 +124,13 @@ export default function Page() {
 
           <Paper withBorder radius="md" p="md">
             <SimpleGrid cols={3} spacing="md">
-              <Stat
+              <AssetStat
                 label="Value"
                 value={
                   <ISKAmount amount={tree.totalValue} fw={700} size="lg" />
                 }
               />
-              <Stat
+              <AssetStat
                 label="Items"
                 value={
                   <Text fw={700} size="lg">
@@ -149,7 +138,7 @@ export default function Page() {
                   </Text>
                 }
               />
-              <Stat
+              <AssetStat
                 label="Locations"
                 value={
                   <Text fw={700} size="lg">

--- a/apps/web/app/assets/corporation/page.tsx
+++ b/apps/web/app/assets/corporation/page.tsx
@@ -9,6 +9,8 @@ import {
   Group,
   Loader,
   Pagination,
+  Paper,
+  SimpleGrid,
   Stack,
   Table,
   Text,
@@ -30,7 +32,9 @@ import {
   useMarketPrices,
   useMultipleCorporationAssets,
 } from "@jitaspace/hooks";
+import { ISKAmount } from "@jitaspace/ui";
 
+import { AssetStat } from "~/components/Assets/AssetStat";
 import { ScopeGuard } from "~/components/ScopeGuard";
 
 export default function Page() {
@@ -93,23 +97,42 @@ export default function Page() {
     () =>
       Object.values(assets)
         .filter((asset) => asset.location_type !== "item")
-        .map((asset) => {
-          const adjustedPrice = marketPrices[asset.type_id]?.adjusted_price;
-          return {
-            typeName: getNameFromCache(asset.type_id),
-            price: adjustedPrice ? adjustedPrice * asset.quantity : undefined,
-            ...asset,
-          };
-        })
+        .map((asset) => ({
+          typeName: getNameFromCache(asset.type_id),
+          ...asset,
+        }))
         .sort((a, b) =>
           (a.typeName ?? "").trim().localeCompare((b.typeName ?? "").trim()),
         ),
-    [assets, getNameFromCache, marketPrices],
+    [assets, getNameFromCache],
   );
 
-  const _totalPrice = useMemo(
-    () => entries.reduce((acc, { price }) => (price ? acc + price : acc), 0),
-    [entries],
+  // Every asset the corporation holds, including the ones nested inside
+  // containers and ships. `entries` deliberately lists only what sits directly
+  // in a location, so summing over it would silently omit a hangar full of
+  // packaged goods and understate the total.
+  const totalValue = useMemo(
+    () =>
+      Object.values(assets).reduce(
+        (total, asset) =>
+          total +
+          (marketPrices[asset.type_id]?.adjusted_price ?? 0) * asset.quantity,
+        0,
+      ),
+    [assets, marketPrices],
+  );
+
+  // An asset whose location_type is "item" is inside another item, so its
+  // location_id names a container rather than a place; counting those would
+  // report far more locations than the corporation actually occupies.
+  const locationCount = useMemo(
+    () =>
+      new Set(
+        Object.values(assets)
+          .filter((asset) => asset.location_type !== "item")
+          .map((asset) => asset.location_id),
+      ).size,
+    [assets],
   );
 
   const numUndefinedNames = entries.filter(
@@ -174,9 +197,30 @@ export default function Page() {
           )}
           {corporationIds.length > 0 && (
             <>
-              <Text size="sm" c="dimmed">
-                {`${Object.keys(assets).length} assets`}
-              </Text>
+              <Paper withBorder radius="md" p="md">
+                <SimpleGrid cols={3} spacing="md">
+                  <AssetStat
+                    label="Value"
+                    value={<ISKAmount amount={totalValue} fw={700} size="lg" />}
+                  />
+                  <AssetStat
+                    label="Items"
+                    value={
+                      <Text fw={700} size="lg">
+                        {Object.keys(assets).length.toLocaleString()}
+                      </Text>
+                    }
+                  />
+                  <AssetStat
+                    label="Locations"
+                    value={
+                      <Text fw={700} size="lg">
+                        {locationCount.toLocaleString()}
+                      </Text>
+                    }
+                  />
+                </SimpleGrid>
+              </Paper>
               {numUndefinedNames > 0 && (
                 <Text c="red" size="sm">
                   Failed to resolve names for {numUndefinedNames} items! This

--- a/apps/web/components/Assets/AssetStat.tsx
+++ b/apps/web/components/Assets/AssetStat.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Stack, Text } from "@mantine/core";
+
+/**
+ * One labelled figure in the asset pages' summary grid.
+ *
+ * Shared by the character and corporation asset pages so the two headers stay
+ * identical by construction rather than by two copies drifting apart.
+ */
+export function AssetStat({
+  label,
+  value,
+}: Readonly<{ label: string; value: ReactNode }>) {
+  return (
+    <Stack gap={2}>
+      <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+        {label}
+      </Text>
+      {value}
+    </Stack>
+  );
+}

--- a/apps/web/tests/corporationAssetsPage.test.tsx
+++ b/apps/web/tests/corporationAssetsPage.test.tsx
@@ -36,22 +36,6 @@ jest.mock("@jitaspace/hooks", () => ({
   useMarketPrices: () => mockUseMarketPrices(),
 }));
 
-jest.mock("@jitaspace/ui", () => ({
-  TypeAvatar: () => null,
-  TypeAnchor: ({ children }: { children: ReactNode }) => (
-    <span>{children}</span>
-  ),
-  TypeName: ({ typeId }: { typeId: number }) => (
-    <span data-testid={`type-name-${typeId}`}>{typeId}</span>
-  ),
-  EveEntityAnchor: ({ children }: { children: ReactNode }) => (
-    <span>{children}</span>
-  ),
-  EveEntityName: ({ entityId }: { entityId: number }) => (
-    <span data-testid={`entity-name-${entityId}`}>{entityId}</span>
-  ),
-}));
-
 jest.mock("@jitaspace/eve-components", () => ({
   ...jest.requireActual<Record<string, unknown>>(
     "../__mocks__/@jitaspace/eve-components",
@@ -134,6 +118,18 @@ const SAMPLE_ASSETS: TaggedAsset[] = [
   },
 ];
 
+/** Sits inside another item, so its location_id names a container, not a place. */
+const NESTED_IN_CONTAINER: TaggedAsset = {
+  item_id: 2005,
+  subjectId: CORP,
+  type_id: 38,
+  quantity: 2,
+  location_id: 9000001,
+  location_type: "item",
+  is_singleton: false,
+  is_blueprint_copy: false,
+};
+
 /**
  * `subjectIds` is the corporations that were queried; `data` is what came back.
  * They are deliberately separate arguments here, because every case worth
@@ -158,6 +154,13 @@ const failure = (subjectId: number) => ({
   subjectId,
   error: new Error("boom"),
 });
+
+/** Read one summary tile's figure by its label. */
+function stat(label: string): string {
+  const tile = screen.getByText(label).parentElement;
+  if (!tile) throw new Error(`no stat tile labelled "${label}"`);
+  return tile.textContent.slice(label.length).trim();
+}
 
 function renderPage() {
   const Page = require("~/app/assets/corporation/page").default;
@@ -192,10 +195,53 @@ describe("Corporation Assets Page", () => {
     expect(screen.queryByTestId("select:Filter by corporation")).toBeNull();
   });
 
-  it("shows total asset count", () => {
+  it("shows the item count", () => {
     renderPage();
-    // Object.keys(SAMPLE_ASSETS).length = 4
-    expect(screen.getByText("4 assets")).toBeInTheDocument();
+    // Every asset counts, including the location_type "item" one the table omits.
+    expect(stat("Items")).toBe("4");
+  });
+
+  it("sums the value of every asset, including those inside containers", () => {
+    // Asset 2002 sits inside another item, so the table never lists it — but
+    // the corporation still owns it. Summing over the table's rows instead of
+    // over every asset would silently omit a hangar full of packaged goods.
+    mockUseMarketPrices.mockReturnValue({
+      data: {
+        34: { adjusted_price: 5 },
+        35: { adjusted_price: 10 },
+        36: { adjusted_price: 2 },
+        37: { adjusted_price: 100 },
+      },
+    });
+    renderPage();
+
+    // 1000*5 + 50*10 (the nested one) + 300*2 + 1*100
+    expect(stat("Value")).toBe((6200).toLocaleString());
+    // ...and the nested asset is still absent from the table itself.
+    expect(screen.getAllByRole("row")).toHaveLength(4); // header + 3
+  });
+
+  it("treats an asset with no market price as zero, not NaN", () => {
+    // 35 is present but carries no adjusted_price; 36 and 37 are absent
+    // entirely. Both must contribute nothing rather than poison the total.
+    mockUseMarketPrices.mockReturnValue({
+      data: { 34: { adjusted_price: 5 }, 35: {} },
+    });
+    renderPage();
+
+    // An exact total is the NaN check: a leaked NaN renders as "NaN" here.
+    expect(stat("Value")).toBe((5000).toLocaleString()); // 1000 * 5
+  });
+
+  it("counts distinct locations, not the containers assets sit in", () => {
+    mockUseMultipleCorporationAssets.mockReturnValue(
+      envelope([CORP], [...SAMPLE_ASSETS, NESTED_IN_CONTAINER]),
+    );
+    renderPage();
+
+    // 60003760 and 60008526 are places; 9000001 is a container's item_id.
+    expect(stat("Locations")).toBe("2");
+    expect(stat("Items")).toBe("5");
   });
 
   it("filters out assets with location_type 'item'", () => {
@@ -249,7 +295,7 @@ describe("Corporation Assets Page", () => {
     ).toBeInTheDocument();
     // The readable corporation's assets still render — previously any error
     // replaced the whole table.
-    expect(screen.getByText("4 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("4");
   });
 
   it("pluralises the failure notice", () => {
@@ -272,7 +318,7 @@ describe("Corporation Assets Page", () => {
     renderPage();
 
     expect(screen.getByText(/needs the Director role/)).toBeInTheDocument();
-    expect(screen.queryByText(/assets$/)).toBeNull();
+    expect(screen.queryByText("Items")).toBeNull();
   });
 
   it("shows an empty table, not the Director message, for a corporation that owns nothing", () => {
@@ -283,7 +329,7 @@ describe("Corporation Assets Page", () => {
     renderPage();
 
     expect(screen.queryByText(/needs the Director role/)).toBeNull();
-    expect(screen.getByText("0 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("0");
   });
 
   it("reports only the failure when every readable corporation errors", () => {
@@ -327,11 +373,11 @@ describe("Corporation Assets Page", () => {
       envelope([CORP, OTHER_CORP], [...SAMPLE_ASSETS, OTHER_CORP_ASSET]),
     );
     renderPage();
-    expect(screen.getByText("5 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("5");
 
     fireEvent.click(screen.getByTestId(`option:${OTHER_CORP}`));
 
-    expect(screen.getByText("1 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("1");
   });
 
   it("offers a corporation that owns nothing, and shows it as empty", () => {
@@ -344,7 +390,7 @@ describe("Corporation Assets Page", () => {
 
     fireEvent.click(screen.getByTestId(`option:${OTHER_CORP}`));
 
-    expect(screen.getByText("0 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("0");
   });
 
   it("ignores a pick for a corporation that is no longer readable", () => {
@@ -357,7 +403,7 @@ describe("Corporation Assets Page", () => {
     const { rerender } = renderPage();
 
     fireEvent.click(screen.getByTestId(`option:${OTHER_CORP}`));
-    expect(screen.getByText("1 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("1");
 
     mockUseMultipleCorporationAssets.mockReturnValue(
       envelope([CORP], SAMPLE_ASSETS),
@@ -370,7 +416,7 @@ describe("Corporation Assets Page", () => {
       </MantineProvider>,
     );
 
-    expect(screen.getByText("4 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("4");
   });
 
   it("returns to a valid page when narrowing to a smaller corporation", () => {
@@ -403,7 +449,7 @@ describe("Corporation Assets Page", () => {
     // OTHER_CORP has 40 assets, so page 2 no longer exists.
     fireEvent.click(screen.getByTestId(`option:${OTHER_CORP}`));
 
-    expect(screen.getByText("40 assets")).toBeInTheDocument();
+    expect(stat("Items")).toBe("40");
     expect(screen.getAllByRole("row")).toHaveLength(41); // header + 40
   });
 


### PR DESCRIPTION
> **Stacked on #753** — base is `claude/corp-assets-drop-dead-filter`, so the diff here shows only the price change. GitHub retargets this to `main` automatically once #753 merges.

## What

The corporation assets page computed a per-row `price` and a `_totalPrice` that **nothing ever rendered**. `_totalPrice` was underscore-prefixed purely to silence the unused-variable rule, so market prices were fetched and a running total accumulated on every render, for nothing.

This replaces it with the summary the character assets page already shows — **Value / Items / Locations** — above the table.

## The old total could not just be rendered

This is the part worth reviewing. The old `_totalPrice` reduced over `entries`:

```ts
Object.values(assets).filter((asset) => asset.location_type !== "item")
```

An asset with `location_type === "item"` is **inside another item** — a container, or a ship's hold. Those were filtered out, so every packaged item in a corp hangar contributed **zero**. Displaying that number as-is would have shipped an understated total that silently disagreed with the character page.

The new `totalValue` sums over every asset the corporation holds, matching how `buildAssetTree` computes the character page's Value — `?? 0` included, since the old `adjustedPrice ? … : undefined` also discarded a legitimate price of `0`.

`locationCount` counts distinct `location_id`s among assets **not** inside another item, because a nested asset's `location_id` names a container rather than a place. Structures arrive as `location_type: "other"` (per `packages/esi-client/swagger.json` and `AssetLocationName.tsx`) and are counted normally.

## Shared component

The character page's local `Stat` moved to `components/Assets/AssetStat.tsx`, used by both pages, so the two headers stay identical by construction instead of as two copies.

## Verification

- Full `apps/web` suite: 147 suites / **1381 tests** pass.
- **100% statements / branches / functions / lines** on all three changed source files. The price branches were previously unreachable by assertion because nothing displayed the value they fed.
- ESLint across all 30 packages: 0 errors. `tsc --noEmit`: clean in `apps/web`.
- Mutation-tested — each caught by exactly one test:
  - `totalValue` summing over `entries` instead of all assets (the bug this PR exists to avoid)
  - dropping the `?? 0` guard (renders `NaN`)
  - counting every `location_id` without excluding nested items

## Tests

`shows total asset count` and friends moved from asserting the old `"N assets"` string to reading tiles via a `stat(label)` helper. Three new tests cover the summary: the total including container contents, an unpriced asset contributing `0` rather than `NaN`, and locations counting places rather than containers.

The test file also drops its inline `jest.mock("@jitaspace/ui", …)`, which had gone stale — the page takes those components from `@jitaspace/eve-components` now, and the stale stub only served to hide `ISKAmount` from the shared one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)