### PR TITLE
Unfurl killmails the way killboards do

### DIFF
--- a/.changeset/killmail-og-card.md
+++ b/.changeset/killmail-og-card.md
@@ -1,0 +1,5 @@
+---
+"@jitaspace/web": patch
+---
+
+Killmail links now unfurl the way zKillboard and EVE-Kill do: the ship's own render as a small thumbnail, with the victim, corporation/alliance, system, attacker count, final blow, and total ISK value in the description — instead of the generic branded card most kill links previously fell back to (the rich card required a `?hash=` query parameter that nothing in the app ever added, so ordinary shared links never got past "Killmail #12345").

--- a/apps/web/app/kill/[killId]/page.tsx
+++ b/apps/web/app/kill/[killId]/page.tsx
@@ -1,14 +1,112 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
+import { cacheLife } from "next/cache";
 import { notFound } from "next/navigation";
 
-import { getKillmailsKillmailIdKillmailHash } from "@jitaspace/esi-client";
+import {
+  getAlliancesAllianceId,
+  getCharactersDetail,
+  getCorporationsCorporationId,
+  getKillmailsKillmailIdKillmailHash,
+} from "@jitaspace/esi-client";
 
 import { PageSkeleton } from "~/components/PageSkeleton";
 import { prisma } from "~/lib/db";
 import { pageMetadata, resolveTypeImage } from "~/lib/metadata";
 import { parsePositiveEntityId } from "~/lib/routeParams";
 import PageClient from "./page.client";
+
+interface KillmailParty {
+  character_id?: number;
+  corporation_id?: number;
+  alliance_id?: number;
+  faction_id?: number;
+}
+
+/**
+ * A short "who" for a victim or attacker: a character with their corporation,
+ * or — for a structure, NPC, or drone — whichever of alliance/corporation/
+ * faction the killmail carries (alliance preferred, the same priority
+ * `war/[warId]` uses to label a side). Any ESI/DB failure just omits the
+ * clause; a partial card beats none.
+ */
+async function describeKillmailParty(
+  party: KillmailParty,
+): Promise<string | undefined> {
+  try {
+    if (party.character_id) {
+      const character = (await getCharactersDetail(party.character_id)).data;
+      const corporation = await getCorporationsCorporationId(
+        character.corporation_id,
+      )
+        .then((res) => res.data.name)
+        .catch(() => undefined);
+      return corporation
+        ? `${character.name} (${corporation})`
+        : character.name;
+    }
+    if (party.alliance_id) {
+      return (await getAlliancesAllianceId(party.alliance_id)).data.name;
+    }
+    if (party.corporation_id) {
+      return (await getCorporationsCorporationId(party.corporation_id)).data
+        .name;
+    }
+    if (party.faction_id) {
+      return (
+        await prisma.faction.findUnique({
+          select: { name: true },
+          where: { factionId: party.faction_id },
+        })
+      )?.name;
+    }
+  } catch {
+    // Fall through — see doc comment above.
+  }
+  return undefined;
+}
+
+/** ISK abbreviated the way the client's `ISKAmount` does, for plain text. */
+function formatIskShort(amount: number): string {
+  const tiers = [
+    { value: 1e12, symbol: "T" },
+    { value: 1e9, symbol: "B" },
+    { value: 1e6, symbol: "M" },
+    { value: 1e3, symbol: "K" },
+  ];
+  const tier = tiers.find((t) => Math.abs(amount) >= t.value);
+  if (!tier) return amount.toFixed(0);
+  return `${(amount / tier.value).toFixed(1).replace(/\.0$/, "")}${tier.symbol}`;
+}
+
+interface ZkbLookup {
+  hash: string;
+  totalValue?: number;
+}
+
+/**
+ * zKillboard is the only way to recover a killmail's ESI hash from just its
+ * numeric ID, and the only rate-limited third party this page touches — so the
+ * lookup is cached forever (a killmail's hash and reported value never change)
+ * rather than repeated on every crawler unfurl of a popular kill. Throws on any
+ * failure so a transient zKillboard outage never gets cached as "no such kill".
+ */
+async function resolveZkbLookup(killId: number): Promise<ZkbLookup> {
+  "use cache";
+  cacheLife("max");
+
+  const res = await fetch(`https://zkillboard.com/api/killID/${killId}/`, {
+    headers: { "User-Agent": "JitaSpace/1.0 (+https://jita.space)" },
+  });
+  if (!res.ok) throw new Error(`zKillboard responded ${res.status}`);
+  const [entry] = (await res.json()) as {
+    zkb?: { hash?: string; totalValue?: number };
+  }[];
+  if (!entry?.zkb?.hash) {
+    throw new Error("zKillboard has no record of this killmail");
+  }
+  return { hash: entry.zkb.hash, totalValue: entry.zkb.totalValue };
+}
 
 export async function generateMetadata({
   params,
@@ -30,44 +128,80 @@ export async function generateMetadata({
     badge: "Killmail",
   });
 
-  // ESI needs the killmail hash, which isn't in the path. The page itself
-  // recovers a missing hash from zKillboard, but doing that here would put a
-  // rate-limited third party on the path of every crawler unfurl — so a
-  // detailed card is offered only when the shared link already carries `?hash=`.
-  const hash = (await searchParams)?.hash;
-  if (typeof hash !== "string" || !hash) return fallback;
+  // ESI needs the killmail hash, which isn't in the path. A shared link may
+  // already carry it (`?hash=`); otherwise recover it from zKillboard, whose
+  // lookup by ID alone is what `resolveZkbLookup` caches forever.
+  const hashParam = (await searchParams)?.hash;
+  let hash = typeof hashParam === "string" && hashParam ? hashParam : undefined;
+  let totalValue: number | undefined;
+
+  if (!hash) {
+    try {
+      const zkb = await resolveZkbLookup(id);
+      hash = zkb.hash;
+      totalValue = zkb.totalValue;
+    } catch {
+      return fallback;
+    }
+  }
 
   try {
     const killmail = (await getKillmailsKillmailIdKillmailHash(hash, id)).data;
     const { victim } = killmail;
+    const finalBlow = killmail.attackers.find((a) => a.final_blow);
+    const attackerCount = killmail.attackers.length;
 
-    const [ship, system] = await Promise.all([
-      prisma.type.findUnique({
-        select: { name: true },
-        where: { typeId: victim.ship_type_id },
-      }),
-      prisma.solarSystem.findUnique({
-        select: { name: true },
-        where: { solarSystemId: killmail.solar_system_id },
-      }),
-    ]);
+    // Every lookup here degrades independently on failure (a database blip
+    // shouldn't discard the victim/attacker/value data other entries already
+    // resolved) — matching describeKillmailParty's own "a partial card beats
+    // none" philosophy, rather than letting Promise.all's fail-fast semantics
+    // drop the whole card to the generic fallback below.
+    const [ship, system, shipImage, victimLabel, finalBlowLabel] =
+      await Promise.all([
+        prisma.type
+          .findUnique({
+            select: { name: true },
+            where: { typeId: victim.ship_type_id },
+          })
+          .catch(() => null),
+        prisma.solarSystem
+          .findUnique({
+            select: { name: true },
+            where: { solarSystemId: killmail.solar_system_id },
+          })
+          .catch(() => null),
+        resolveTypeImage(victim.ship_type_id),
+        describeKillmailParty(victim),
+        finalBlow ? describeKillmailParty(finalBlow) : undefined,
+      ]);
 
-    const when = killmail.killmail_time.slice(0, 10);
     const shipName = ship?.name;
     const systemName = system?.name;
 
+    const description = [
+      `${victimLabel ?? "A capsuleer"} lost ${
+        shipName ? `their ${shipName}` : "their ship"
+      }${systemName ? ` in ${systemName}` : ""} to ${attackerCount} attacker${
+        attackerCount === 1 ? "" : "s"
+      }.`,
+      finalBlowLabel ? `Final blow by ${finalBlowLabel}.` : "",
+      totalValue ? `Total value: ${formatIskShort(totalValue)} ISK.` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+
     return pageMetadata({
       title: shipName ? `${shipName} destroyed` : `Killmail #${id}`,
-      description: `An EVE Online ${shipName ?? "ship"} was destroyed${
-        systemName ? ` in ${systemName}` : ""
-      } on ${when} by ${killmail.attackers.length} attackers.`,
+      description,
       path: `/kill/${id}`,
       badge: "Killmail",
-      image: await resolveTypeImage(victim.ship_type_id),
+      rawImage: shipImage,
       facts: [
         ...(systemName ? [{ label: "System", value: systemName }] : []),
-        { label: "Attackers", value: String(killmail.attackers.length) },
-        { label: "Date", value: when },
+        { label: "Attackers", value: String(attackerCount) },
+        ...(totalValue
+          ? [{ label: "Value", value: `${formatIskShort(totalValue)} ISK` }]
+          : []),
       ],
     });
   } catch {

--- a/apps/web/lib/metadata.ts
+++ b/apps/web/lib/metadata.ts
@@ -21,6 +21,9 @@ import { buildOgImageUrl, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from "./og";
 
 export const SITE_NAME = "JitaSpace";
 
+/** EVE CDN artwork is always requested at this size (see `eveImage.type`). */
+const RAW_IMAGE_SIZE = 512;
+
 export interface PageMetadataInput {
   /** Page/entity name. The root layout's `%s | JitaSpace` template is applied. */
   title: string;
@@ -36,11 +39,20 @@ export interface PageMetadataInput {
   facts?: OgFact[];
   /** `article` for changelog-style pages; defaults to `website`. */
   type?: "website" | "article";
+  /**
+   * Unfurl this artwork directly, square, instead of compositing the generated
+   * `/api/og` card — how killboards (zKillboard, EVE-Kill) present a kill: the
+   * ship's own render as a small thumbnail, with the story told by
+   * title/description rather than overlaid card text. Falls back to the
+   * generated card (using `image`/`badge`/`facts` above) when unset.
+   */
+  rawImage?: string;
 }
 
 /**
  * Assembles `title`, `description`, canonical URL, OpenGraph and Twitter tags
- * from one description of the page, with a generated card as the image.
+ * from one description of the page, with a generated card — or, when
+ * `rawImage` is given, that artwork directly — as the image.
  */
 export function pageMetadata({
   title,
@@ -50,14 +62,20 @@ export function pageMetadata({
   image,
   facts,
   type = "website",
+  rawImage,
 }: PageMetadataInput): Metadata {
-  const ogImage = buildOgImageUrl({
-    title,
-    subtitle: description,
-    badge,
-    image,
-    facts,
-  });
+  const ogImage =
+    rawImage ??
+    buildOgImageUrl({
+      title,
+      subtitle: description,
+      badge,
+      image,
+      facts,
+    });
+  const imageSize = rawImage
+    ? { width: RAW_IMAGE_SIZE, height: RAW_IMAGE_SIZE }
+    : { width: OG_IMAGE_WIDTH, height: OG_IMAGE_HEIGHT };
 
   return {
     title,
@@ -72,15 +90,16 @@ export function pageMetadata({
       images: [
         {
           url: ogImage,
-          width: OG_IMAGE_WIDTH,
-          height: OG_IMAGE_HEIGHT,
+          ...imageSize,
           alt: title,
         },
       ],
     },
     twitter: {
-      // The generated card is 1.91:1, so it fills the large card properly.
-      card: "summary_large_image",
+      // The generated card is 1.91:1 and wants the large card; a raw square
+      // thumbnail unfurls the way zKillboard/EVE-Kill declare their own kill
+      // images — as "summary", not stretched into the large-image slot.
+      card: rawImage ? "summary" : "summary_large_image",
       title,
       description,
       images: [ogImage],

--- a/apps/web/tests/pageMetadata.test.ts
+++ b/apps/web/tests/pageMetadata.test.ts
@@ -86,6 +86,44 @@ describe("pageMetadata", () => {
   });
 });
 
+describe("pageMetadata rawImage", () => {
+  const rawImageUrl = "https://images.evetech.net/types/587/render?size=512";
+  const meta = pageMetadata({
+    title: "Rifter destroyed",
+    description: "Someone lost their Rifter.",
+    path: "/kill/12345",
+    badge: "Killmail",
+    rawImage: rawImageUrl,
+  });
+
+  it("unfurls the artwork directly instead of the generated /api/og card", () => {
+    const images = meta.openGraph?.images as { url: string }[];
+    expect(images).toHaveLength(1);
+    expect(images[0]!.url).toBe(rawImageUrl);
+  });
+
+  it("sizes the image square, matching the EVE CDN artwork it is", () => {
+    const images = meta.openGraph?.images as {
+      width: number;
+      height: number;
+    }[];
+    expect(images[0]!.width).toBe(512);
+    expect(images[0]!.height).toBe(512);
+  });
+
+  it("uses the small Twitter card, not the large-image slot a square doesn't fill", () => {
+    expect(meta.twitter).toHaveProperty("card", "summary");
+    expect(meta.twitter?.images).toEqual([rawImageUrl]);
+  });
+
+  it("still states title/description/canonical/siteName in full", () => {
+    expect(meta.title).toBe("Rifter destroyed");
+    expect(meta.openGraph?.description).toBe("Someone lost their Rifter.");
+    expect(meta.alternates?.canonical).toBe("/kill/12345");
+    expect(meta.openGraph?.siteName).toBe("JitaSpace");
+  });
+});
+
 describe("toDescription", () => {
   it("strips EVE's in-game HTML markup", () => {
     expect(toDescription("<p>Hello <b>world</b></p>")).toBe("Hello world");

--- a/apps/web/tests/seoMetadataEntities.test.ts
+++ b/apps/web/tests/seoMetadataEntities.test.ts
@@ -44,6 +44,8 @@ const mockGetCorporationsCorporationId =
 const mockGetAlliancesAllianceId =
   jest.fn<(...args: unknown[]) => Promise<unknown>>();
 const mockGetKillmail = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetCharactersDetail =
+  jest.fn<(...args: unknown[]) => Promise<unknown>>();
 
 jest.mock("@jitaspace/esi-client", () => ({
   getWarsWarId: (...a: unknown[]) => mockGetWarsWarId(...a),
@@ -52,6 +54,7 @@ jest.mock("@jitaspace/esi-client", () => ({
   getAlliancesAllianceId: (...a: unknown[]) => mockGetAlliancesAllianceId(...a),
   getKillmailsKillmailIdKillmailHash: (...a: unknown[]) =>
     mockGetKillmail(...a),
+  getCharactersDetail: (...a: unknown[]) => mockGetCharactersDetail(...a),
 }));
 
 // Prisma mock — methods are replaced per describe block
@@ -68,6 +71,9 @@ const mockCorporationFindUnique =
   jest.fn<(...args: unknown[]) => Promise<unknown>>();
 const mockLoyaltyStoreOfferCount =
   jest.fn<(...args: unknown[]) => Promise<number>>();
+const mockTypeFindUnique = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockSolarSystemFindUnique =
+  jest.fn<(...args: unknown[]) => Promise<unknown>>();
 
 jest.mock("~/lib/db", () => ({
   prisma: {
@@ -88,8 +94,58 @@ jest.mock("~/lib/db", () => ({
     loyaltyStoreOffer: {
       count: (...a: unknown[]) => mockLoyaltyStoreOfferCount(...a),
     },
+    type: { findUnique: (...a: unknown[]) => mockTypeFindUnique(...a) },
+    solarSystem: {
+      findUnique: (...a: unknown[]) => mockSolarSystemFindUnique(...a),
+    },
   },
 }));
+
+// zKillboard's lookup-by-ID and the EVE image CDN both go through the global
+// `fetch`, dispatched here by host so a test only has to describe the parts it
+// cares about.
+interface KillFetchMocks {
+  /** "not-found" = zKillboard has no record; "error" = it 5xxs. */
+  zkb?: { hash: string; totalValue?: number } | "not-found" | "error";
+  /** Variations the image CDN reports for the victim's ship type. */
+  imageVariations?: string[];
+}
+
+function mockKillFetches({
+  zkb,
+  imageVariations = ["render"],
+}: KillFetchMocks) {
+  global.fetch = jest.fn((url: string | URL) => {
+    const href = String(url);
+    if (href.includes("zkillboard.com")) {
+      if (zkb === "not-found") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as unknown as Response);
+      }
+      if (!zkb || zkb === "error") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({}),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([{ killmail_id: 1, zkb }]),
+      } as unknown as Response);
+    }
+    if (href.includes("images.evetech.net")) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(imageVariations),
+      } as unknown as Response);
+    }
+    return Promise.reject(new Error(`Unexpected fetch in test: ${href}`));
+  }) as unknown as typeof fetch;
+}
 
 function rp<T>(obj: T): Promise<T> {
   return Promise.resolve(obj);
@@ -261,9 +317,20 @@ describe("faction/[factionId] generateMetadata", () => {
 describe("kill/[killId] generateMetadata", () => {
   beforeEach(() => {
     jest.resetModules();
+    mockGetKillmail.mockReset();
+    mockGetCharactersDetail.mockReset();
+    mockGetCorporationsCorporationId.mockReset();
+    mockGetAlliancesAllianceId.mockReset();
+    mockTypeFindUnique.mockReset();
+    mockSolarSystemFindUnique.mockReset();
+    mockFactionFindUnique.mockReset();
+    // Most tests never reach zKillboard/ESI; default to "no record" so a test
+    // that forgets to mock further still gets a deterministic fallback rather
+    // than an unhandled rejection.
+    mockKillFetches({ zkb: "not-found" });
   });
 
-  it("returns killmail title for valid id", async () => {
+  it("falls back to the plain card when zKillboard has no record of the kill", async () => {
     const { generateMetadata } = await import("~/app/kill/[killId]/page");
     const result = await generateMetadata({ params: rp({ killId: "12345" }) });
     expect(result.title).toBe("Killmail #12345");
@@ -287,6 +354,300 @@ describe("kill/[killId] generateMetadata", () => {
     expect(await generateMetadata({ params: rp({ killId: "-99" }) })).toEqual(
       {},
     );
+  });
+
+  it("builds a killboard-style card from just the numeric id, via zKillboard's hash lookup", async () => {
+    mockKillFetches({
+      zkb: { hash: "abc123", totalValue: 128_500_000 },
+      imageVariations: ["render"],
+    });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: {
+          character_id: 90000001,
+          corporation_id: 98000001,
+          ship_type_id: 587,
+        },
+        attackers: [
+          {
+            character_id: 90000002,
+            corporation_id: 98000002,
+            final_blow: true,
+            damage_done: 100,
+          },
+          { character_id: 90000003, final_blow: false, damage_done: 50 },
+        ],
+      },
+    });
+    mockTypeFindUnique.mockResolvedValue({ name: "Rifter" });
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Jita" });
+    mockGetCharactersDetail.mockImplementation((...args: unknown[]) =>
+      Promise.resolve({
+        data:
+          args[0] === 90000001
+            ? { name: "Victim Vic", corporation_id: 98000001 }
+            : { name: "Final Blow Fred", corporation_id: 98000002 },
+      }),
+    );
+    mockGetCorporationsCorporationId.mockImplementation((...args: unknown[]) =>
+      Promise.resolve({
+        data: {
+          name: args[0] === 98000001 ? "Victim Corp" : "Attacker Corp",
+        },
+      }),
+    );
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    expect(result.title).toBe("Rifter destroyed");
+    expect(result.description).toContain("Victim Vic (Victim Corp)");
+    expect(result.description).toContain("their Rifter");
+    expect(result.description).toContain("in Jita");
+    expect(result.description).toContain("2 attackers");
+    expect(result.description).toContain(
+      "Final blow by Final Blow Fred (Attacker Corp)",
+    );
+    expect(result.description).toContain("128.5M ISK");
+
+    // The image is the ship's own render, unfurled directly — no generated
+    // /api/og card, no brand chrome — mirroring zKillboard/EVE-Kill.
+    const images = result.openGraph?.images as {
+      url: string;
+      width: number;
+      height: number;
+    }[];
+    expect(images[0]?.url).toBe(
+      "https://images.evetech.net/types/587/render?size=512",
+    );
+    expect(images[0]?.width).toBe(512);
+    expect(images[0]?.height).toBe(512);
+    expect(result.twitter).toHaveProperty("card", "summary");
+  });
+
+  it("uses an explicit ?hash= without ever calling zKillboard", async () => {
+    // zKillboard is mocked to error — the test fails if the hash-recovery path
+    // is reached at all.
+    mockKillFetches({ zkb: "error" });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: { corporation_id: 98000001, ship_type_id: 587 },
+        attackers: [{ faction_id: 500001, final_blow: true, damage_done: 100 }],
+      },
+    });
+    mockTypeFindUnique.mockResolvedValue({ name: "Rifter" });
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Jita" });
+    mockGetCorporationsCorporationId.mockResolvedValue({
+      data: { name: "Victim Corp" },
+    });
+    mockFactionFindUnique.mockResolvedValue({ name: "Guristas Pirates" });
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({
+      params: rp({ killId: "12345" }),
+      searchParams: rp({ hash: "explicit-hash" }),
+    });
+
+    expect(mockGetKillmail).toHaveBeenCalledWith("explicit-hash", 12345);
+    const fetchMock = global.fetch as jest.Mock;
+    expect(
+      fetchMock.mock.calls.some((call: unknown[]) =>
+        String(call[0]).includes("zkillboard.com"),
+      ),
+    ).toBe(false);
+    expect(result.description).toContain("Victim Corp");
+    expect(result.description).toContain("Final blow by Guristas Pirates");
+  });
+
+  it("falls back to the plain card when ESI is unavailable after the hash resolves", async () => {
+    mockKillFetches({ zkb: { hash: "abc123" } });
+    mockGetKillmail.mockRejectedValue(new Error("esi down"));
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+    expect(result.title).toBe("Killmail #12345");
+  });
+
+  it("names a structure victim by its alliance, not its corporation", async () => {
+    mockKillFetches({ zkb: { hash: "abc123" } });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: {
+          corporation_id: 98000001,
+          alliance_id: 99000001,
+          ship_type_id: 35833,
+        },
+        attackers: [{ damage_done: 100, final_blow: true }],
+      },
+    });
+    mockTypeFindUnique.mockResolvedValue({ name: "Fortizar" });
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Brybier" });
+    mockGetAlliancesAllianceId.mockResolvedValue({
+      data: { name: "Some Alliance" },
+    });
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    expect(result.description).toContain("Some Alliance lost");
+    // Exactly one attacker — the singular form, not "1 attackers".
+    expect(result.description).toContain("1 attacker.");
+    expect(mockGetCorporationsCorporationId).not.toHaveBeenCalled();
+    // No character/faction on either side to name the final blow — the
+    // sentence just states the loss.
+    expect(result.description).not.toContain("Final blow");
+  });
+
+  it("omits the victim clause rather than failing the card when ESI errors", async () => {
+    mockKillFetches({ zkb: { hash: "abc123" } });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: { corporation_id: 98000001, ship_type_id: 587 },
+        attackers: [{ damage_done: 100, final_blow: true }],
+      },
+    });
+    mockTypeFindUnique.mockResolvedValue({ name: "Rifter" });
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Jita" });
+    mockGetCorporationsCorporationId.mockRejectedValue(new Error("esi down"));
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    expect(result.title).toBe("Rifter destroyed");
+    expect(result.description).toContain("A capsuleer lost");
+  });
+
+  it("falls back to a generic ship/title clause when the ship type isn't in our database", async () => {
+    mockKillFetches({ zkb: { hash: "abc123", totalValue: 1_000_000 } });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: { corporation_id: 98000001, ship_type_id: 99999999 },
+        attackers: [
+          { damage_done: 100, final_blow: true },
+          { damage_done: 50, final_blow: false },
+        ],
+      },
+    });
+    // Not yet ingested into the local Type table — a real scenario for a
+    // brand-new hull.
+    mockTypeFindUnique.mockResolvedValue(null);
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Jita" });
+    mockGetCorporationsCorporationId.mockResolvedValue({
+      data: { name: "Victim Corp" },
+    });
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    expect(result.title).toBe("Killmail #12345");
+    expect(result.description).toContain("Victim Corp lost their ship");
+    expect(result.description).toContain("in Jita");
+    expect(result.description).toContain("2 attackers");
+  });
+
+  it("omits the system clause when the solar system isn't in our database", async () => {
+    mockKillFetches({ zkb: { hash: "abc123" } });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        // Not (yet) ingested into the local SolarSystem table.
+        solar_system_id: 99999999,
+        victim: { corporation_id: 98000001, ship_type_id: 587 },
+        attackers: [{ damage_done: 100, final_blow: true }],
+      },
+    });
+    mockTypeFindUnique.mockResolvedValue({ name: "Rifter" });
+    mockSolarSystemFindUnique.mockResolvedValue(null);
+    mockGetCorporationsCorporationId.mockResolvedValue({
+      data: { name: "Victim Corp" },
+    });
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    expect(result.title).toBe("Rifter destroyed");
+    expect(result.description).toContain("Victim Corp lost their Rifter to");
+    expect(result.description).not.toContain(" in ");
+  });
+
+  it("keeps the rest of the card when only a database lookup rejects", async () => {
+    // Regression test: prisma.type/solarSystem.findUnique used to run bare
+    // inside the Promise.all, so a transient DB error there discarded the
+    // already-resolved victim/attacker/value/image data and fell all the way
+    // back to the generic "Killmail #id" card.
+    mockKillFetches({
+      zkb: { hash: "abc123", totalValue: 1_000_000 },
+      imageVariations: ["render"],
+    });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: { corporation_id: 98000001, ship_type_id: 587 },
+        attackers: [{ damage_done: 100, final_blow: true }],
+      },
+    });
+    mockTypeFindUnique.mockRejectedValue(new Error("db timeout"));
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Jita" });
+    mockGetCorporationsCorporationId.mockResolvedValue({
+      data: { name: "Victim Corp" },
+    });
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    // The ship name specifically is unavailable, so the title falls back —
+    // but everything else the DB blip didn't touch survives.
+    expect(result.title).toBe("Killmail #12345");
+    expect(result.description).toContain("Victim Corp lost their ship");
+    expect(result.description).toContain("in Jita");
+    expect(result.description).toContain("1M ISK");
+    const images = result.openGraph?.images as { url: string }[];
+    expect(images[0]?.url).toBe(
+      "https://images.evetech.net/types/587/render?size=512",
+    );
+  });
+
+  it("omits the final blow clause when no attacker is flagged as the final blow", async () => {
+    mockKillFetches({ zkb: { hash: "abc123" } });
+    mockGetKillmail.mockResolvedValue({
+      data: {
+        killmail_id: 12345,
+        killmail_time: "2026-01-02T03:04:05Z",
+        solar_system_id: 30000142,
+        victim: { corporation_id: 98000001, ship_type_id: 587 },
+        // No attacker carries `final_blow: true` — incomplete/edge-case data.
+        attackers: [{ damage_done: 100, final_blow: false }],
+      },
+    });
+    mockTypeFindUnique.mockResolvedValue({ name: "Rifter" });
+    mockSolarSystemFindUnique.mockResolvedValue({ name: "Jita" });
+    mockGetCorporationsCorporationId.mockResolvedValue({
+      data: { name: "Victim Corp" },
+    });
+
+    const { generateMetadata } = await import("~/app/kill/[killId]/page");
+    const result = await generateMetadata({ params: rp({ killId: "12345" }) });
+
+    expect(result.description).toContain("Victim Corp lost their Rifter");
+    expect(result.description).not.toContain("Final blow");
+    expect(mockGetCharactersDetail).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Kill links shared out of JitaSpace almost always unfurled as the generic **"Killmail #12345"** card. The rich card was gated behind a `?hash=` query parameter — and nothing in the app ever produces a link carrying one, so that branch was effectively dead code in production. Every real paste into Discord got the placeholder.

- **Recover the hash from zKillboard's lookup-by-ID.** That is the one rate-limited third party this page touches, which is why the gate existed in the first place — so the lookup now sits behind `"use cache"` / `cacheLife("max")`. A killmail's hash and value never change, so zKillboard is asked **once per kill** rather than once per crawler unfurl. It throws rather than returning a sentinel, so a transient outage is never what gets written to the cache (the hazard `CLAUDE.md` documents at length).
- **Match zKillboard and EVE-Kill's card.** I checked what both actually emit: the ship's own artwork as a small square image, no generated card, with everything carried by the text. So `pageMetadata` grew a `rawImage` option that unfurls artwork directly instead of compositing the `/api/og` card, and switches the Twitter card to `summary` — a square doesn't fill the large-image slot. Every other caller is untouched.
- **Richer description:** victim and corporation (or alliance, for a structure), ship, system, attacker count, final blow, and total ISK — replacing the old `"An EVE Online ship was destroyed … on 2026-01-02 by 5 attackers."`
- **Each lookup degrades on its own.** A failure naming the victim, or reading the ship/system row, drops that one clause instead of collapsing the whole card back to the placeholder.

## Test plan

- [x] `pnpm type-check` (apps/web) clean
- [x] `pnpm lint` — 0 errors, only the 36 pre-existing warnings
- [x] `pnpm format:check` clean on touched files
- [x] Jest: 132 tests green across the metadata/OG suites; 100% line and 95% branch coverage on `app/kill/[killId]/page.tsx`, 100% on `lib/metadata.ts`
- [x] New coverage: rich card from a bare numeric id, explicit `?hash=` never calling zKillboard, zKillboard-has-no-record fallback, ESI-down fallback, structure victim named by alliance, singular vs. plural attacker grammar, ship type / solar system absent from the local DB, a DB lookup rejecting mid-`Promise.all`, and no attacker flagged as final blow
- [ ] Worth a real-world check after deploy: paste a `jita.space/kill/<id>` link into Discord and confirm the ship render and sentence come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)