### PR TITLE
perf(background-jobs): test compareSets membership against a Set

### DIFF
--- a/.changeset/comparesets-set-membership.md
+++ b/.changeset/comparesets-set-membership.md
@@ -1,0 +1,11 @@
+---
+"@jitaspace/background-jobs": patch
+---
+
+Test set membership in `compareSets` with a `Set` instead of `Array.includes`.
+The three linear scans made the diff quadratic in rows per chunk, and
+`ingestSdeCompositeTable` chunks by parent id rather than by row count — so the
+widest `typeDogma` chunk (148,292 TypeAttribute rows) spent 175.9s in a single
+`compareSets` call, about 618s across that one table. The same call now takes
+0.09s. Behaviour is unchanged: `Set.has` and `Array.includes` both use
+SameValueZero.

--- a/packages/background-jobs/tests/utils/compareSets.test.ts
+++ b/packages/background-jobs/tests/utils/compareSets.test.ts
@@ -10,6 +10,12 @@ interface Item {
   name: string;
 }
 
+/** Ids are `string | number` in the signature, so both can reach one call. */
+interface LooseItem {
+  id: string | number;
+  name: string;
+}
+
 const getId = (item: Item) => item.id;
 const isEqual = (a: Item, b: Item) => a.name === b.name;
 
@@ -110,6 +116,66 @@ describe("compareSets", () => {
     expect(result.deleted[0]).toEqual({ id: 3, name: "will-delete" });
     expect(result.created).toHaveLength(1);
     expect(result.created[0]).toEqual({ id: 4, name: "new-record" });
+  });
+
+  it("keeps a numeric id and its string spelling distinct", () => {
+    // Membership is SameValueZero (what both `Array.includes` and `Set.has`
+    // use), so 1 and "1" are two ids, not one: the numeric row is deleted and
+    // the string row created. The end-of-function sanity check disagrees — it
+    // counts its union with `String(key)`, which folds them back into one — so
+    // this combination is rejected rather than silently mis-partitioned.
+    const before: LooseItem[] = [{ id: 1, name: "numeric" }];
+    const after: LooseItem[] = [{ id: "1", name: "stringly" }];
+    expect(() =>
+      compareSets({
+        recordsBefore: before,
+        recordsAfter: after,
+        getId: (item: LooseItem) => item.id,
+        recordsAreEqual: (a: LooseItem, b: LooseItem) => a.name === b.name,
+      }),
+    ).toThrow("compareSets: input and output length do not match");
+  });
+
+  it("matches ids of one consistent type, string ids included", () => {
+    // The composite ingest helper keys rows by `keyFields.join(":")`, so whole
+    // tables come through here with string ids; they must diff normally.
+    const before: LooseItem[] = [
+      { id: "587:9", name: "unchanged" },
+      { id: "587:38", name: "will-change" },
+    ];
+    const after: LooseItem[] = [
+      { id: "587:9", name: "unchanged" },
+      { id: "587:38", name: "changed" },
+      { id: "588:9", name: "new" },
+    ];
+    const result = compareSets({
+      recordsBefore: before,
+      recordsAfter: after,
+      getId: (item: LooseItem) => item.id,
+      recordsAreEqual: (a: LooseItem, b: LooseItem) => a.name === b.name,
+    });
+    expect(result.equal.map((r) => r.id)).toEqual(["587:9"]);
+    expect(result.modified.map((r) => r.id)).toEqual(["587:38"]);
+    expect(result.created.map((r) => r.id)).toEqual(["588:9"]);
+    expect(result.deleted).toHaveLength(0);
+  });
+
+  it("does not treat a key named like an Object prototype member as present", () => {
+    // `indexBefore` is a plain object, so an id such as `__proto__` or
+    // `constructor` is a live prototype key rather than an own property.
+    // Membership must come from the key sets, never from the object index.
+    const before: LooseItem[] = [{ id: "constructor", name: "a" }];
+    const after: LooseItem[] = [{ id: "__proto__", name: "b" }];
+    const result = compareSets({
+      recordsBefore: before,
+      recordsAfter: after,
+      getId: (item: LooseItem) => item.id,
+      recordsAreEqual: (a: LooseItem, b: LooseItem) => a.name === b.name,
+    });
+    expect(result.created.map((r) => r.id)).toEqual(["__proto__"]);
+    expect(result.deleted.map((r) => r.id)).toEqual(["constructor"]);
+    expect(result.equal).toHaveLength(0);
+    expect(result.modified).toHaveLength(0);
   });
 
   it("throws NonRetriableError when count sanity check fails", () => {

--- a/packages/background-jobs/utils/compareSets.ts
+++ b/packages/background-jobs/utils/compareSets.ts
@@ -15,20 +15,32 @@ export const compareSets = <T extends object>({
   const keysBefore = recordsBefore.map((record) => getId(record));
   const keysAfter = recordsAfter.map((record) => getId(record));
 
+  // Membership is tested against sets, not the key arrays. `Set.prototype.has`
+  // and `Array.prototype.includes` both use SameValueZero, so this is an exact
+  // swap for the linear scans — and it must stay a set keyed on `getId`'s own
+  // values rather than `indexBefore`, whose plain-object keys would both coerce
+  // 1 and "1" together and report inherited names like `constructor` as present.
+  //
+  // What they replace is three O(n*m) scans. `ingestSdeCompositeTable` chunks
+  // by parent id (5000 at a time), which bounds parents but NOT rows, so the
+  // widest typeDogma chunk carries 148,292 TypeAttribute rows: one call on it
+  // measured 175.9s before and 0.09s after, and the table's six chunks together
+  // account for ~618s of the job's 1800s ceiling. Keep membership O(1) — the
+  // row count per chunk is set by SDE fan-out, not by anything we cap here.
+  const keySetBefore = new Set(keysBefore);
+  const keySetAfter = new Set(keysAfter);
+
   const indexBefore: Record<string | number | symbol, T> = {};
   recordsBefore.forEach((record) => (indexBefore[getId(record)] = record));
 
-  const indexAfter: Record<string | number | symbol, T> = {};
-  recordsAfter.forEach((record) => (indexAfter[getId(record)] = record));
-
   // determine which records were created
   const created: T[] = recordsAfter.filter(
-    (record) => !keysBefore.includes(getId(record)),
+    (record) => !keySetBefore.has(getId(record)),
   );
 
   // determine which records were deleted
   const deleted = recordsBefore.filter(
-    (record) => !keysAfter.includes(getId(record)),
+    (record) => !keySetAfter.has(getId(record)),
   );
 
   // validate that object keys are the same
@@ -58,9 +70,7 @@ export const compareSets = <T extends object>({
   }
 
   // get the records that are common to both sets
-  const commonKeys = new Set(
-    keysAfter.filter((key) => keysBefore.includes(key)),
-  );
+  const commonKeys = new Set(keysAfter.filter((key) => keySetBefore.has(key)));
   const commonRecords = recordsAfter.filter((record) =>
     commonKeys.has(getId(record)),
   );
@@ -78,13 +88,6 @@ export const compareSets = <T extends object>({
   const modified = commonRecords.filter(
     (record) => !equalKeys.has(getId(record)),
   );
-
-  /*
-    modified.map((record) => {
-      const before = indexBefore[getId(record)];
-      const after = indexAfter[getId(record)];
-      console.log({ before, after });
-    });*/
 
   // sanity check
   const numInputs = new Set([


### PR DESCRIPTION
`compareSets` tested key membership with `Array.includes` in three places, which made the diff O(n·m) in rows per chunk.

`ingestSdeCompositeTable` chunks by **parent id** (5000 at a time), which bounds parents but not rows — so rows per chunk are set by SDE fan-out. The widest `typeDogma` chunk carries 148,292 TypeAttribute rows.

## Measured

One `compareSets` call on that chunk, against SDE build 3494416:

| | worst chunk | table total (6 chunks) |
|---|---|---|
| before | 175.90s | ~618s |
| after | 0.09s | ~0.5s |

That is roughly a third of the job's 1800s ceiling recovered. `TypeEffect` (widest chunk 12,580 rows) goes from ~4s to nothing. Every other caller improves proportionally — `ingestSdeTable` chunks at 25,000 rows, so its ceiling was smaller but nonzero.

## Behaviour is unchanged, not just intended to be

`Set.prototype.has` and `Array.prototype.includes` both use SameValueZero, so the swap is exact.

Verified by fuzzing the previous implementation against this one over 4,000 randomised cases — numeric and string spellings of the same id, prototype member names (`__proto__`, `constructor`, `toString`), empty strings, composite `"a:b"` keys — comparing the full four-way partition **and** the thrown message, with both the throwing and non-throwing paths exercised. Zero mismatches. That harness was scaffolding and is not part of the diff.

Membership deliberately stays keyed on `getId`'s own values rather than reusing `indexBefore`, which would have been cheaper still and wrong twice over: its plain-object keys coerce `1` and `"1"` together, and report inherited names like `constructor` as present.

## Tests

Three new cases in `tests/utils/compareSets.test.ts`, each **written and confirmed passing against the old implementation first**, so they pin existing behaviour rather than describe the rewrite:

- a numeric id and its string spelling stay distinct — two ids to the partition, one to the sanity check (which counts its union with `String(key)`), so the combination is rejected rather than silently mis-partitioned;
- string ids diff normally, the shape the composite helper actually produces;
- an id named like an `Object.prototype` member is not reported as present.

The sanity check itself is untouched. It is worth noting it remains stricter than the partition — flagged, not changed, since changing it would be a behaviour change rather than a performance fix.

Also drops `indexAfter`, read only inside a commented-out debug block — an unused index of every row in the chunk.

## Checks

`pnpm --filter @jitaspace/background-jobs test` — 26 suites, 193 tests green. Lint and prettier clean. `pnpm type-check` reports one pre-existing failure in `packages/hooks/src/db/esiNamesCollection.ts`; confirmed identical with this change fully reverted, so it is not from this work.

Pre-existing issue, untouched by #743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)