### PR TITLE
Stop the market sidebar full-scanning the Type table

### DIFF
--- a/.changeset/market-tree-covering-index.md
+++ b/.changeset/market-tree-covering-index.md
@@ -1,0 +1,10 @@
+---
+"@jitaspace/db": patch
+"@jitaspace/web": patch
+---
+
+Made the market sidebar's data load dramatically cheaper on the database.
+
+Building the market tree read every type that belongs to a market group. Because the index on `Type.marketGroupId` did not contain `name`, and the query asked for `name`, CockroachDB gave up on the index and full-scanned the whole `Type` table — 52,859 rows and 18 MiB per execution, the bulk of it item `description` text that was read and immediately discarded. The index is now keyed on `(marketGroupId, name)` so the same read is served as an index-only scan.
+
+The two nested relation loads were also replaced with flat queries. Prisma resolved each nested relation as its own `WHERE <fk> IN (…all 2,109 market group ids…)` statement, and an `IN` list that large is exactly what pushed the planner onto a full scan; filtering on `IS NOT NULL` gives it a single index span instead. The market group `children` round trip is gone entirely — the parent/child edges were already available from `parentMarketGroupId`.

--- a/.changeset/market-tree-covering-index.md
+++ b/.changeset/market-tree-covering-index.md
@@ -1,10 +1,13 @@
 ---
 "@jitaspace/db": patch
-"@jitaspace/web": patch
 ---
 
-Made the market sidebar's data load dramatically cheaper on the database.
+Made the index on `Type.marketGroupId` cover `name`, keying it `(marketGroupId, name)`.
 
-Building the market tree read every type that belongs to a market group. Because the index on `Type.marketGroupId` did not contain `name`, and the query asked for `name`, CockroachDB gave up on the index and full-scanned the whole `Type` table — 52,859 rows and 18 MiB per execution, the bulk of it item `description` text that was read and immediately discarded. The index is now keyed on `(marketGroupId, name)` so the same read is served as an index-only scan.
+The market sidebar reads every type belonging to a market group and projects `name`. The old index was keyed `(marketGroupId, typeId)`, so `name` was uncovered and CockroachDB abandoned the index entirely, full-scanning `Type@Type_pkey` — 52,859 rows and 18 MiB per execution, the bulk of it item `description` text read and immediately discarded. That single statement was ~12% of all database usage. Covering the projection turns the same read into an index-only scan: 19,675 rows, 1.2 MiB. Verified on CockroachDB v26.2 loaded with the production table's shape.
 
-The two nested relation loads were also replaced with flat queries. Prisma resolved each nested relation as its own `WHERE <fk> IN (…all 2,109 market group ids…)` statement, and an `IN` list that large is exactly what pushed the planner onto a full scan; filtering on `IS NOT NULL` gives it a single index span instead. The market group `children` round trip is gone entirely — the parent/child edges were already available from `parentMarketGroupId`.
+The predicate is not what mattered: `marketGroupId IN (…2111 ids…)` and `marketGroupId IS NOT NULL` plan identically, and both full-scan while `name` is uncovered.
+
+`([marketGroupId]) STORING (name)` is the idiomatic form and is deliberately not used — Prisma cannot express it, and an index created out of band is dropped by `prisma db push`. The two forms are measurably indistinguishable (same plan, same 1.2 MiB read, 3.00 vs 2.95 MiB of index, identical write cost).
+
+Note this index cannot be installed by `pnpm db:push`: production's `Type` is `schema_locked`, and Prisma emits the swap in a form the server will not auto-unlock. Apply the `CREATE INDEX` / `DROP INDEX` pair directly — see the comment on the index in `schema.prisma`.

--- a/.changeset/market-tree-index-user-note.md
+++ b/.changeset/market-tree-index-user-note.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+The market sidebar now loads its category tree far more cheaply. Building the tree was by a wide margin the heaviest thing JitaSpace asked of its database — enough that it contributed to the site running out of database capacity — and it now reads about a fifteenth of the data to show you exactly the same thing.

--- a/apps/web/components/Market/MarketGroupsNavigation.tsx
+++ b/apps/web/components/Market/MarketGroupsNavigation.tsx
@@ -1,7 +1,7 @@
 import { cacheLife } from "next/cache";
 
-import type { MarketGroupIndex } from "./MarketGroupNavLink";
 import { prisma } from "~/lib/db";
+import { buildMarketGroupIndex } from "./buildMarketGroupIndex";
 import { MarketGroupNavLink } from "./MarketGroupNavLink";
 
 export async function MarketGroupsNavigation() {
@@ -17,15 +17,15 @@ export async function MarketGroupsNavigation() {
   // ~1.3 MiB today, against a 2 MiB limit.)
   cacheLife("days");
 
-  // Two flat reads, assembled below, rather than one `findMany` with nested
-  // `children`/`types` relations. Prisma resolves each nested relation as its
-  // own `WHERE <fk> IN (…every one of the 2109 market group ids…)` statement,
-  // and CockroachDB will not plan a constrained scan against an IN list that
-  // large — the types query in particular degraded into a FULL SCAN of
-  // Type@Type_pkey (52k rows / 18 MiB / ~1400 RUs a go). Filtering on
-  // `IS NOT NULL` instead gives the planner a single span over the covering
-  // (marketGroupId, name) index, and the parent/child edges are already implied
-  // by `parentMarketGroupId`, so the `children` round trip is pure waste.
+  // Two flat reads, assembled by buildMarketGroupIndex, rather than one
+  // `findMany` with nested `children`/`types` relations. Prisma resolves each
+  // nested relation as its own `WHERE <fk> IN (…every one of the 2109 market
+  // group ids…)` statement, and CockroachDB will not plan a constrained scan
+  // against an IN list that large — the types query in particular degraded into
+  // a FULL SCAN of Type@Type_pkey (52k rows / 18 MiB / ~1400 RUs a go).
+  // Filtering on `IS NOT NULL` instead gives the planner a single span over the
+  // covering (marketGroupId, name) index, and the parent/child edges are already
+  // implied by `parentMarketGroupId`, so the `children` round trip is pure waste.
   const [marketGroups, types] = await Promise.all([
     prisma.marketGroup.findMany({
       select: {
@@ -46,33 +46,7 @@ export async function MarketGroupsNavigation() {
     }),
   ]);
 
-  const marketGroupsIndex: MarketGroupIndex = {};
-  marketGroups.forEach(
-    (marketGroup) =>
-      (marketGroupsIndex[marketGroup.marketGroupId] = {
-        name: marketGroup.name,
-        parentMarketGroupId: marketGroup.parentMarketGroupId,
-        childrenMarketGroupIds: [],
-        types: [],
-        iconId: marketGroup.iconId,
-      }),
-  );
-
-  marketGroups.forEach((marketGroup) => {
-    if (marketGroup.parentMarketGroupId === null) return;
-    marketGroupsIndex[
-      marketGroup.parentMarketGroupId
-    ]?.childrenMarketGroupIds.push(marketGroup.marketGroupId);
-  });
-
-  types.forEach((type) => {
-    // Narrowed by the `not: null` filter above; Prisma still types it nullable.
-    if (type.marketGroupId === null) return;
-    marketGroupsIndex[type.marketGroupId]?.types.push({
-      typeId: type.typeId,
-      name: type.name,
-    });
-  });
+  const marketGroupsIndex = buildMarketGroupIndex(marketGroups, types);
 
   const rootMarketGroupIds = marketGroups
     .filter((marketGroup) => marketGroup.parentMarketGroupId === null)

--- a/apps/web/components/Market/MarketGroupsNavigation.tsx
+++ b/apps/web/components/Market/MarketGroupsNavigation.tsx
@@ -7,41 +7,44 @@ import { MarketGroupNavLink } from "./MarketGroupNavLink";
 export async function MarketGroupsNavigation() {
   "use cache";
   // Load the whole market tree (groups + their types) up front so expanding a
-  // group is instant — no per-group loading spinner. This is one large read of
-  // the Type table (Prisma resolves the `types` relation as
-  // `SELECT ... FROM "Type" WHERE "marketGroupId" IN (…all groups…)`), so it
-  // MUST stay cached: at "hours" it re-ran ~24×/day per region (and on every
-  // deploy) and became ~30% of the database's request-unit usage. The market
-  // taxonomy only moves when a new SDE build is ingested (rare), so cache it for
-  // a day. NB: if this payload ever exceeds the platform's per-entry data-cache
-  // limit it silently won't be stored and the query runs per request again —
-  // watch the DB's top statements after deploying.
+  // group is instant — no per-group loading spinner. That is ~19.7k type rows,
+  // so it MUST stay cached: at "hours" it re-ran ~24×/day per region (and on
+  // every deploy) and became ~30% of the database's request-unit usage. The
+  // market taxonomy only moves when a new SDE build is ingested (rare), so cache
+  // it for a day. NB: if this payload ever exceeds the platform's per-entry
+  // data-cache limit it silently won't be stored and the queries run per request
+  // again — watch the DB's top statements after deploying. (Serialized index is
+  // ~1.3 MiB today, against a 2 MiB limit.)
   cacheLife("days");
 
-  const marketGroups = await prisma.marketGroup.findMany({
-    select: {
-      marketGroupId: true,
-      name: true,
-      parentMarketGroupId: true,
-      children: {
-        select: {
-          marketGroupId: true,
-        },
+  // Two flat reads, assembled below, rather than one `findMany` with nested
+  // `children`/`types` relations. Prisma resolves each nested relation as its
+  // own `WHERE <fk> IN (…every one of the 2109 market group ids…)` statement,
+  // and CockroachDB will not plan a constrained scan against an IN list that
+  // large — the types query in particular degraded into a FULL SCAN of
+  // Type@Type_pkey (52k rows / 18 MiB / ~1400 RUs a go). Filtering on
+  // `IS NOT NULL` instead gives the planner a single span over the covering
+  // (marketGroupId, name) index, and the parent/child edges are already implied
+  // by `parentMarketGroupId`, so the `children` round trip is pure waste.
+  const [marketGroups, types] = await Promise.all([
+    prisma.marketGroup.findMany({
+      select: {
+        marketGroupId: true,
+        name: true,
+        parentMarketGroupId: true,
+        // Bundling the icon id here is what keeps the sidebar request-free:
+        // resolving it client-side used to cost two SDE lookups per group (the
+        // group, then its icon) plus an ESI market group call, i.e. ~3 requests
+        // per visible NavLink on load and on every expand. The icon server
+        // addresses images by icon id, so the id alone is enough — no join.
+        iconId: true,
       },
-      types: {
-        select: {
-          typeId: true,
-          name: true,
-        },
-      },
-      // Bundling the icon id here is what keeps the sidebar request-free:
-      // resolving it client-side used to cost two SDE lookups per group (the
-      // group, then its icon) plus an ESI market group call, i.e. ~3 requests
-      // per visible NavLink on load and on every expand. The icon server
-      // addresses images by icon id, so the id alone is enough — no join.
-      iconId: true,
-    },
-  });
+    }),
+    prisma.type.findMany({
+      where: { marketGroupId: { not: null } },
+      select: { typeId: true, name: true, marketGroupId: true },
+    }),
+  ]);
 
   const marketGroupsIndex: MarketGroupIndex = {};
   marketGroups.forEach(
@@ -49,13 +52,27 @@ export async function MarketGroupsNavigation() {
       (marketGroupsIndex[marketGroup.marketGroupId] = {
         name: marketGroup.name,
         parentMarketGroupId: marketGroup.parentMarketGroupId,
-        childrenMarketGroupIds: marketGroup.children.map(
-          (childMarketGroup) => childMarketGroup.marketGroupId,
-        ),
-        types: marketGroup.types,
+        childrenMarketGroupIds: [],
+        types: [],
         iconId: marketGroup.iconId,
       }),
   );
+
+  marketGroups.forEach((marketGroup) => {
+    if (marketGroup.parentMarketGroupId === null) return;
+    marketGroupsIndex[
+      marketGroup.parentMarketGroupId
+    ]?.childrenMarketGroupIds.push(marketGroup.marketGroupId);
+  });
+
+  types.forEach((type) => {
+    // Narrowed by the `not: null` filter above; Prisma still types it nullable.
+    if (type.marketGroupId === null) return;
+    marketGroupsIndex[type.marketGroupId]?.types.push({
+      typeId: type.typeId,
+      name: type.name,
+    });
+  });
 
   const rootMarketGroupIds = marketGroups
     .filter((marketGroup) => marketGroup.parentMarketGroupId === null)

--- a/apps/web/components/Market/MarketGroupsNavigation.tsx
+++ b/apps/web/components/Market/MarketGroupsNavigation.tsx
@@ -11,21 +11,26 @@ export async function MarketGroupsNavigation() {
   // so it MUST stay cached: at "hours" it re-ran ~24×/day per region (and on
   // every deploy) and became ~30% of the database's request-unit usage. The
   // market taxonomy only moves when a new SDE build is ingested (rare), so cache
-  // it for a day. NB: if this payload ever exceeds the platform's per-entry
-  // data-cache limit it silently won't be stored and the queries run per request
-  // again — watch the DB's top statements after deploying. (Serialized index is
-  // ~1.3 MiB today, against a 2 MiB limit.)
+  // it for a day. Caching is not a guarantee though — the entry is per-region
+  // and dies on every deploy, and this statement still reached ~12% of database
+  // usage while nominally cached for a day, so treat the covering index (not
+  // cacheLife) as what actually bounds the cost. The serialized index is ~1.3
+  // MiB; if a payload ever grows past what the platform will store it silently
+  // won't be, so watch the DB's top statements after deploying.
   cacheLife("days");
 
   // Two flat reads, assembled by buildMarketGroupIndex, rather than one
   // `findMany` with nested `children`/`types` relations. Prisma resolves each
-  // nested relation as its own `WHERE <fk> IN (…every one of the 2109 market
-  // group ids…)` statement, and CockroachDB will not plan a constrained scan
-  // against an IN list that large — the types query in particular degraded into
-  // a FULL SCAN of Type@Type_pkey (52k rows / 18 MiB / ~1400 RUs a go).
-  // Filtering on `IS NOT NULL` instead gives the planner a single span over the
-  // covering (marketGroupId, name) index, and the parent/child edges are already
-  // implied by `parentMarketGroupId`, so the `children` round trip is pure waste.
+  // nested relation as its own `WHERE <fk> IN (…every one of the ~2100 market
+  // group ids…)` statement, so `children` costs a whole round trip for edges
+  // `parentMarketGroupId` already gives us — that round trip is what this saves.
+  //
+  // It is NOT what fixed the full scan, and the IN list was never the problem:
+  // measured on the production cluster, `marketGroupId IN (…2111 ids…)` plans a
+  // perfectly good constrained index scan. What tips Type@Type_pkey into a FULL
+  // SCAN is projecting `name` while no index covers it — see the index comment
+  // on Type.marketGroupId in schema.prisma. Both predicates behave identically
+  // either side of that: uncovered, both full-scan; covered, both scan the index.
   const [marketGroups, types] = await Promise.all([
     prisma.marketGroup.findMany({
       select: {

--- a/apps/web/components/Market/buildMarketGroupIndex.ts
+++ b/apps/web/components/Market/buildMarketGroupIndex.ts
@@ -1,0 +1,64 @@
+import type { MarketGroupIndex } from "./MarketGroupNavLink";
+
+/** A market group row, as read for the sidebar. */
+export interface MarketGroupRow {
+  marketGroupId: number;
+  name: string;
+  parentMarketGroupId: number | null;
+  iconId: number | null;
+}
+
+/** A type row, as read for the sidebar. */
+export interface MarketTypeRow {
+  typeId: number;
+  name: string;
+  marketGroupId: number | null;
+}
+
+/**
+ * Assemble the sidebar's market tree from two flat reads.
+ *
+ * Kept separate from the query so the shape can be tested without a database:
+ * the alternative is Prisma's nested `children`/`types` relations, which cost
+ * two extra `WHERE <fk> IN (…all 2109 market group ids…)` statements and push
+ * CockroachDB off the covering index into a full scan of Type. See the index
+ * comment on `Type.marketGroupId` in schema.prisma.
+ *
+ * Rows referencing a market group that isn't in `marketGroups` are dropped
+ * rather than creating a placeholder, matching what the relation loads did —
+ * `MarketGroupNavLink` renders nothing for an id missing from the index.
+ */
+export function buildMarketGroupIndex(
+  marketGroups: MarketGroupRow[],
+  types: MarketTypeRow[],
+): MarketGroupIndex {
+  const index: MarketGroupIndex = {};
+
+  marketGroups.forEach((marketGroup) => {
+    index[marketGroup.marketGroupId] = {
+      name: marketGroup.name,
+      parentMarketGroupId: marketGroup.parentMarketGroupId,
+      childrenMarketGroupIds: [],
+      types: [],
+      iconId: marketGroup.iconId,
+    };
+  });
+
+  marketGroups.forEach((marketGroup) => {
+    if (marketGroup.parentMarketGroupId === null) return;
+    index[marketGroup.parentMarketGroupId]?.childrenMarketGroupIds.push(
+      marketGroup.marketGroupId,
+    );
+  });
+
+  types.forEach((type) => {
+    // Narrowed by the query's `not: null` filter; Prisma still types it nullable.
+    if (type.marketGroupId === null) return;
+    index[type.marketGroupId]?.types.push({
+      typeId: type.typeId,
+      name: type.name,
+    });
+  });
+
+  return index;
+}

--- a/apps/web/components/Market/buildMarketGroupIndex.ts
+++ b/apps/web/components/Market/buildMarketGroupIndex.ts
@@ -18,11 +18,12 @@ export interface MarketTypeRow {
 /**
  * Assemble the sidebar's market tree from two flat reads.
  *
- * Kept separate from the query so the shape can be tested without a database:
- * the alternative is Prisma's nested `children`/`types` relations, which cost
- * two extra `WHERE <fk> IN (…all 2109 market group ids…)` statements and push
- * CockroachDB off the covering index into a full scan of Type. See the index
- * comment on `Type.marketGroupId` in schema.prisma.
+ * Kept separate from the query so the shape can be tested without a database.
+ * Assembling here rather than through Prisma's nested `children`/`types`
+ * relations saves one round trip: `children` re-reads MarketGroup only to learn
+ * edges `parentMarketGroupId` already carries. That is the whole benefit — it
+ * does not affect the query plan, which turns on whether an index covers `name`
+ * (see the index comment on `Type.marketGroupId` in schema.prisma).
  *
  * Rows referencing a market group that isn't in `marketGroups` are dropped
  * rather than creating a placeholder, matching what the relation loads did —

--- a/apps/web/tests/buildMarketGroupIndex.test.ts
+++ b/apps/web/tests/buildMarketGroupIndex.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type {
+  MarketGroupRow,
+  MarketTypeRow,
+} from "~/components/Market/buildMarketGroupIndex";
+import { buildMarketGroupIndex } from "~/components/Market/buildMarketGroupIndex";
+
+const group = (
+  marketGroupId: number,
+  name: string,
+  parentMarketGroupId: number | null = null,
+  iconId: number | null = null,
+): MarketGroupRow => ({ marketGroupId, name, parentMarketGroupId, iconId });
+
+const type = (
+  typeId: number,
+  name: string,
+  marketGroupId: number | null,
+): MarketTypeRow => ({ typeId, name, marketGroupId });
+
+describe("buildMarketGroupIndex", () => {
+  it("indexes every market group by id, carrying name and icon", () => {
+    const index = buildMarketGroupIndex(
+      [group(1, "Ships", null, 1443), group(2, "Frigates", 1)],
+      [],
+    );
+
+    expect(Object.keys(index)).toHaveLength(2);
+    expect(index[1]).toEqual({
+      name: "Ships",
+      parentMarketGroupId: null,
+      childrenMarketGroupIds: [2],
+      types: [],
+      iconId: 1443,
+    });
+    expect(index[2]?.iconId).toBeNull();
+  });
+
+  it("derives child edges from parentMarketGroupId", () => {
+    const index = buildMarketGroupIndex(
+      [
+        group(1, "Ships"),
+        group(2, "Frigates", 1),
+        group(3, "Cruisers", 1),
+        group(4, "Assault Frigates", 2),
+      ],
+      [],
+    );
+
+    expect(index[1]?.childrenMarketGroupIds).toEqual([2, 3]);
+    expect(index[2]?.childrenMarketGroupIds).toEqual([4]);
+    expect(index[4]?.childrenMarketGroupIds).toEqual([]);
+  });
+
+  it("groups types under their market group", () => {
+    const index = buildMarketGroupIndex(
+      [group(1, "Ships"), group(2, "Frigates", 1)],
+      [type(587, "Rifter", 2), type(588, "Reaper", 2), type(670, "Capsule", 1)],
+    );
+
+    expect(index[2]?.types).toEqual([
+      { typeId: 587, name: "Rifter" },
+      { typeId: 588, name: "Reaper" },
+    ]);
+    expect(index[1]?.types).toEqual([{ typeId: 670, name: "Capsule" }]);
+  });
+
+  it("drops types with no market group", () => {
+    const index = buildMarketGroupIndex(
+      [group(1, "Ships")],
+      [type(587, "Rifter", 1), type(99, "Unlisted", null)],
+    );
+
+    expect(index[1]?.types).toEqual([{ typeId: 587, name: "Rifter" }]);
+  });
+
+  it("drops rows pointing at a market group that does not exist", () => {
+    const index = buildMarketGroupIndex(
+      [group(1, "Ships"), group(2, "Orphan", 404)],
+      [type(587, "Rifter", 909)],
+    );
+
+    // The dangling parent creates no placeholder entry...
+    expect(index[404]).toBeUndefined();
+    expect(index[909]).toBeUndefined();
+    // ...and the orphan group itself is still indexed, just unreachable.
+    expect(index[2]?.parentMarketGroupId).toBe(404);
+    expect(index[1]?.types).toEqual([]);
+  });
+
+  it("returns an empty index for empty input", () => {
+    expect(buildMarketGroupIndex([], [])).toEqual({});
+  });
+
+  it("keeps groups and types independent across the tree", () => {
+    const index = buildMarketGroupIndex(
+      [group(1, "Ships"), group(2, "Frigates", 1)],
+      [type(587, "Rifter", 2)],
+    );
+
+    // A type under a child must not leak into the parent's own list.
+    expect(index[1]?.types).toEqual([]);
+    expect(index[2]?.types).toHaveLength(1);
+  });
+});

--- a/apps/web/tests/marketGroupsNavigation.test.tsx
+++ b/apps/web/tests/marketGroupsNavigation.test.tsx
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+// @swc/jest does not hoist jest.mock above imports, so register the mocks first
+// and lazy-require the component. `cacheLife` is a no-op here — the caching
+// behaviour is Next's, what matters is the queries and the tree that comes out.
+jest.mock("next/cache", () => ({ cacheLife: jest.fn() }));
+
+const marketGroupFindMany = jest.fn<() => Promise<Record<string, unknown>[]>>();
+const typeFindMany = jest.fn<() => Promise<Record<string, unknown>[]>>();
+
+jest.mock("~/lib/db", () => ({
+  prisma: {
+    marketGroup: { findMany: () => marketGroupFindMany() },
+    type: { findMany: () => typeFindMany() },
+  },
+}));
+
+jest.mock("~/components/Market/MarketGroupNavLink", () => ({
+  MarketGroupNavLink: () => null,
+}));
+
+const { MarketGroupsNavigation } =
+  require("~/components/Market/MarketGroupsNavigation") as {
+    MarketGroupsNavigation: () => Promise<{
+      props: {
+        children: {
+          key: string | null;
+          props: {
+            marketGroupId: number;
+            marketGroups: Record<
+              number,
+              {
+                name: string;
+                childrenMarketGroupIds: number[];
+                types: { typeId: number; name: string }[];
+              }
+            >;
+          };
+        }[];
+      };
+    }>;
+  };
+
+describe("MarketGroupsNavigation", () => {
+  beforeEach(() => {
+    marketGroupFindMany.mockReset();
+    typeFindMany.mockReset();
+  });
+
+  it("renders one nav link per root group, sorted by name", async () => {
+    marketGroupFindMany.mockResolvedValue([
+      { marketGroupId: 1, name: "Ships", parentMarketGroupId: null, iconId: 1 },
+      {
+        marketGroupId: 2,
+        name: "Ammunition",
+        parentMarketGroupId: null,
+        iconId: 2,
+      },
+      { marketGroupId: 3, name: "Frigates", parentMarketGroupId: 1, iconId: 3 },
+    ]);
+    typeFindMany.mockResolvedValue([]);
+
+    const result = await MarketGroupsNavigation();
+    const links = result.props.children;
+
+    // Only roots get a link, and "Ammunition" sorts before "Ships".
+    expect(links.map((link) => link.props.marketGroupId)).toEqual([2, 1]);
+  });
+
+  it("hands each link the whole assembled tree", async () => {
+    marketGroupFindMany.mockResolvedValue([
+      { marketGroupId: 1, name: "Ships", parentMarketGroupId: null, iconId: 1 },
+      { marketGroupId: 3, name: "Frigates", parentMarketGroupId: 1, iconId: 3 },
+    ]);
+    typeFindMany.mockResolvedValue([
+      { typeId: 587, name: "Rifter", marketGroupId: 3 },
+    ]);
+
+    const result = await MarketGroupsNavigation();
+    const index = result.props.children[0]!.props.marketGroups;
+
+    expect(index[1]?.childrenMarketGroupIds).toEqual([3]);
+    expect(index[3]?.types).toEqual([{ typeId: 587, name: "Rifter" }]);
+  });
+
+  it("renders nothing when there are no market groups", async () => {
+    marketGroupFindMany.mockResolvedValue([]);
+    typeFindMany.mockResolvedValue([]);
+
+    const result = await MarketGroupsNavigation();
+
+    expect(result.props.children).toEqual([]);
+  });
+});

--- a/apps/web/tests/marketGroupsNavigation.test.tsx
+++ b/apps/web/tests/marketGroupsNavigation.test.tsx
@@ -5,13 +5,18 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 // behaviour is Next's, what matters is the queries and the tree that comes out.
 jest.mock("next/cache", () => ({ cacheLife: jest.fn() }));
 
-const marketGroupFindMany = jest.fn<() => Promise<Record<string, unknown>[]>>();
-const typeFindMany = jest.fn<() => Promise<Record<string, unknown>[]>>();
+// Args are forwarded rather than swallowed: the `marketGroupId IS NOT NULL`
+// filter and the narrow `select` are the point of these queries, so they get
+// asserted on below — a mock that drops its arguments cannot catch their loss.
+const marketGroupFindMany =
+  jest.fn<(args?: unknown) => Promise<Record<string, unknown>[]>>();
+const typeFindMany =
+  jest.fn<(args?: unknown) => Promise<Record<string, unknown>[]>>();
 
 jest.mock("~/lib/db", () => ({
   prisma: {
-    marketGroup: { findMany: () => marketGroupFindMany() },
-    type: { findMany: () => typeFindMany() },
+    marketGroup: { findMany: (args: unknown) => marketGroupFindMany(args) },
+    type: { findMany: (args: unknown) => typeFindMany(args) },
   },
 }));
 
@@ -45,6 +50,31 @@ describe("MarketGroupsNavigation", () => {
   beforeEach(() => {
     marketGroupFindMany.mockReset();
     typeFindMany.mockReset();
+  });
+
+  it("reads only types in a market group, and only the columns the tree needs", async () => {
+    marketGroupFindMany.mockResolvedValue([]);
+    typeFindMany.mockResolvedValue([]);
+
+    await MarketGroupsNavigation();
+
+    // Dropping the filter would read all ~53k types instead of the ~20k that
+    // belong to a market group; widening the select would drag `description`
+    // (6.6 MiB) back into a read that exists to fetch names.
+    expect(typeFindMany).toHaveBeenCalledWith({
+      where: { marketGroupId: { not: null } },
+      select: { typeId: true, name: true, marketGroupId: true },
+    });
+    // iconId is bundled deliberately — resolving it client-side costs ~3
+    // requests per visible NavLink.
+    expect(marketGroupFindMany).toHaveBeenCalledWith({
+      select: {
+        marketGroupId: true,
+        name: true,
+        parentMarketGroupId: true,
+        iconId: true,
+      },
+    });
   });
 
   it("renders one nav link per root group, sorted by name", async () => {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -225,7 +225,23 @@ model Type {
   masteries                       Mastery[]
   skinTypes                       SkinType[]
 
-  @@index([marketGroupId])
+  /// Covering index for the market-tree sidebar, which reads every type that
+  /// belongs to a market group. `name` is in the key on purpose: with a bare
+  /// ([marketGroupId]) index the projection of `name` is not covered, so
+  /// CockroachDB abandons the index and FULL SCANs Type@Type_pkey — 52k rows /
+  /// 18 MiB / ~1400 RUs per execution, almost all of it the `description`
+  /// column being read and thrown away. Covering it drops the same read to
+  /// 19.7k rows / 1.2 MiB. It is also a prefix index on marketGroupId alone, so
+  /// it still serves plain lookups by market group.
+  ///
+  /// The idiomatic CockroachDB form is ([marketGroupId]) STORING (name), which
+  /// keeps `name` out of the key. Don't. Prisma cannot express STORING, and an
+  /// index created out of band does not survive: `prisma db push` — which is
+  /// how this schema reaches every environment, CI included — silently DROPs
+  /// it, and the query regresses to the full scan with nothing to show for it.
+  /// Measured, the two forms are anyway indistinguishable: same plan, same 1.2
+  /// MiB read, 3.00 vs 2.95 MiB of index, identical write cost.
+  @@index([marketGroupId, name])
   @@index([graphicId])
   @@index([groupId])
   @@index([iconId])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -241,6 +241,16 @@ model Type {
   /// it, and the query regresses to the full scan with nothing to show for it.
   /// Measured, the two forms are anyway indistinguishable: same plan, same 1.2
   /// MiB read, 3.00 vs 2.95 MiB of index, identical write cost.
+  ///
+  /// APPLYING THIS: `pnpm db:push` will NOT install it. Production's Type is
+  /// `WITH (schema_locked = true)` (CockroachDB v26 default), and Prisma's
+  /// schema engine emits the index swap in a form the server refuses to
+  /// auto-unlock — the push aborts with "this schema change is disallowed
+  /// because table Type is locked". Plain DDL does auto-unlock, so apply it
+  /// directly instead, which also avoids dragging in the unrelated schema drift
+  /// a full push would attempt:
+  ///   CREATE INDEX "Type_marketGroupId_name_idx" ON "Type" ("marketGroupId", "name");
+  ///   DROP INDEX "Type"@"Type_marketGroupId_idx";
   @@index([marketGroupId, name])
   @@index([graphicId])
   @@index([groupId])


### PR DESCRIPTION
## What

The market sidebar's data load was **~12% of all database usage**. This makes the same read ~15× cheaper in I/O.

1. **`Type.marketGroupId` index is now keyed `(marketGroupId, name)`** so it covers the query.
2. **The nested `children`/`types` relation loads are replaced with two flat queries** assembled in JS by a new pure module, dropping one round trip.

## Why

Building the market tree reads every type belonging to a market group and projects `name`. The old index was keyed `(marketGroupId, typeId)`, so `name` was not covered — CockroachDB abandoned the index entirely and full-scanned the primary index:

```
rows decoded from KV: 52,859 (18 MiB, 2 gRPC calls)
estimated RUs consumed: 1,399.9
table: Type@Type_pkey   spans: FULL SCAN
```

~1,400 RUs per execution to produce ~600 KB of names. Most of those bytes are the `description` column — 6.6 MB across the relevant rows — read off the primary index and immediately discarded.

**The uncovered `name` projection is the sole cause.** Measured on production:

| query | plan |
|---|---|
| `typeId` + `IN (…2111 ids…)` | constrained index scan |
| `typeId, name` + `IN (…2111 ids…)` | **FULL SCAN** |
| `typeId, marketGroupId` + `IS NOT NULL` | constrained index scan |
| `typeId, name, marketGroupId` + `IS NOT NULL` | **FULL SCAN** |

The predicate is irrelevant; the projection is everything. An earlier revision of this PR claimed the large `IN` list caused the full scan — that was wrong and is corrected. The flat queries are kept on their real merit: the `children` load was a whole round trip for edges `parentMarketGroupId` already carries.

Verified on CockroachDB v26.2 (production's major) loaded with the production table's real shape:

| index | plan | KV rows | bytes |
|---|---|---|---|
| `(marketGroupId)` | **FULL SCAN** | 53,010 | 15 MiB |
| `(marketGroupId, name)` | index scan | 19,794 | 1.2 MiB |
| `(marketGroupId) STORING (name)` | index scan | 19,794 | 1.2 MiB |

## Why `name` is in the key rather than `STORING`

`STORING` is the idiomatic CockroachDB form and keeps `name` out of the key. It is deliberately not used: Prisma cannot express it, and an index created out of band is dropped by `prisma db push` — verified locally, where a hand-rolled `market_tree_covering` STORING index was silently deleted by a push whose schema declared the plain index. Measured, the two forms are indistinguishable (same plan, same 1.2 MiB read, 3.00 vs 2.95 MiB of index, identical write cost).

## ⚠️ How to actually apply the index

**Do not run `pnpm db:push` for this.** Two independent reasons, both verified:

1. **`Type` is `schema_locked`.** Production runs CockroachDB v26.2.5, where tables are locked by default. Prisma's schema engine emits the index swap in a form the server refuses to auto-unlock. Reproduced at a local v26.2 with the index swap as the *only* pending delta:
   ```
   ERROR: this schema change is disallowed because table "Type" is locked
          and this operation cannot automatically unlock the table
   ```
2. **The repo schema is far behind production.** `pnpm db:diff` currently reports **186 pending statements — 45 `DROP TABLE` and 114 `DROP COLUMN`** against populated tables. A push would need `--accept-data-loss`, the exact operation CLAUDE.md says never to run. This drift is pre-existing and unrelated to this PR (the branch is level with `main`), but it makes a push unusable as a delivery path.

Apply the two statements directly instead. Plain DDL *does* auto-unlock — verified against a locked table via both the `cockroach` CLI and a plain pg client:

```sql
CREATE INDEX "Type_marketGroupId_name_idx" ON "Type" ("marketGroupId", "name");
DROP INDEX "Type"@"Type_marketGroupId_idx";
```

This is recorded on the index in `schema.prisma` so the next person doesn't rediscover it.

## Verification

- The rewrite produces a **byte-identical** `MarketGroupIndex` — `deepStrictEqual` including array order — checked against production across 2,111 market groups, 19,794 types and 2,092 child edges, with no orphans.
- New tests assert the query shape as well as the tree: deleting the `marketGroupId IS NOT NULL` filter now fails the suite (it previously passed silently).
- `type-check`, `lint`, `format:check` clean; full web suite 152 suites / 1,456 tests.

## Reviewer notes

- **The code change alone is roughly neutral.** It removes the redundant `children` query, but the `Type` read stays a full scan until the index exists. The win lands with the index, applied by hand.
- **Dropping the old index is safe** — nothing else in the codebase filters `Type` by `marketGroupId`, and the new composite has it as a prefix.
- This PR went through an adversarial multi-agent review; the corrected root cause, the `schema_locked` finding, the changeset split, and the query-shape assertions all came out of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
